### PR TITLE
Fix node navigational issues (#133, #134), add search history with localStorage (#130)

### DIFF
--- a/src/components/OntologyComponents/TreeViewSimplified.tsx
+++ b/src/components/OntologyComponents/TreeViewSimplified.tsx
@@ -76,6 +76,7 @@ const TreeViewSimplified = ({
         <TreeItem
           key={treeVisualization[nodeId]?.id || nodeId}
           nodeId={treeVisualization[nodeId]?.id || nodeId}
+          className={`node-${nodeId}`}
           label={
             <Box
               sx={{

--- a/src/components/SearchSideBar/SearchSideBar.tsx
+++ b/src/components/SearchSideBar/SearchSideBar.tsx
@@ -42,6 +42,7 @@ const SearchSideBar = ({
 
   const handleFocus = () => {
     setIsFocused(true);
+    updateLastSearches();
     if (searchValue.trim() !== "" || !!lastSearches.length) {
       setIsListOpen(true);
     }

--- a/src/components/SearchSideBar/SearchSideBar.tsx
+++ b/src/components/SearchSideBar/SearchSideBar.tsx
@@ -18,9 +18,13 @@ import { SCROLL_BAR_STYLE } from " @components/lib/CONSTANTS";
 const SearchSideBar = ({
   openSearchedNode,
   searchWithFuse,
+  lastSearches,
+  updateLastSearches,
 }: {
   openSearchedNode: any;
   searchWithFuse: any;
+  lastSearches: any[];
+  updateLastSearches: Function;
 }) => {
   const [searchValue, setSearchValue] = useState("");
   const [isListOpen, setIsListOpen] = useState(false);
@@ -37,8 +41,8 @@ const SearchSideBar = ({
   }, [searchValue]);
 
   const handleFocus = () => {
-    if (searchValue.trim() !== "") {
-      setIsFocused(true);
+    setIsFocused(true);
+    if (searchValue.trim() !== "" || !!lastSearches.length) {
       setIsListOpen(true);
     }
   };
@@ -70,6 +74,14 @@ const SearchSideBar = ({
     }
   };
 
+  const handleNodeClick = (node: any) => {
+    openSearchedNode(node);
+    setSearchValue(node.title);
+    updateLastSearches(node);
+    setIsListOpen(false);
+    setIsFocused(false);
+  };
+
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
@@ -86,6 +98,34 @@ const SearchSideBar = ({
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, []);
+
+  const renderListItem = (node: any) => (
+    <ListItem
+      key={node.id}
+      onClick={() => handleNodeClick(node)}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        color: "white",
+        cursor: "pointer",
+        borderRadius: "4px",
+        padding: "8px",
+        transition: "background-color 0.3s",
+        mt: "5px",
+        "&:hover": {
+          backgroundColor: (theme) =>
+            theme.palette.mode === "dark"
+              ? "rgba(255, 255, 255, 0.1)"
+              : "rgba(0, 0, 0, 0.1)",
+        },
+      }}
+    >
+      <Typography>
+        {node.title}
+        {!!node.context?.title && ` at ${node.context.title}`}
+      </Typography>
+    </ListItem>
+  );
 
   return (
     <Box
@@ -164,41 +204,13 @@ const SearchSideBar = ({
           zIndex: 1000,
         }}
       />
-      {isListOpen && searchResults.length > 0 && (
+      {isListOpen && (
         <List sx={{ zIndex: isListOpen ? 10 : 0 }}>
-          {searchResults.map((node: any) => (
-            <ListItem
-              key={node.id}
-              onClick={() => {
-                openSearchedNode(node);
-                setSearchValue(node.title);
-                setIsListOpen(false);
-                setIsFocused(false);
-              }}
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                color: "white",
-                cursor: "pointer",
-                borderRadius: "4px",
-                padding: "8px",
-                transition: "background-color 0.3s",
-                // border: "1px solid #ccc",
-                mt: "5px",
-                "&:hover": {
-                  backgroundColor: (theme) =>
-                    theme.palette.mode === "dark"
-                      ? DESIGN_SYSTEM_COLORS.notebookG450
-                      : "white",
-                },
-              }}
-            >
-              <Typography>
-                {node.title}
-                {!!node.context?.title && ` at ${node.context.title}`}
-              </Typography>
-            </ListItem>
-          ))}
+          {searchResults.length > 0
+            ? searchResults.map(renderListItem)
+            : searchValue === "" &&
+              lastSearches.length > 0 &&
+              lastSearches.map(renderListItem)}
         </List>
       )}
     </Box>

--- a/src/components/Sidebar/ToolbarSidebar.tsx
+++ b/src/components/Sidebar/ToolbarSidebar.tsx
@@ -100,6 +100,8 @@ type MainSidebarProps = {
   setDisplayGuidelines: Function;
   currentImprovement: any;
   setCurrentImprovement: any;
+  lastSearches: string[];
+  updateLastSearches: Function;
 };
 
 const ToolbarSidebar = ({
@@ -124,6 +126,8 @@ const ToolbarSidebar = ({
   setDisplayGuidelines,
   currentImprovement,
   setCurrentImprovement,
+  lastSearches,
+  updateLastSearches,
 }: MainSidebarProps) => {
   const theme = useTheme();
   const db = getFirestore();
@@ -450,6 +454,8 @@ const ToolbarSidebar = ({
           <SearchSideBar
             openSearchedNode={openSearchedNode}
             searchWithFuse={searchWithFuse}
+            lastSearches={lastSearches}
+            updateLastSearches={updateLastSearches}
           />
         );
       case "userActivity":

--- a/src/pages/Ontology.tsx
+++ b/src/pages/Ontology.tsx
@@ -227,11 +227,34 @@ const Ontology = () => {
   // Function to update last searches
   const updateLastSearches = (searchedNode: any) => {
     setLastSearches((prevSearches) => {
+      // If searchedNode is null, only filter valid searches from prevSearches
+      if (!searchedNode) {
+        const validSearches = prevSearches.filter((node) => {
+          const nodeInNodes = nodes[node.id];
+          return nodeInNodes && !nodeInNodes.deleted; // Keep only non-deleted nodes
+        });
+
+        localStorage.setItem(
+          `lastSearches_${user?.userId}`,
+          JSON.stringify(validSearches)
+        );
+        return validSearches;
+      }
+
+      // Proceed with the usual update if searchedNode is not null
       const filteredSearches = prevSearches.filter(
         (s) => s.id !== searchedNode.id
       );
       const updatedSearches = [searchedNode, ...filteredSearches];
-      const limitedSearches = updatedSearches.slice(0, 20);
+
+      const validSearches = updatedSearches.filter((node) => {
+        const nodeInNodes = nodes[node.id];
+        return nodeInNodes && !nodeInNodes.deleted; // Keep only non-deleted nodes
+      });
+
+      const limitedSearches = validSearches.slice(0, 20);
+
+      // Update localStorage with the new list of searches
       localStorage.setItem(
         `lastSearches_${user?.userId}`,
         JSON.stringify(limitedSearches)

--- a/src/pages/Ontology.tsx
+++ b/src/pages/Ontology.tsx
@@ -167,6 +167,18 @@ const Ontology = () => {
   const [currentImprovement, setCurrentImprovement] = useState(null);
   const [displayGuidelines, setDisplayGuidelines] = useState(false);
   const [prevHash, setPrevHash] = useState("");
+  const [lastSearches, setLastSearches] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (user) {
+      // Load last searches from localStorage with userId prefix
+      const searches = localStorage.getItem(`lastSearches_${user.userId}`);
+      if (searches) {
+        setLastSearches(JSON.parse(searches));
+      }
+    }
+  }, [user]);
+
   useEffect(() => {
     // Check if a user is logged in
     if (user) {
@@ -211,6 +223,22 @@ const Ontology = () => {
       window.removeEventListener("hashchange", handleHashChange);
     };
   }, [eachOntologyPath, prevHash]);
+
+  // Function to update last searches
+  const updateLastSearches = (searchedNode: any) => {
+    setLastSearches((prevSearches) => {
+      const filteredSearches = prevSearches.filter(
+        (s) => s.id !== searchedNode.id
+      );
+      const updatedSearches = [searchedNode, ...filteredSearches];
+      const limitedSearches = updatedSearches.slice(0, 20);
+      localStorage.setItem(
+        `lastSearches_${user?.userId}`,
+        JSON.stringify(limitedSearches)
+      );
+      return limitedSearches;
+    });
+  };
 
   // Function to perform a search using Fuse.js library
   const searchWithFuse = (query: string, nodeType?: INodeTypes): INode[] => {
@@ -733,9 +761,11 @@ const Ontology = () => {
       navigateToNode(node.id);
 
       setTimeout(() => {
-        const element = document.getElementById("node-" + node?.id);
-        if (element) {
-          element.scrollIntoView({ behavior: "smooth", block: "center" });
+        const elements = document.getElementsByClassName("node-" + node?.id);
+        const firstElement = elements.length > 0 ? elements[0] : null;
+
+        if (firstElement) {
+          firstElement.scrollIntoView({ behavior: "smooth", block: "center" });
         }
       }, 500);
       // initializeExpanded(eachOntologyPath[node.id]);
@@ -793,15 +823,28 @@ const Ontology = () => {
     return () => clearInterval(intervalId);
   }, [lastInteractionDate]);
 
+  // Navigate to the currentVisibleNode when the viewValue is 0 (Outline View)
+  // Note: This functionality might be implemented without useEffect in the future.
+  useEffect(() => {
+    if (viewValue === 0 && currentVisibleNode) {
+      navigateToNode(currentVisibleNode.id);
+    }
+  }, [viewValue, currentVisibleNode]);
+
   const navigateToNode = async (nodeId: string) => {
     if (nodes[nodeId]) {
       setCurrentVisibleNode(nodes[nodeId]);
       initializeExpanded(eachOntologyPath[nodeId]);
       setSelectedDiffNode(null);
       setTimeout(() => {
-        const element = document.getElementById("node-" + nodeId);
-        if (element) {
-          element.scrollIntoView({ behavior: "smooth", block: "center" });
+        // Retrieve elements with the class name based on the nodeId
+        // Since the same node may be displayed multiple times across different parents, using unique IDs alone is not sufficient.
+        // MUI TreeView handles IDs internally, so adding an additional class to each node allows for easier access and manipulation later on.
+        const elements = document.getElementsByClassName("node-" + nodeId);
+        const firstElement = elements.length > 0 ? elements[0] : null; // Safely access the first element
+
+        if (firstElement) {
+          firstElement.scrollIntoView({ behavior: "smooth", block: "center" });
         }
       }, 800);
     }
@@ -909,20 +952,18 @@ const Ontology = () => {
                 <TabPanel
                   value={viewValue}
                   index={0}
-                  sx={
-                    {
-                      height: "100%",
+                  sx={{
+                    height: "100%",
                     overflowX: "auto",
                     whiteSpace: "nowrap",
                     ...SCROLL_BAR_STYLE,
-                    }
-                  }
-              >
-                <Box
-                  sx={{
-                    display: "inline-block", // Keep it inline for horizontal scroll
-                    minWidth: "100%", // Ensures it takes at least the width of the container
                   }}
+                >
+                  <Box
+                    sx={{
+                      display: "inline-block", // Keep it inline for horizontal scroll
+                      minWidth: "100%", // Ensures it takes at least the width of the container
+                    }}
                   >
                     <TreeViewSimplified
                       treeVisualization={treeVisualization}
@@ -931,7 +972,7 @@ const Ontology = () => {
                       setExpandedNodes={setExpandedNodes}
                       currentVisibleNode={currentVisibleNode}
                     />
-                </Box>
+                  </Box>
                 </TabPanel>
                 <TabPanel value={viewValue} index={1}>
                   <DagGraph
@@ -954,6 +995,8 @@ const Ontology = () => {
                 <SearchSideBar
                   openSearchedNode={openSearchedNode}
                   searchWithFuse={searchWithFuse}
+                  lastSearches={lastSearches}
+                  updateLastSearches={updateLastSearches}
                 />
               </Box>
             </Section>
@@ -1047,6 +1090,8 @@ const Ontology = () => {
             setDisplayGuidelines={setDisplayGuidelines}
             currentImprovement={currentImprovement}
             setCurrentImprovement={setCurrentImprovement}
+            lastSearches={lastSearches}
+            updateLastSearches={updateLastSearches}
           />
         </Container>
         {ConfirmDialog}


### PR DESCRIPTION
Hi @samadouhra 

This PR address following issues:

- Fixed the outline view not scrolling into current visible nodes
  - https://github.com/MIT-Center-for-Collective-Intelligence/1Ontology/issues/133
  - https://github.com/MIT-Center-for-Collective-Intelligence/1Ontology/issues/134
- Added a search history limiting to the last 20 searches when the user focuses on the search bar and has not typed anything in
  - https://github.com/MIT-Center-for-Collective-Intelligence/1Ontology/issues/130