### PR TITLE
Add pagination to node history and add lowercase check for text property tooltip

### DIFF
--- a/src/components/ActiveUsers/NodeActivity.tsx
+++ b/src/components/ActiveUsers/NodeActivity.tsx
@@ -5,6 +5,7 @@ import {
   CircularProgress,
   Paper,
   Typography,
+  Pagination,
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import {
@@ -24,6 +25,8 @@ import { SCROLL_BAR_STYLE } from " @components/lib/CONSTANTS";
 import OptimizedAvatar from "../Chat/OptimizedAvatar";
 import ActivityDetails from "./ActivityDetails";
 
+const ITEMS_PER_PAGE = 15;
+
 const NodeActivity = ({
   currentVisibleNode,
   selectedDiffNode,
@@ -38,11 +41,14 @@ const NodeActivity = ({
   const db = getFirestore();
   const [logs, setLogs] = useState<(NodeChange & { id: string })[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
+  const [currentPage, setCurrentPage] = useState<number>(1);
 
   useEffect(() => {
     if (!currentVisibleNode?.id) return;
+    
     setLogs([]);
-
+    setCurrentPage(1);
+    
     const nodesQuery = query(
       collection(db, NODES_LOGS),
       where("nodeId", "==", currentVisibleNode?.id),
@@ -51,20 +57,25 @@ const NodeActivity = ({
     );
 
     const unsubscribeNodes = onSnapshot(nodesQuery, (snapshot) => {
-      const docChanges = snapshot.docChanges();
-      setLogs((prev: (NodeChange & { id: string })[]) => {
-        for (let change of docChanges) {
-          const changeData: any = change.doc.data();
-          const id = change.doc.id;
-          prev.push({ ...changeData, id });
-        }
-        return prev;
-      });
+      const docs = snapshot.docs.map(doc => ({
+        ...doc.data(),
+        id: doc.id
+      })) as (NodeChange & { id: string })[];
+      
+      setLogs(docs);
       setLoading(false);
     });
 
     return () => unsubscribeNodes();
   }, [db, currentVisibleNode?.id]);
+
+  const indexOfLastLog = currentPage * ITEMS_PER_PAGE;
+  const indexOfFirstLog = indexOfLastLog - ITEMS_PER_PAGE;
+  const currentLogs = logs.slice(indexOfFirstLog, indexOfLastLog);
+
+  const handlePageChange = (event: React.ChangeEvent<unknown>, value: number) => {
+    setCurrentPage(value);
+  };
 
   if (loading) {
     return (
@@ -122,15 +133,10 @@ const NodeActivity = ({
           </Box>
         </Box>
       )}
-      {logs.length > 0 &&
-        logs
-          .sort((a: any, b: any) => {
-            return (
-              new Date(b.modifiedAt.toDate()).getTime() -
-              new Date(a.modifiedAt.toDate()).getTime()
-            );
-          })
-          .map((log: NodeChange & { id: string }) => (
+
+      {logs.length > 0 && (
+        <>
+          {currentLogs.map((log: NodeChange & { id: string }) => (
             <ActivityDetails
               key={log.id}
               activity={log}
@@ -139,6 +145,26 @@ const NodeActivity = ({
               isSelected={selectedDiffNode?.id === log.id}
             />
           ))}
+
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'center',
+              mt: 8,
+              mb: 2,
+            }}
+          >
+            <Pagination
+              count={Math.ceil(logs.length / ITEMS_PER_PAGE)}
+              page={currentPage}
+              onChange={handlePageChange}
+              color="primary"
+              showFirstButton
+              showLastButton
+            />
+          </Box>
+        </>
+      )}
     </Box>
   );
 };

--- a/src/components/OntologyComponents/Text.tsx
+++ b/src/components/OntologyComponents/Text.tsx
@@ -31,6 +31,7 @@ import { diffWords, diffLines } from "diff"; // Using diffLines for line-by-line
 import {
   capitalizeFirstLetter,
   getTooltipHelper as getTooltipHelper,
+  lowercaseFirstLetter,
 } from " @components/lib/utils/string.utils";
 import ManageNodeButtons from "./ManageNodeButtons";
 import { DISPLAY, WS_URL } from " @components/lib/CONSTANTS";
@@ -320,7 +321,7 @@ const Text = ({
                 : "",
           }}
         >
-          <Tooltip title={getTooltipHelper(property)}>
+          <Tooltip title={getTooltipHelper(lowercaseFirstLetter(property))}>
             <Typography
               sx={{
                 fontSize: "20px",

--- a/src/lib/utils/string.utils.ts
+++ b/src/lib/utils/string.utils.ts
@@ -11,6 +11,13 @@ export function capitalizeFirstLetter(str: string): string {
   return capitalized;
 }
 
+export function lowercaseFirstLetter(str: string): string {
+  if (typeof str !== "string") {
+    return "";
+  }
+  return str.charAt(0).toLowerCase() + str.slice(1);
+}
+
 // Function to capitalize each word in a string
 export const capitalizeString = (str: string): string => {
   return str


### PR DESCRIPTION
Hi @samadouhra 

This is PR for:

- https://github.com/MIT-Center-for-Collective-Intelligence/1Ontology/issues/216
- https://github.com/MIT-Center-for-Collective-Intelligence/1Ontology/issues/150

For the tooltips missing issue, I have checked the codebase and confirmed that all tooltips are correctly implemented as per the specifications. Updated the code in Text component to ensure tooltips are shown correctly for properties that aren't in lowercase.