### PR TITLE
Update firestore query for new nodes logs as to properly display in history tabs

### DIFF
--- a/src/components/ActiveUsers/HistoryTab.tsx
+++ b/src/components/ActiveUsers/HistoryTab.tsx
@@ -62,6 +62,7 @@ const NodeActivity = ({
           collection(db, NODES_LOGS),
           where("changeType", "==", "add node"),
           where("skillsFuture", "==", !!skillsFuture),
+          where("appName", "==", skillsFutureApp),
           orderBy("modifiedAt", "desc"),
           limit(100),
         );
@@ -71,6 +72,7 @@ const NodeActivity = ({
           where("changeType", "==", "add node"),
           where("modifiedBy", "==", selectedUser),
           where("skillsFuture", "==", !!skillsFuture),
+          where("appName", "==", skillsFutureApp),
           orderBy("modifiedAt", "desc"),
           limit(100),
         );
@@ -177,6 +179,7 @@ const NodeActivity = ({
             collection(db, NODES_LOGS),
             where("changeType", "==", "add node"),
             where("skillsFuture", "==", !!skillsFuture),
+            where("appName", "==", skillsFutureApp),
             orderBy("modifiedAt", "desc"),
             startAfter(lastDoc),
             limit(50),
@@ -187,6 +190,7 @@ const NodeActivity = ({
             where("changeType", "==", "add node"),
             where("modifiedBy", "==", selectedUser),
             where("skillsFuture", "==", !!skillsFuture),
+            where("appName", "==", skillsFutureApp),
             orderBy("modifiedAt", "desc"),
             startAfter(lastDoc),
             limit(50),


### PR DESCRIPTION
Hi @samadouhra 

This is the PR for same history tabs issue, but for "new nodes" logs.