### PR TITLE
Fix outline jumping when navigating to root nodes via URL hash change

### DIFF
--- a/src/components/OntologyComponents/DraggableTree.tsx
+++ b/src/components/OntologyComponents/DraggableTree.tsx
@@ -713,6 +713,14 @@ function DraggableTree({
     collapsingLoader.current = false;
   };
 
+  const generateDomElementId = (node: NodeApi<PaginatedTreeData>): string => {
+    const { id } = node.data;
+    const isRootNode = node.level === 0;
+    
+    // Prefix root nodes to prevent browser hash auto-scrolling
+    return isRootNode ? `tree-root-${id}` : id;
+  };
+
   function Node({
     node,
     style,
@@ -752,7 +760,7 @@ function DraggableTree({
           <Box
             style={style}
             className={clsx(styles.node, styles.loadMoreNode)}
-            id={node.data.id}
+            id={generateDomElementId(node)}
             onClick={() => !isLoading && handleLoadMore(node.data.id)}
             sx={{
               cursor: isLoading ? "default" : "pointer",
@@ -823,7 +831,7 @@ function DraggableTree({
         style={style}
         className={clsx(styles.node, node.state)}
         onClick={() => node.isInternal && node.toggle()}
-        id={node.data.id}
+        id={generateDomElementId(node)}
         sx={{
           backgroundColor:
             node.data.nodeId === currentVisibleNode?.id && !node.data.category

--- a/src/pages/Ontology.tsx
+++ b/src/pages/Ontology.tsx
@@ -911,11 +911,9 @@ const Ontology = ({
     }
     // setOntologyPath(eachOntologyPath[currentVisibleNode?.id]);
 
-    if (!isRootNode) {
-      updateTheUrl([
+    updateTheUrl([
         { id: currentVisibleNode?.id, title: currentVisibleNode.title },
       ]);
-    }
   }, [currentVisibleNode?.id, eachOntologyPath]);
 
   // Callback function to add a new node to the database


### PR DESCRIPTION
Hi @samadouhra 

This is PR for the browser navigation issue that Iman reported.

This fix was to:
- Include root nodes in URL updates for proper browser navigation
- Prefix root node DOM IDs to prevent browser auto-scroll behavior