### PR TITLE
Handle neverInherit properties during inheritance propagation

### DIFF
--- a/src/components/SelectInheritance/SelectInheritance.tsx
+++ b/src/components/SelectInheritance/SelectInheritance.tsx
@@ -25,6 +25,11 @@ const SelectInheritance = ({
   nodes: { [nodeId: string]: INode };
   enableEdit: boolean;
 }) => {
+  // Don't render if inheritanceType is neverInherit
+  if (currentVisibleNode.inheritance[property]?.inheritanceType === "neverInherit") {
+    return null;
+  }
+
   const db = getFirestore();
   const [generalizations, setGeneralizations] = useState<
     { id: string; title: string }[]


### PR DESCRIPTION
Hi @samadouhra 

This is PR for handling neverInherit properties.
I opened it as a new PR instead of updating #279 to maintain better tracking.

Changes included are:
  - Implements `neverInherit` property handling during node creation and inheritance propagation
  - Ensures properties marked as `neverInherit` use default values instead of inherited values
  - Sets inheritance refs to `null` for `neverInherit` properties to break inheritance chains