### PR TITLE
Add null checks when recursively updating inheritance

### DIFF
--- a/src/components/SelectInheritance/SelectInheritance.tsx
+++ b/src/components/SelectInheritance/SelectInheritance.tsx
@@ -96,9 +96,11 @@ const SelectInheritance = ({
       for (let link of links) {
         const nodeRef = doc(collection(db, NODES), link.id);
         if (
-          !nodes[link.id].inheritance.ref ||
-          generalizationId === nodes[link.id].inheritance[property].ref ||
-          modifiedInheritanceFor === nodes[link.id].inheritance[property].ref
+          nodes[link.id] && (
+            !nodes[link.id].inheritance[property]?.ref ||
+            generalizationId === nodes[link.id].inheritance[property]?.ref ||
+            modifiedInheritanceFor === nodes[link.id].inheritance[property]?.ref
+          )
         ) {
           let objectUpdate = {
             [`inheritance.${property}.ref`]: ref,
@@ -114,14 +116,16 @@ const SelectInheritance = ({
           newBatch = writeBatch(db);
         }
 
-        newBatch = await updateSpecializationsInheritance(
-          nodes[link.id].specializations,
-          newBatch,
-          property,
-          ref,
-          link.id,
-          modifiedInheritanceFor,
-        );
+        if (nodes[link.id]?.specializations) {
+          newBatch = await updateSpecializationsInheritance(
+            nodes[link.id].specializations,
+            newBatch,
+            property,
+            ref,
+            link.id,
+            modifiedInheritanceFor,
+          );
+        }
       }
     }
 


### PR DESCRIPTION
Hi @samadouhra 

This PR addresses the issue where "Select Inheritance" was not updating recursively.

The root cause was inconsistent  or incorrect data types in the dev database, which failed the condition check and threw error.

I’ve added a check to handle this, to make sure it won’t fail issues if similar data inconsistencies appear in production.