### PR TITLE
Add Firestore fallback content to yjs editor while waiting for Yjs sync to prevent empty fields

### DIFF
--- a/src/components/Markdown/MarkdownEditor.tsx
+++ b/src/components/Markdown/MarkdownEditor.tsx
@@ -130,6 +130,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
                 checkDuplicateTitle={editor.checkDuplicateTitle}
                 onEditorReady={handleEditorReady}
                 setEditorContent={setEditorContent}
+                fallbackContent={content.text}
               />
             ) : (
               <SimpleEditor

--- a/src/components/YJSEditor/YjsEditor.tsx
+++ b/src/components/YJSEditor/YjsEditor.tsx
@@ -17,6 +17,7 @@ const YjsEditor = ({
   cursorPosition,
   onEditorReady,
   setEditorContent,
+  fallbackContent,
 }: {
   fullname: string;
   property: string;
@@ -29,6 +30,7 @@ const YjsEditor = ({
   cursorPosition: number | null;
   onEditorReady?: (editor: any) => void;
   setEditorContent: any;
+  fallbackContent?: string;
 }) => {
   return (
     <YjsEditorWrapper
@@ -43,6 +45,7 @@ const YjsEditor = ({
       cursorPosition={cursorPosition}
       onEditorReady={onEditorReady}
       setEditorContent={setEditorContent}
+      fallbackContent={fallbackContent}
     />
   );
 };

--- a/src/components/YJSEditor/YjsEditorWrapper.tsx
+++ b/src/components/YJSEditor/YjsEditorWrapper.tsx
@@ -119,7 +119,7 @@ const YjsEditorWrapper = ({
     );
     provider.on("sync", (isSynced: boolean) => {
       if (isSynced) {
-                setSynced(true);
+        setSynced(true);
 
         // Initial check for duplicates when document first loads
         if (property === "title") {


### PR DESCRIPTION
Hi @samadouhra 

This PR is a fix for yjs fields showing blank content for a period of time when entering edit mode.

- added firestore fallback content to display immediately while yjs connects and syncs.