### PR TITLE
Fix treeview background color to match dark mode selection

### DIFF
--- a/src/components/OntologyComponents/drag.tree.module.css
+++ b/src/components/OntologyComponents/drag.tree.module.css
@@ -101,7 +101,6 @@
 
 .tree {
     border-radius: 16px;
-    background: #efefef;
     scrollbar-width: none; /* Firefox */
     -ms-overflow-style: none; /* IE/Edge */
 }
@@ -232,12 +231,6 @@
 
     .mobileWarning {
         display: block;
-    }
-}
-
-@media (prefers-color-scheme: dark) {
-    .tree {
-        background: transparent;
     }
 }
 


### PR DESCRIPTION
Hi @samadouhra 

This is a PR for the treeview background issue Xinru reported.

When the browser is set to light mode, the `@media (prefers-color-scheme: dark)` query was overriding the MUI theme, and setting the treeview's background to white.

Hardcoded background color and this media query are both removed. 
