### PR TITLE
Fix InheritanceDetailsPanel breaking on nodes with multiple generalizations

### DIFF
--- a/src/components/StructuredProperty/InheritanceDetailsPanel.tsx
+++ b/src/components/StructuredProperty/InheritanceDetailsPanel.tsx
@@ -232,8 +232,14 @@ const InheritanceDetailsPanel: React.FC<InheritanceDetailsPanelProps> = ({
     const { propertyType, isNumeric } = inheritanceData;
     if (propertyType) return propertyType;
     if (isNumeric) return "numeric";
-    if (Array.isArray(inheritanceData.inheritanceSources[0]?.value))
+    if (Array.isArray(inheritanceData.inheritanceSources[0]?.value)) {
+      // Check if it's a collection to prevent type mismatch error
+      const firstItem = inheritanceData.inheritanceSources[0]?.value?.[0];
+      if (firstItem?.nodes !== undefined || firstItem?.collectionName !== undefined) {
+        return "collection";
+      }
       return "string-array";
+    }
     return "string";
   }, [inheritanceData]);
 
@@ -354,7 +360,8 @@ const InheritanceDetailsPanel: React.FC<InheritanceDetailsPanelProps> = ({
 
   if (
     !inheritanceData.hasMultipleGeneralizations ||
-    !currentVisibleNode.inheritance[property]?.ref
+    !currentVisibleNode.inheritance[property]?.ref ||
+    property === "parts"
   ) {
     return null;
   }


### PR DESCRIPTION
Hello @samadouhra 

The issue occurs when editing any node with two or more generalizations and user attempts to click on "Add new part" button in the "Parts" section.

I've made two changes:  
1. to prevent collection objects from being rendered as strings  
2. excluded this component from rendering entirely for the "parts" property since we don't need it