### PR TITLE
Expose raw provider error payload

### DIFF
--- a/src/pages/landing/_components/AiPanel.tsx
+++ b/src/pages/landing/_components/AiPanel.tsx
@@ -70,7 +70,7 @@ const TypingDots: React.FC<{ color: string }> = ({ color }) => (
 type Turn =
   | { kind: "user"; text: string }
   | { kind: "assistant"; text: string; modelLabel: string }
-  | { kind: "error"; text: string };
+  | { kind: "error"; text: string; details?: unknown; status?: number };
 
 type Props = {
   nodes: { [id: string]: INode };
@@ -266,6 +266,16 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const [editingConf, setEditingConf] = useState(false);
+  const [expandedErrors, setExpandedErrors] = useState<Set<number>>(new Set());
+
+  const toggleErrorDetails = useCallback((idx: number) => {
+    setExpandedErrors((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }, []);
 
   // Form state for provider/model/key (used by empty-state + "change key")
   const [formProv, setFormProv] = useState<AiProviderId>("openrouter");
@@ -333,7 +343,12 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
           : e instanceof Error
             ? e.message
             : "Something went wrong.";
-      setTurns((prev) => [...prev, { kind: "error", text: msg }]);
+      const details = e instanceof AiCallError ? e.details : undefined;
+      const status = e instanceof AiCallError ? e.status : undefined;
+      setTurns((prev) => [
+        ...prev,
+        { kind: "error", text: msg, details, status },
+      ]);
     } finally {
       setLoading(false);
     }
@@ -798,6 +813,24 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
               );
             }
             // error
+            const isExpanded = expandedErrors.has(idx);
+            const hasDetails = t.details !== undefined;
+            let detailsText = "";
+            if (hasDetails) {
+              try {
+                detailsText = JSON.stringify(
+                  t.status !== undefined &&
+                    t.details &&
+                    typeof t.details === "object"
+                    ? { status: t.status, ...(t.details as object) }
+                    : t.details,
+                  null,
+                  2,
+                );
+              } catch {
+                detailsText = String(t.details);
+              }
+            }
             return (
               <Box
                 key={idx}
@@ -814,11 +847,58 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
                   fontFamily: INTER,
                   fontSize: "0.82rem",
                   lineHeight: 1.5,
-                  whiteSpace: "pre-wrap",
                   overflowWrap: "anywhere",
                 }}
               >
-                {t.text}
+                <Box sx={{ whiteSpace: "pre-wrap" }}>{t.text}</Box>
+                {hasDetails && (
+                  <Box
+                    component="button"
+                    type="button"
+                    onClick={() => toggleErrorDetails(idx)}
+                    sx={{
+                      mt: 0.6,
+                      background: "none",
+                      border: "none",
+                      p: 0,
+                      cursor: "pointer",
+                      fontFamily: INTER,
+                      fontSize: "0.7rem",
+                      fontWeight: 500,
+                      color: "error.main",
+                      opacity: 0.75,
+                      textDecoration: "underline",
+                      textDecorationStyle: "dotted",
+                      textUnderlineOffset: "2px",
+                      "&:hover": { opacity: 1 },
+                    }}
+                  >
+                    {isExpanded ? "Hide details" : "Show details"}
+                  </Box>
+                )}
+                {hasDetails && isExpanded && (
+                  <Box
+                    component="pre"
+                    sx={{
+                      mt: 0.8,
+                      p: 1,
+                      borderRadius: 1,
+                      bgcolor: (tt) =>
+                        alpha(tt.palette.text.primary, 0.06),
+                      color: "text.primary",
+                      fontFamily:
+                        '"SF Mono", ui-monospace, Menlo, Monaco, "Cascadia Code", monospace',
+                      fontSize: "0.7rem",
+                      lineHeight: 1.5,
+                      maxHeight: 280,
+                      overflow: "auto",
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-word",
+                    }}
+                  >
+                    {detailsText}
+                  </Box>
+                )}
               </Box>
             );
           })}

--- a/src/pages/landing/_components/aiProviders.ts
+++ b/src/pages/landing/_components/aiProviders.ts
@@ -268,9 +268,11 @@ export const clearAiConf = (): void => {
 
 export class AiCallError extends Error {
   status?: number;
-  constructor(message: string, status?: number) {
+  details?: unknown;
+  constructor(message: string, status?: number, details?: unknown) {
     super(message);
     this.status = status;
+    this.details = details;
   }
 }
 
@@ -294,21 +296,34 @@ export const callLLM = async (
       e instanceof Error
         ? `Network error: ${e.message}`
         : "Network error while contacting the provider.",
+      undefined,
+      {
+        reason: "network",
+        url: req.url,
+        provider: conf.prov,
+        model: conf.model,
+        cause:
+          e instanceof Error
+            ? { name: e.name, message: e.message }
+            : String(e),
+      },
     );
   }
 
   if (!resp.ok) {
     const txt = await resp.text().catch(() => "");
+    let parsed: unknown = null;
     let msg = "";
     try {
-      const j = JSON.parse(txt);
+      parsed = JSON.parse(txt);
+      const j = parsed as { error?: { message?: string }; message?: string };
       msg = j?.error?.message || j?.message || "";
     } catch {
       /* ignore */
     }
     if (resp.status === 401 || resp.status === 403) {
       msg =
-        "Invalid or expired API key. Check the key in the AI settings below.";
+        "Invalid or expired API key.";
     } else if (resp.status === 429) {
       msg = "Rate limit exceeded. Wait a moment and try again.";
     } else if (
@@ -319,14 +334,32 @@ export const callLLM = async (
     } else if (!msg) {
       msg = txt.slice(0, 200) || `HTTP ${resp.status}`;
     }
-    throw new AiCallError(msg, resp.status);
+    throw new AiCallError(msg, resp.status, {
+      reason: "http",
+      url: req.url,
+      provider: conf.prov,
+      model: conf.model,
+      status: resp.status,
+      statusText: resp.statusText,
+      body: parsed ?? txt,
+    });
   }
 
   let data: unknown;
   try {
     data = await resp.json();
   } catch {
-    throw new AiCallError("Malformed response from the provider.");
+    throw new AiCallError(
+      "Malformed response from the provider.",
+      undefined,
+      {
+        reason: "parse",
+        url: req.url,
+        provider: conf.prov,
+        model: conf.model,
+        status: resp.status,
+      },
+    );
   }
   const err = (data as { error?: { message?: string; code?: number } }).error;
   if (err) {
@@ -336,7 +369,14 @@ export const callLLM = async (
     } else if (err.code === 401 || err.code === 403) {
       msg = "Invalid or expired API key.";
     }
-    throw new AiCallError(msg);
+    throw new AiCallError(msg, undefined, {
+      reason: "provider-error",
+      url: req.url,
+      provider: conf.prov,
+      model: conf.model,
+      status: resp.status,
+      body: data,
+    });
   }
 
   if (p.parse) return p.parse(data);


### PR DESCRIPTION
Hi @samadouhra 

This PR is for displaying the provider error payload behind a "Show details" toggle on the AI chat error bubbles, so when users report issues like the `Provider returned error`, we can see the actual response from the provider instead of just the short message we map to.

The API key and request body are excluded from the payload; and  only response status, URL, model, provider, and the response body are shown.
