### PR TITLE
Optimize Navigator View

### DIFF
--- a/src/components/NodBody/NodeGraph.tsx
+++ b/src/components/NodBody/NodeGraph.tsx
@@ -1,11 +1,7 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Box,
+  CircularProgress,
   Paper,
   Typography,
   useTheme,
@@ -25,8 +21,8 @@ import {
   type ReactFlowInstance,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-// `dagre` ships no types, but is available transitively via `dagre-d3`.
-// A local minimal declaration keeps us honest without pulling another dep.
+
+// `dagre` ships no types — local declaration in lieu of pulling another dep.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const dagre: {
   graphlib: {
@@ -41,34 +37,23 @@ const dagre: {
   layout: (g: unknown) => void;
 } = require("dagre");
 
-import { ICollection, INode } from "@components/types/INode";
+import { TreeData } from "@components/types/INode";
 
 type Props = {
-  currentVisibleNode: INode;
-  relatedNodes: { [id: string]: INode };
-  navigateToNode: (nodeId: string) => void;
-  /** Height of the graph canvas. Pass a number (px) or any CSS length. Defaults to 540px. */
+  // `null` while the hierarchy is being built; spinner shown.
+  hierarchyTree: TreeData[] | null;
+  focusedId: string;
+  // `treeId` disambiguates duplicate nodeIds across positions in the tree.
+  onExpandNode: (treeId: string, nodeId: string) => Promise<void>;
+  onCollapseNode: (treeId: string, nodeId: string) => void;
   height?: number | string;
-  /** When true, strips the outer Paper chrome so the graph fills its container edge-to-edge. */
   borderless?: boolean;
-  /**
-   * When true, plain wheel/two-finger-swipe no longer zooms — the page
-   * scrolls behind the canvas instead. Zoom still works via Cmd/Ctrl+scroll
-   * and trackpad pinch. Recommended on embedded pages; off by default.
-   */
+  // When true, page scrolls instead of zooming; ⌘/Ctrl-scroll or pinch still zoom.
   requireModifierToZoom?: boolean;
-  /**
-   * Set of node ids whose outward neighbours are visible. Lifted to the
-   * parent so the exploration state survives view toggles (compass ↔ graph)
-   * that would otherwise unmount this component.
-   */
-  expanded: Set<string>;
-  onToggleExpand: (id: string) => void;
 };
 
 const DEFAULT_HEIGHT = 540;
 
-// Shared "glass" surface used by the widgets — matches NodeCompass for visual parity.
 const WIDGET_BG_DARK = "rgba(13,17,23,0.82)";
 const WIDGET_BG_LIGHT = "rgba(255,255,255,0.92)";
 const WIDGET_SHADOW_DARK =
@@ -78,86 +63,57 @@ const WIDGET_SHADOW_LIGHT =
 const WIDGET_HOVER_DARK = "rgba(255,255,255,0.06)";
 const WIDGET_HOVER_LIGHT = "rgba(0,0,0,0.04)";
 
-// Fan-out cap per node, per direction — bushy nodes (e.g. "Act") would
-// otherwise drop hundreds of siblings at once. No depth cap: the graph grows
-// only through user-driven expansion (click a node to expand / collapse).
-const MAX_PER_DIRECTION = 12;
-
-// Node sizes for dagre + React Flow render.
 const NODE_W = 200;
 const NODE_H = 46;
-const CENTER_W = 230;
-const CENTER_H = 66;
+const FOCUSED_W = 230;
+const FOCUSED_H = 66;
 
-type GraphRole = "center" | "gen" | "spec";
-
-const flattenIds = (cols: ICollection[] | undefined): string[] => {
-  if (!Array.isArray(cols)) return [];
-  const ids: string[] = [];
-  for (const c of cols) {
-    for (const n of c?.nodes ?? []) {
-      if (n?.id) ids.push(n.id);
-    }
-  }
-  return ids;
-};
-
-// ──────────────────────────────────────────────────────────────
-// Custom node
-// ──────────────────────────────────────────────────────────────
+type GraphRole = "focused" | "path" | "sibling";
 
 type GraphNodeData = {
   title: string;
   role: GraphRole;
-  depth: number;
   color: string;
-  partsCount: number;
-  isPartOfCount: number;
   canExpand: boolean;
   isExpanded: boolean;
+  isExpanding: boolean;
+  treeId: string;
+  nodeId: string;
 };
 
 const GraphNode: React.FC<NodeProps> = ({ data }) => {
   const d = data as unknown as GraphNodeData;
-  const isCenter = d.role === "center";
-  const dim = d.depth >= 2;
-  const isClickable = !isCenter && (d.canExpand || d.isExpanded);
-  const showBadge = isClickable;
-  // Expansion direction hint: "gen" grows leftward, "spec" rightward — place
-  // the badge on the outward side so the affordance feels directional.
-  const badgeSide = d.role === "gen" ? "left" : "right";
+  const isFocused = d.role === "focused";
   return (
     <Box
       sx={{
         position: "relative",
-        width: isCenter ? CENTER_W : NODE_W,
-        height: isCenter ? CENTER_H : NODE_H,
-        borderRadius: isCenter ? "16px" : "10px",
+        width: isFocused ? FOCUSED_W : NODE_W,
+        height: isFocused ? FOCUSED_H : NODE_H,
+        borderRadius: isFocused ? "16px" : "10px",
         background: (t) =>
-          isCenter
+          isFocused
             ? t.palette.mode === "dark"
               ? `${t.palette.primary.main}1f`
               : `${t.palette.primary.main}12`
             : t.palette.mode === "dark"
               ? "rgba(22,27,34,0.92)"
               : "rgba(255,255,255,0.98)",
-        border: `${isCenter ? 2 : 1.5}px solid ${d.color}`,
+        border: `${isFocused ? 2 : 1.5}px solid ${d.color}`,
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
         padding: "6px 10px",
-        cursor: isClickable ? "pointer" : "default",
-        opacity: dim ? 0.78 : 1,
+        cursor: "pointer",
+        opacity: d.role === "sibling" ? 0.92 : 1,
         userSelect: "none",
         transition: "background-color 0.15s ease, transform 0.1s ease",
-        "&:hover": isClickable
-          ? {
-              background: (t) =>
-                t.palette.mode === "dark" ? `${d.color}22` : `${d.color}14`,
-              transform: "translateY(-1px)",
-            }
-          : {},
+        "&:hover": {
+          background: (t) =>
+            t.palette.mode === "dark" ? `${d.color}22` : `${d.color}14`,
+          transform: "translateY(-1px)",
+        },
       }}
       title={d.title}
     >
@@ -170,48 +126,20 @@ const GraphNode: React.FC<NodeProps> = ({ data }) => {
           overflow: "hidden",
           textAlign: "center",
           lineHeight: 1.2,
-          fontSize: isCenter ? "13px" : "11px",
-          fontWeight: isCenter ? 700 : 500,
+          fontSize: isFocused ? "13px" : "11px",
+          fontWeight: isFocused ? 700 : 500,
           color: (t) => t.palette.text.primary,
           width: "100%",
         }}
       >
         {d.title}
       </Box>
-      {!isCenter && (d.partsCount > 0 || d.isPartOfCount > 0) && (
-        <Box
-          sx={{
-            display: "flex",
-            gap: 0.75,
-            mt: 0.3,
-            fontSize: "9px",
-            fontWeight: 600,
-          }}
-        >
-          {d.partsCount > 0 && (
-            <Box
-              component="span"
-              sx={{ color: (t) => t.palette.success.main, opacity: 0.9 }}
-            >
-              ▼ {d.partsCount}
-            </Box>
-          )}
-          {d.isPartOfCount > 0 && (
-            <Box
-              component="span"
-              sx={{ color: (t) => t.palette.warning.main, opacity: 0.9 }}
-            >
-              ▲ {d.isPartOfCount}
-            </Box>
-          )}
-        </Box>
-      )}
-      {showBadge && (
+      {(d.canExpand || d.isExpanded) && (
         <Box
           sx={{
             position: "absolute",
             top: -7,
-            [badgeSide]: -7,
+            right: -7,
             width: 18,
             height: 18,
             borderRadius: "50%",
@@ -234,6 +162,22 @@ const GraphNode: React.FC<NodeProps> = ({ data }) => {
           {d.isExpanded ? "−" : "+"}
         </Box>
       )}
+      {d.isExpanding && (
+        <Box
+          sx={{
+            position: "absolute",
+            top: "50%",
+            right: -28,
+            transform: "translateY(-50%)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            pointerEvents: "none",
+          }}
+        >
+          <CircularProgress size={14} thickness={5} sx={{ color: d.color }} />
+        </Box>
+      )}
       <Handle
         type="target"
         position={Position.Left}
@@ -252,229 +196,242 @@ const GraphNode: React.FC<NodeProps> = ({ data }) => {
 
 const nodeTypes: NodeTypes = { graph: GraphNode };
 
-// ──────────────────────────────────────────────────────────────
-// Main component
-// ──────────────────────────────────────────────────────────────
+type WalkedNode = {
+  treeId: string;
+  nodeId: string;
+  title: string;
+  hasChildren: boolean;
+  hasUnresolved: boolean;
+  parentTreeId: string | null;
+};
+
+// Skip `category: true` rows — they're tree-display artifacts (their
+// nodeId is the parent's), not real ontology nodes. Lift their children
+// up to the parent so the graph shows only real nodes.
+function walkHierarchy(tree: TreeData[]): WalkedNode[] {
+  const out: WalkedNode[] = [];
+  const visit = (node: TreeData, parentTreeId: string | null) => {
+    if (node.category) {
+      for (const c of node.children ?? []) visit(c, parentTreeId);
+      return;
+    }
+    out.push({
+      treeId: node.id,
+      nodeId: node.nodeId,
+      title: node.name || node.nodeId,
+      hasChildren: !!(node.children && node.children.length > 0),
+      hasUnresolved:
+        !!node.outlineLoadChildren ||
+        (!!node.hasUnresolvedChildren &&
+          (!node.children || node.children.length === 0)),
+      parentTreeId,
+    });
+    if (node.children) {
+      for (const c of node.children) visit(c, node.id);
+    }
+  };
+  for (const root of tree) visit(root, null);
+  return out;
+}
+
+function findPathTreeIds(tree: TreeData[], focusedId: string): Set<string> {
+  const chain: string[] = [];
+  const find = (node: TreeData): boolean => {
+    chain.push(node.id);
+    if (node.nodeId === focusedId && !node.category) return true;
+    for (const c of node.children ?? []) if (find(c)) return true;
+    chain.pop();
+    return false;
+  };
+  for (const root of tree) {
+    if (find(root)) break;
+  }
+  return new Set(chain);
+}
 
 const NodeGraph: React.FC<Props> = ({
-  currentVisibleNode,
-  relatedNodes,
-  navigateToNode,
+  hierarchyTree,
+  focusedId,
+  onExpandNode,
+  onCollapseNode,
   height = DEFAULT_HEIGHT,
   borderless = false,
   requireModifierToZoom = false,
-  expanded,
-  onToggleExpand,
 }) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
 
-  const axisColors = useMemo(
+  const colors = useMemo(
     () => ({
-      gen: isDark ? "#bc8cff" : "#8250df",
-      center: theme.palette.primary.main,
-      spec: theme.palette.primary.main,
+      focused: theme.palette.primary.main,
+      path: theme.palette.primary.main,
+      sibling: isDark ? "#bc8cff" : "#8250df",
     }),
     [theme.palette.primary.main, isDark],
   );
 
+  const [expandingTreeIds, setExpandingTreeIds] = useState<Set<string>>(
+    new Set(),
+  );
+  // Path-interior nodes are NOT added here — their children belong to
+  // the canonical hierarchy, not a user expansion. That's what makes
+  // collapse safe: clicks on them don't match and become no-ops.
+  const [userExpanded, setUserExpanded] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    setExpandingTreeIds(new Set());
+    setUserExpanded(new Set());
+  }, [focusedId]);
+
   const { nodes, edges } = useMemo(() => {
-    type Built = {
-      id: string;
-      title: string;
-      role: GraphRole;
-      depth: number;
-      color: string;
-      partsCount: number;
-      isPartOfCount: number;
-      canExpand: boolean;
-      isExpanded: boolean;
-    };
-    const builtNodes: Built[] = [];
-    const builtEdges: { source: string; target: string; color: string }[] = [];
-    const seen = new Set<string>();
+    if (!hierarchyTree || hierarchyTree.length === 0)
+      return { nodes: [] as Node[], edges: [] as Edge[] };
 
-    const nodeOf = (id: string): INode | undefined =>
-      relatedNodes[id] ??
-      (id === currentVisibleNode.id ? currentVisibleNode : undefined);
+    const walked = walkHierarchy(hierarchyTree);
+    const pathTreeIds = findPathTreeIds(hierarchyTree, focusedId);
 
-    const add = (id: string, role: GraphRole, depth: number, color: string) => {
-      if (seen.has(id)) return;
-      const n = nodeOf(id);
-      if (!n) return;
-      seen.add(id);
-      // canExpand points outward: gen-role grows further left (more gens),
-      // spec-role grows further right (more specs). The center never shows
-      // a badge — it's implicitly expanded in both directions.
-      const outwardLen =
-        role === "gen"
-          ? flattenIds(n.generalizations).length
-          : role === "spec"
-            ? flattenIds(n.specializations).length
-            : 0;
-      builtNodes.push({
-        id,
-        title: n.title ?? id,
-        role,
-        depth,
-        color,
-        partsCount: flattenIds(
-          n.properties?.parts as ICollection[] | undefined,
-        ).length,
-        isPartOfCount: flattenIds(
-          n.properties?.isPartOf as ICollection[] | undefined,
-        ).length,
-        canExpand: role !== "center" && outwardLen > 0,
-        isExpanded: expanded.has(id),
-      });
+    const roleOf = (n: WalkedNode): GraphRole => {
+      if (n.nodeId === focusedId) return "focused";
+      if (pathTreeIds.has(n.treeId)) return "path";
+      return "sibling";
     };
 
-    add(currentVisibleNode.id, "center", 0, axisColors.center);
-
-    // BFS through generalizations — ancestors (to the left in LR). Recurses
-    // only through the center and nodes the user has explicitly expanded.
-    let genFrontier: Array<{ id: string; depth: number }> = [
-      { id: currentVisibleNode.id, depth: 0 },
-    ];
-    while (genFrontier.length) {
-      const next: typeof genFrontier = [];
-      for (const { id: parentId, depth: pd } of genFrontier) {
-        const p = nodeOf(parentId);
-        if (!p) continue;
-        const gens = flattenIds(p.generalizations).slice(0, MAX_PER_DIRECTION);
-        for (const gid of gens) {
-          if (seen.has(gid)) continue;
-          add(gid, "gen", pd + 1, axisColors.gen);
-          builtEdges.push({
-            source: gid,
-            target: parentId,
-            color: axisColors.gen,
-          });
-          if (expanded.has(gid)) next.push({ id: gid, depth: pd + 1 });
-        }
-      }
-      genFrontier = next;
-    }
-
-    // BFS through specializations — descendants (to the right in LR).
-    let specFrontier: Array<{ id: string; depth: number }> = [
-      { id: currentVisibleNode.id, depth: 0 },
-    ];
-    while (specFrontier.length) {
-      const next: typeof specFrontier = [];
-      for (const { id: parentId, depth: pd } of specFrontier) {
-        const p = nodeOf(parentId);
-        if (!p) continue;
-        const specs = flattenIds(p.specializations).slice(0, MAX_PER_DIRECTION);
-        for (const sid of specs) {
-          if (seen.has(sid)) continue;
-          add(sid, "spec", pd + 1, axisColors.spec);
-          builtEdges.push({
-            source: parentId,
-            target: sid,
-            color: axisColors.spec,
-          });
-          if (expanded.has(sid)) next.push({ id: sid, depth: pd + 1 });
-        }
-      }
-      specFrontier = next;
-    }
-
-    // Dagre layout, left-to-right with generalizations on the left.
     const g = new dagre.graphlib.Graph();
     g.setGraph({
       rankdir: "LR",
       ranksep: 90,
-      nodesep: 24,
+      nodesep: 16,
       edgesep: 8,
       marginx: 40,
       marginy: 40,
     });
     g.setDefaultEdgeLabel(() => ({}));
-    for (const n of builtNodes) {
-      const isCenter = n.role === "center";
-      g.setNode(n.id, {
-        width: isCenter ? CENTER_W : NODE_W,
-        height: isCenter ? CENTER_H : NODE_H,
+    for (const n of walked) {
+      const r = roleOf(n);
+      const isFocused = r === "focused";
+      g.setNode(n.treeId, {
+        width: isFocused ? FOCUSED_W : NODE_W,
+        height: isFocused ? FOCUSED_H : NODE_H,
       });
     }
-    for (const e of builtEdges) g.setEdge(e.source, e.target);
+    for (const n of walked) {
+      if (n.parentTreeId) g.setEdge(n.parentTreeId, n.treeId);
+    }
     dagre.layout(g);
 
-    const rfNodes: Node[] = builtNodes.map((n) => {
-      const p = g.node(n.id);
-      const isCenter = n.role === "center";
-      const w = isCenter ? CENTER_W : NODE_W;
-      const h = isCenter ? CENTER_H : NODE_H;
+    const rfNodes: Node[] = walked.map((n) => {
+      const role = roleOf(n);
+      const p = g.node(n.treeId);
+      const isFocused = role === "focused";
+      const w = isFocused ? FOCUSED_W : NODE_W;
+      const h = isFocused ? FOCUSED_H : NODE_H;
       return {
-        id: n.id,
+        id: n.treeId,
         type: "graph",
         position: { x: p.x - w / 2, y: p.y - h / 2 },
         data: {
           title: n.title,
-          role: n.role,
-          depth: n.depth,
-          color: n.color,
-          partsCount: n.partsCount,
-          isPartOfCount: n.isPartOfCount,
-          canExpand: n.canExpand,
-          isExpanded: n.isExpanded,
+          role,
+          color: colors[role],
+          canExpand: n.hasUnresolved,
+          isExpanded: userExpanded.has(n.treeId),
+          isExpanding: expandingTreeIds.has(n.treeId),
+          treeId: n.treeId,
+          nodeId: n.nodeId,
         } as unknown as Record<string, unknown>,
         draggable: false,
         selectable: false,
       };
     });
 
-    const rfEdges: Edge[] = builtEdges.map((e, idx) => ({
-      id: `e${idx}-${e.source}-${e.target}`,
-      source: e.source,
-      target: e.target,
-      type: "default",
-      animated: false,
-      style: { stroke: e.color, strokeWidth: 1.6, strokeOpacity: 0.7 },
-      markerEnd: {
-        type: MarkerType.ArrowClosed,
-        color: e.color,
-        width: 16,
-        height: 16,
-      },
-    }));
+    const rfEdges: Edge[] = [];
+    for (const n of walked) {
+      if (!n.parentTreeId) continue;
+      const onPath =
+        pathTreeIds.has(n.parentTreeId) && pathTreeIds.has(n.treeId);
+      const color = onPath ? colors.path : colors.sibling;
+      rfEdges.push({
+        id: `e-${n.parentTreeId}-${n.treeId}`,
+        source: n.parentTreeId,
+        target: n.treeId,
+        type: "default",
+        animated: false,
+        style: {
+          stroke: color,
+          strokeWidth: onPath ? 2 : 1.4,
+          strokeOpacity: onPath ? 0.85 : 0.55,
+        },
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          color,
+          width: 16,
+          height: 16,
+        },
+      });
+    }
 
     return { nodes: rfNodes, edges: rfEdges };
-  }, [currentVisibleNode, relatedNodes, axisColors, expanded]);
+  }, [hierarchyTree, focusedId, colors, expandingTreeIds, userExpanded]);
 
   const [rfInstance, setRfInstance] = useState<ReactFlowInstance | null>(null);
 
-  // Re-fit on focus change.
+  // Refit only on focus change so expand/collapse preserves pan/zoom.
   useEffect(() => {
     if (!rfInstance) return;
     const t = setTimeout(() => {
       rfInstance.fitView({ padding: 0.12, duration: 320 });
     }, 60);
     return () => clearTimeout(t);
-  }, [rfInstance, currentVisibleNode.id, nodes.length]);
+  }, [rfInstance, focusedId]);
 
-  // Click = toggle expansion, but only on nodes that actually have something
-  // to expand or collapse. Otherwise we'd be mutating the `expanded` set on
-  // leaf nodes with no outward neighbours, which silently adds them, flips
-  // `isExpanded`, and makes the "−" badge appear for no functional reason.
   const onNodeClick = useCallback(
-    (_: React.MouseEvent, node: Node) => {
-      if (!node.id || node.id === currentVisibleNode.id) return;
+    (_e: React.MouseEvent, node: Node) => {
       const d = node.data as unknown as GraphNodeData;
-      if (d.canExpand || d.isExpanded) {
-        onToggleExpand(node.id);
+      if (userExpanded.has(d.treeId)) {
+        onCollapseNode(d.treeId, d.nodeId);
+        setUserExpanded((prev) => {
+          const next = new Set(prev);
+          next.delete(d.treeId);
+          return next;
+        });
+        return;
       }
+      if (!d.canExpand) return;
+      if (expandingTreeIds.has(d.treeId)) return;
+      setExpandingTreeIds((prev) => new Set(prev).add(d.treeId));
+      Promise.resolve(onExpandNode(d.treeId, d.nodeId))
+        .then(() => {
+          setUserExpanded((prev) => new Set(prev).add(d.treeId));
+        })
+        .catch((err) => console.error("graph expand failed:", err))
+        .finally(() => {
+          setExpandingTreeIds((prev) => {
+            const next = new Set(prev);
+            next.delete(d.treeId);
+            return next;
+          });
+        });
     },
-    [onToggleExpand, currentVisibleNode.id],
+    [onExpandNode, onCollapseNode, expandingTreeIds, userExpanded],
   );
 
-  // Empty-state guard — if the current node has no gen and no spec, the
-  // graph would just be the solitary center node; skip it entirely.
-  const hasContext =
-    flattenIds(currentVisibleNode.generalizations).length > 0 ||
-    flattenIds(currentVisibleNode.specializations).length > 0;
-  if (!hasContext) return null;
+  if (!hierarchyTree) {
+    return (
+      <Paper
+        elevation={borderless ? 0 : 9}
+        sx={{
+          borderRadius: borderless ? 0 : "20px",
+          width: "100%",
+          height: borderless ? "100%" : height,
+          background: borderless ? "transparent" : undefined,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <CircularProgress size={28} thickness={4} />
+      </Paper>
+    );
+  }
 
   return (
     <Paper
@@ -564,7 +521,6 @@ const NodeGraph: React.FC<Props> = ({
           </ReactFlow>
         </ReactFlowProvider>
 
-        {/* Info pill — bottom-left, glass surface */}
         <Box
           sx={{
             position: "absolute",
@@ -603,9 +559,10 @@ const NodeGraph: React.FC<Props> = ({
               lineHeight: 1,
             }}
           >
-            Click + to expand · click − to collapse ·{" "}
-            {requireModifierToZoom ? "⌘-scroll or pinch to zoom" : "scroll to zoom"}{" "}
-            · ▼ parts · ▲ is part of
+            Click a node to expand or collapse ·{" "}
+            {requireModifierToZoom
+              ? "⌘-scroll or pinch to zoom"
+              : "scroll to zoom"}
           </Typography>
         </Box>
       </Box>

--- a/src/pages/landing/_components/AiPanel.tsx
+++ b/src/pages/landing/_components/AiPanel.tsx
@@ -24,11 +24,20 @@ import {
   SettingsOutlined as GearIcon,
 } from "@mui/icons-material";
 import {
+  collection,
+  documentId,
+  getDocs,
+  getFirestore,
+  query as firestoreQuery,
+  where,
+} from "firebase/firestore";
+import {
   AI_PROVIDERS,
   AiCallError,
   type AiConf,
   type AiProviderId,
   type ChatMsg,
+  type ToolCall,
   callLLM,
   clearAiConf,
   defaultModel,
@@ -37,13 +46,23 @@ import {
   saveAiConf,
   verifyAiConf,
 } from "./aiProviders";
-import { buildDirectory, buildSystemPrompt } from "./aiContext";
+import {
+  MAX_GET_ACTIVITIES_BATCH,
+  MAX_SEARCH_RESULTS,
+  MAX_TOOL_ITERATIONS,
+  SYSTEM_PROMPT,
+  TOOLS,
+  formatActivityProfiles,
+  formatSearchResults,
+  type SearchHit,
+} from "./aiContext";
+import { Post } from "../../../lib/utils/Post";
+import { NODES } from "../../../lib/firestoreClient/collections";
 import type { INode } from "../../../types/INode";
 
 const INTER =
   '"Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif';
 
-// Three-dot typing indicator — each dot bounces on a staggered delay.
 const dotBounce = keyframes`
   0%, 80%, 100% { transform: translateY(0); opacity: 0.35; }
   40% { transform: translateY(-4px); opacity: 1; }
@@ -73,19 +92,208 @@ type Turn =
   | { kind: "error"; text: string; details?: unknown; status?: number };
 
 type Props = {
-  nodes: { [id: string]: INode };
-  navigateToNode: (id: string) => void;
+  appName: string;
+  // optional title forwarded from chip clicks for an immediate label
+  navigateToNode: (id: string, title?: string) => void;
 };
 
-// ──────────────────────────────────────────────────────────────
-// Inline markdown-lite renderer for assistant replies.
-// Handles fenced code blocks, **#ID Title** chips (clickable), **bold**,
-// `inline code`, ## headings, --- rules, and newlines.
-// ──────────────────────────────────────────────────────────────
+// Verbose tool-loop logging gated on window.__AI_DEBUG (default on).
+// Silence with: window.__AI_DEBUG = false in the browser console.
+const aiDebug = (...args: unknown[]) => {
+  if (typeof window === "undefined") return;
+  const w = window as unknown as { __AI_DEBUG?: boolean };
+  if (w.__AI_DEBUG === false) return;
+  // eslint-disable-next-line no-console
+  console.log("AI Process", ...args);
+};
 
+type SearchChromaResult = {
+  id: string;
+  title?: string;
+  description?: string;
+};
+
+const runSearchActivities = async (
+  query: string,
+  appName: string,
+): Promise<string> => {
+  const trimmed = (query ?? "").trim();
+  aiDebug("search_activities → input", { query, trimmed, appName });
+  if (!trimmed) {
+    aiDebug("search_activities → empty query, returning no-match");
+    return formatSearchResults(query ?? "", []);
+  }
+  try {
+    const reqBody = {
+      query: trimmed,
+      appName,
+      nodeType: "activity",
+      resultsNum: MAX_SEARCH_RESULTS,
+      skillsFuture: false,
+    };
+    aiDebug("search_activities → POST /api/searchChroma body:", reqBody);
+    const t0 = performance.now();
+    const resp = await Post<{ results?: SearchChromaResult[] }>(
+      "/searchChroma",
+      reqBody,
+    );
+    const ms = Math.round(performance.now() - t0);
+    aiDebug(
+      `search_activities → response in ${ms}ms; ${resp?.results?.length ?? 0} result(s)`,
+      resp,
+    );
+    const hits: SearchHit[] = (resp?.results ?? []).map((r) => ({
+      id: r.id,
+      title: r.title ?? r.id,
+      description: r.description,
+    }));
+    const formatted = formatSearchResults(trimmed, hits);
+    aiDebug("search_activities → formatted result fed to LLM:", formatted);
+    return formatted;
+  } catch (e) {
+    const msg =
+      e instanceof Error ? e.message : "Search failed for an unknown reason.";
+    aiDebug("search_activities → ERROR", { message: msg, error: e });
+    return `Search error: ${msg}. Try a different query or proceed without search.`;
+  }
+};
+
+// Firestore `in` queries cap at 30 ids per call. We cap inputs at
+// MAX_GET_ACTIVITIES_BATCH (20) but still chunk to be safe.
+const FIRESTORE_IN_LIMIT = 30;
+
+const fetchNodesByIds = async (
+  ids: string[],
+): Promise<Map<string, INode>> => {
+  const out = new Map<string, INode>();
+  if (ids.length === 0) return out;
+  const db = getFirestore();
+  const chunks: string[][] = [];
+  for (let i = 0; i < ids.length; i += FIRESTORE_IN_LIMIT) {
+    chunks.push(ids.slice(i, i + FIRESTORE_IN_LIMIT));
+  }
+  aiDebug(
+    `fetchNodesByIds → ${ids.length} id(s) in ${chunks.length} chunk(s)`,
+    ids,
+  );
+  const t0 = performance.now();
+  const snapshots = await Promise.all(
+    chunks.map((chunk) =>
+      getDocs(
+        firestoreQuery(
+          collection(db, NODES),
+          where(documentId(), "in", chunk),
+        ),
+      ),
+    ),
+  );
+  for (const snapshot of snapshots) {
+    snapshot.forEach((doc) => {
+      const data = { id: doc.id, ...(doc.data() as object) } as INode;
+      out.set(doc.id, data);
+    });
+  }
+  const ms = Math.round(performance.now() - t0);
+  aiDebug(
+    `fetchNodesByIds → got ${out.size}/${ids.length} doc(s) in ${ms}ms`,
+  );
+  if (out.size < ids.length) {
+    const missing = ids.filter((id) => !out.has(id));
+    aiDebug("fetchNodesByIds → missing ids:", missing);
+  }
+  return out;
+};
+
+const runGetActivities = async (
+  ids: string[],
+  appName: string,
+): Promise<string> => {
+  aiDebug("get_activities → input", { ids, appName });
+  const cleaned = Array.from(
+    new Set(
+      (Array.isArray(ids) ? ids : [])
+        .filter((x): x is string => typeof x === "string" && !!x.trim())
+        .map((x) => x.trim()),
+    ),
+  ).slice(0, MAX_GET_ACTIVITIES_BATCH);
+
+  if (cleaned.length === 0) {
+    aiDebug("get_activities → no valid ids after cleanup");
+    return "No ids provided.";
+  }
+  if (cleaned.length !== (ids?.length ?? 0)) {
+    aiDebug(
+      `get_activities → cleaned ids: ${ids?.length ?? 0} → ${cleaned.length}`,
+      cleaned,
+    );
+  }
+
+  try {
+    const fetched = await fetchNodesByIds(cleaned);
+    let scopeFiltered = 0;
+    const profiles = cleaned.map((id) => {
+      const node = fetched.get(id) ?? null;
+      // Scope guard: if the node belongs to a different appName, hide it
+      // from the model so cross-app data can't leak through tool calls.
+      if (node && (node as { appName?: string }).appName !== appName) {
+        scopeFiltered++;
+        return { id, node: null };
+      }
+      return { id, node };
+    });
+    if (scopeFiltered > 0) {
+      aiDebug(
+        `get_activities → ${scopeFiltered} node(s) hidden by appName scope guard`,
+      );
+    }
+    const formatted = formatActivityProfiles(profiles);
+    aiDebug("get_activities → formatted result fed to LLM:", formatted);
+    return formatted;
+  } catch (e) {
+    const msg =
+      e instanceof Error ? e.message : "Fetch failed for an unknown reason.";
+    aiDebug("get_activities → ERROR", { message: msg, error: e });
+    return `get_activities error: ${msg}.`;
+  }
+};
+
+const executeToolCall = async (
+  call: ToolCall,
+  appName: string,
+): Promise<string> => {
+  aiDebug(`tool call → ${call.name}`, { id: call.id, input: call.input });
+  if (call.name === "search_activities") {
+    const q = (call.input?.query ?? "") as string;
+    return runSearchActivities(q, appName);
+  }
+  if (call.name === "get_activities") {
+    const ids = (call.input?.ids ?? []) as string[];
+    return runGetActivities(ids, appName);
+  }
+  aiDebug(`tool call → UNKNOWN tool: ${call.name}`);
+  return `Unknown tool: ${call.name}. Available tools: search_activities, get_activities.`;
+};
+
+const statusForCall = (call: ToolCall): string => {
+  if (call.name === "search_activities") {
+    const q = (call.input?.query ?? "") as string;
+    return q ? `Searching for "${q.slice(0, 40)}"…` : "Searching ontology…";
+  }
+  if (call.name === "get_activities") {
+    const ids = (call.input?.ids ?? []) as string[];
+    const n = Array.isArray(ids) ? ids.length : 0;
+    return n === 1
+      ? "Reading 1 activity…"
+      : `Reading ${n} activities…`;
+  }
+  return `Calling ${call.name}…`;
+};
+
+// Markdown-lite: fenced code, **#ID Title** chips, **bold**, `code`,
+// ## headings, --- rules, newlines.
 const renderInline = (
   text: string,
-  onNav: (id: string) => void,
+  onNav: (id: string, title?: string) => void,
   accent: string,
   keyPrefix: string,
 ): React.ReactNode[] => {
@@ -111,7 +319,7 @@ const renderInline = (
       <Box
         key={`${keyPrefix}-chip${i}`}
         component="span"
-        onClick={() => onNav(id)}
+        onClick={() => onNav(id, title)}
         sx={{
           display: "inline-flex",
           alignItems: "center",
@@ -148,7 +356,6 @@ const renderPlain = (
   accent: string,
   keyPrefix: string,
 ): React.ReactNode[] => {
-  // Handle **bold**, `code`, newlines.
   const out: React.ReactNode[] = [];
   const tokenRe = /\*\*([^*]+)\*\*|`([^`]+)`|\n/g;
   let last = 0;
@@ -196,12 +403,11 @@ const renderPlain = (
 
 const AssistantText: React.FC<{
   text: string;
-  onNav: (id: string) => void;
+  onNav: (id: string, title?: string) => void;
 }> = ({ text, onNav }) => {
   const theme = useTheme();
   const accent = theme.palette.primary.main;
 
-  // Split out fenced code blocks (```...```) and render them as preformatted.
   const segments = useMemo(() => {
     const re = /```(\w*)\n?([\s\S]*?)```/g;
     const parts: Array<
@@ -252,11 +458,7 @@ const AssistantText: React.FC<{
   );
 };
 
-// ──────────────────────────────────────────────────────────────
-// Main panel
-// ──────────────────────────────────────────────────────────────
-
-export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
+export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
   const theme = useTheme();
   const accent = theme.palette.primary.main;
 
@@ -265,8 +467,13 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
   const [turns, setTurns] = useState<Turn[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<string>("");
   const [editingConf, setEditingConf] = useState(false);
   const [expandedErrors, setExpandedErrors] = useState<Set<number>>(new Set());
+
+  // Full log fed to the model (incl. tool calls/results); `turns` is
+  // the visible history (user/assistant text + errors only).
+  const [msgLog, setMsgLog] = useState<ChatMsg[]>([]);
 
   const toggleErrorDetails = useCallback((idx: number) => {
     setExpandedErrors((prev) => {
@@ -286,7 +493,6 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
 
   const streamRef = useRef<HTMLDivElement | null>(null);
 
-  // Hydrate from localStorage once.
   useEffect(() => {
     const existing = loadAiConf();
     if (existing) {
@@ -297,26 +503,11 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
     setHydrated(true);
   }, []);
 
-  // Scroll to bottom on new turns or loading flip.
   useEffect(() => {
     const el = streamRef.current;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
   }, [turns, loading]);
-
-  // Directory is expensive to build for large ontologies; memoize on `nodes`.
-  const directory = useMemo(() => buildDirectory(nodes), [nodes]);
-
-  // Keep only the last 20 display turns of conversation context.
-  const historyForPrompt: ChatMsg[] = useMemo(() => {
-    const msgs: ChatMsg[] = [];
-    for (const t of turns) {
-      if (t.kind === "user") msgs.push({ role: "user", content: t.text });
-      else if (t.kind === "assistant")
-        msgs.push({ role: "assistant", content: t.text });
-    }
-    return msgs.slice(-20);
-  }, [turns]);
 
   const send = useCallback(async () => {
     const q = input.trim();
@@ -324,18 +515,110 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
     setInput("");
     setTurns((prev) => [...prev, { kind: "user", text: q }]);
     setLoading(true);
+    setStatus("Thinking…");
+
+    // Snapshot so we can revert on error (avoids a half-tool-called log).
+    const baseLog = msgLog;
+    // Rough budget: ~24 mixed user/assistant/tool messages.
+    const trimmed = baseLog.length > 24 ? baseLog.slice(-24) : baseLog;
+    const initialMessages: ChatMsg[] = [
+      { role: "system", content: SYSTEM_PROMPT },
+      ...trimmed,
+      { role: "user", content: q },
+    ];
+
+    aiDebug("send → start", {
+      query: q,
+      provider: conf.prov,
+      model: conf.model,
+      historyMsgs: trimmed.length,
+      appName,
+    });
+
+    let working: ChatMsg[] = initialMessages;
+    let finalText = "";
+
     try {
-      const sys = buildSystemPrompt(q, nodes, directory);
-      const msgs: ChatMsg[] = [
-        { role: "system", content: sys },
-        ...historyForPrompt,
-        { role: "user", content: q },
-      ];
-      const text = await callLLM(conf, msgs);
+      for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+        // Last iteration: drop tools so the model must produce a final answer.
+        const toolsForCall = i === MAX_TOOL_ITERATIONS - 1 ? undefined : TOOLS;
+        aiDebug(
+          `iter ${i} → calling LLM (${working.length} msgs, tools: ${toolsForCall ? "yes" : "no"})`,
+        );
+        const t0 = performance.now();
+        const resp = await callLLM(conf, working, toolsForCall);
+        const ms = Math.round(performance.now() - t0);
+
+        if (resp.kind === "text") {
+          aiDebug(
+            `iter ${i} → LLM returned TEXT in ${ms}ms (${resp.text.length} chars)`,
+            resp.text.slice(0, 200),
+          );
+          finalText = resp.text;
+          working = [
+            ...working,
+            { role: "assistant", content: resp.text },
+          ];
+          break;
+        }
+
+        aiDebug(
+          `iter ${i} → LLM returned ${resp.calls.length} tool call(s) in ${ms}ms`,
+          {
+            preamble: resp.text?.slice(0, 200) ?? "",
+            calls: resp.calls.map((c) => ({ name: c.name, input: c.input })),
+          },
+        );
+
+        const calls = resp.calls;
+        setStatus(
+          calls.length === 1
+            ? statusForCall(calls[0])
+            : `Running ${calls.length} tools…`,
+        );
+        working = [
+          ...working,
+          {
+            role: "assistant",
+            content: resp.text ?? "",
+            toolCalls: calls,
+          },
+        ];
+
+        const results = await Promise.all(
+          calls.map(async (c) => ({
+            id: c.id,
+            name: c.name,
+            content: await executeToolCall(c, appName),
+          })),
+        );
+        for (const r of results) {
+          working.push({
+            role: "tool",
+            content: r.content,
+            toolCallId: r.id,
+            toolName: r.name,
+          });
+        }
+        setStatus("Thinking…");
+      }
+
+      if (!finalText) {
+        throw new AiCallError(
+          "The assistant kept calling tools without answering. Try rephrasing your question.",
+        );
+      }
+
+      // System header is re-prepended on every send, so strip it here.
+      setMsgLog(working.filter((m) => m.role !== "system"));
       setTurns((prev) => [
         ...prev,
-        { kind: "assistant", text, modelLabel: modelLabel(conf) },
+        { kind: "assistant", text: finalText, modelLabel: modelLabel(conf) },
       ]);
+      aiDebug("send → done", {
+        finalChars: finalText.length,
+        totalMsgs: working.length,
+      });
     } catch (e) {
       const msg =
         e instanceof AiCallError
@@ -344,15 +627,18 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
             ? e.message
             : "Something went wrong.";
       const details = e instanceof AiCallError ? e.details : undefined;
-      const status = e instanceof AiCallError ? e.status : undefined;
+      const errStatus = e instanceof AiCallError ? e.status : undefined;
+      aiDebug("send → ERROR", { message: msg, status: errStatus, details });
       setTurns((prev) => [
         ...prev,
-        { kind: "error", text: msg, details, status },
+        { kind: "error", text: msg, details, status: errStatus },
       ]);
+      // Don't poison the log with a half-finished tool-call cycle.
     } finally {
       setLoading(false);
+      setStatus("");
     }
-  }, [input, conf, loading, nodes, directory, historyForPrompt]);
+  }, [input, conf, loading, msgLog, appName]);
 
   const handleProvChange = (prov: AiProviderId) => {
     setFormProv(prov);
@@ -394,11 +680,11 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
     setConf(null);
     setFormKey("");
     setTurns([]);
+    setMsgLog([]);
     setEditingConf(false);
   };
 
-  // Until we've loaded from localStorage, show a spinner to avoid flashing
-  // the empty state for users who already have a key configured.
+  // Spinner until hydrated, to avoid flashing the empty state.
   if (!hydrated) {
     return (
       <Box
@@ -416,10 +702,6 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
 
   const showForm = !conf || editingConf;
 
-  // ──────────────────────────────────────────────────────────
-  // Empty / configure state
-  // ──────────────────────────────────────────────────────────
-
   if (showForm) {
     return (
       <Box
@@ -436,7 +718,6 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
           },
         }}
       >
-        {/* Hero — minimal text block, matches the search empty-state voice */}
         <Box
           sx={{
             display: "flex",
@@ -478,7 +759,6 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
           </Typography>
         </Box>
 
-        {/* Form — stacked fields, no card chrome */}
         <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
           <Box sx={{ display: "flex", flexDirection: "column", gap: 0.55 }}>
             <Typography sx={fieldLabelSx}>Provider</Typography>
@@ -642,10 +922,6 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
     );
   }
 
-  // ──────────────────────────────────────────────────────────
-  // Chat state
-  // ──────────────────────────────────────────────────────────
-
   return (
     <Box
       sx={{
@@ -656,7 +932,6 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
         position: "relative",
       }}
     >
-      {/* Floating gear — opens the API settings form */}
       {/* <IconButton
         onClick={() => setEditingConf(true)}
         aria-label="API settings"
@@ -685,7 +960,6 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
         <GearIcon sx={{ fontSize: 15 }} />
       </IconButton> */}
 
-      {/* Conversation stream */}
       <Box
         ref={streamRef}
         sx={{
@@ -695,8 +969,7 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
           px: 1.5,
           pt: 1.5,
           pb: 2,
-          // Soft fade at the bottom so scrolled messages dissolve into the
-          // composer area instead of getting hard-cut at the edge.
+          // Soft fade so scrolled messages dissolve into the composer.
           maskImage:
             "linear-gradient(to bottom, #000 calc(100% - 24px), transparent)",
           WebkitMaskImage:
@@ -913,15 +1186,29 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
                 bgcolor: (tt) => alpha(tt.palette.text.primary, 0.04),
                 border: (tt) =>
                   `1px solid ${alpha(tt.palette.text.primary, 0.05)}`,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 1,
               }}
             >
               <TypingDots color={alpha(theme.palette.text.primary, 0.45)} />
+              {status && (
+                <Typography
+                  sx={{
+                    fontSize: "0.75rem",
+                    fontFamily: INTER,
+                    color: "text.secondary",
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {status}
+                </Typography>
+              )}
             </Box>
           )}
         </Box>
       </Box>
 
-      {/* Composer — pinned to the bottom, sits just above the footer */}
       <Box sx={{ px: 1.5, pt: 1, pb: 1 }}>
         <Box
           sx={{
@@ -1018,7 +1305,6 @@ export const AiPanel: React.FC<Props> = ({ nodes, navigateToNode }) => {
         </Box>
       </Box>
 
-      {/* Persistent footer: model info + change-key link */}
       <Box
         sx={{
           borderTop: (t) => `1px solid ${alpha(t.palette.text.primary, 0.06)}`,

--- a/src/pages/landing/_components/AiPanel.tsx
+++ b/src/pages/landing/_components/AiPanel.tsx
@@ -97,16 +97,6 @@ type Props = {
   navigateToNode: (id: string, title?: string) => void;
 };
 
-// Verbose tool-loop logging gated on window.__AI_DEBUG (default on).
-// Silence with: window.__AI_DEBUG = false in the browser console.
-const aiDebug = (...args: unknown[]) => {
-  if (typeof window === "undefined") return;
-  const w = window as unknown as { __AI_DEBUG?: boolean };
-  if (w.__AI_DEBUG === false) return;
-  // eslint-disable-next-line no-console
-  console.log("AI Process", ...args);
-};
-
 type SearchChromaResult = {
   id: string;
   title?: string;
@@ -118,42 +108,29 @@ const runSearchActivities = async (
   appName: string,
 ): Promise<string> => {
   const trimmed = (query ?? "").trim();
-  aiDebug("search_activities → input", { query, trimmed, appName });
   if (!trimmed) {
-    aiDebug("search_activities → empty query, returning no-match");
     return formatSearchResults(query ?? "", []);
   }
   try {
-    const reqBody = {
-      query: trimmed,
-      appName,
-      nodeType: "activity",
-      resultsNum: MAX_SEARCH_RESULTS,
-      skillsFuture: false,
-    };
-    aiDebug("search_activities → POST /api/searchChroma body:", reqBody);
-    const t0 = performance.now();
     const resp = await Post<{ results?: SearchChromaResult[] }>(
       "/searchChroma",
-      reqBody,
-    );
-    const ms = Math.round(performance.now() - t0);
-    aiDebug(
-      `search_activities → response in ${ms}ms; ${resp?.results?.length ?? 0} result(s)`,
-      resp,
+      {
+        query: trimmed,
+        appName,
+        nodeType: "activity",
+        resultsNum: MAX_SEARCH_RESULTS,
+        skillsFuture: false,
+      },
     );
     const hits: SearchHit[] = (resp?.results ?? []).map((r) => ({
       id: r.id,
       title: r.title ?? r.id,
       description: r.description,
     }));
-    const formatted = formatSearchResults(trimmed, hits);
-    aiDebug("search_activities → formatted result fed to LLM:", formatted);
-    return formatted;
+    return formatSearchResults(trimmed, hits);
   } catch (e) {
     const msg =
       e instanceof Error ? e.message : "Search failed for an unknown reason.";
-    aiDebug("search_activities → ERROR", { message: msg, error: e });
     return `Search error: ${msg}. Try a different query or proceed without search.`;
   }
 };
@@ -172,11 +149,6 @@ const fetchNodesByIds = async (
   for (let i = 0; i < ids.length; i += FIRESTORE_IN_LIMIT) {
     chunks.push(ids.slice(i, i + FIRESTORE_IN_LIMIT));
   }
-  aiDebug(
-    `fetchNodesByIds → ${ids.length} id(s) in ${chunks.length} chunk(s)`,
-    ids,
-  );
-  const t0 = performance.now();
   const snapshots = await Promise.all(
     chunks.map((chunk) =>
       getDocs(
@@ -193,14 +165,6 @@ const fetchNodesByIds = async (
       out.set(doc.id, data);
     });
   }
-  const ms = Math.round(performance.now() - t0);
-  aiDebug(
-    `fetchNodesByIds → got ${out.size}/${ids.length} doc(s) in ${ms}ms`,
-  );
-  if (out.size < ids.length) {
-    const missing = ids.filter((id) => !out.has(id));
-    aiDebug("fetchNodesByIds → missing ids:", missing);
-  }
   return out;
 };
 
@@ -212,7 +176,6 @@ const runGetActivities = async (
   cache: Map<string, string>,
   currentLog: ChatMsg[],
 ): Promise<string> => {
-  aiDebug("get_activities → input", { ids, appName });
   const cleaned = Array.from(
     new Set(
       (Array.isArray(ids) ? ids : [])
@@ -221,46 +184,27 @@ const runGetActivities = async (
     ),
   ).slice(0, MAX_GET_ACTIVITIES_BATCH);
 
-  if (cleaned.length === 0) {
-    aiDebug("get_activities → no valid ids after cleanup");
-    return "No ids provided.";
-  }
-  if (cleaned.length !== (ids?.length ?? 0)) {
-    aiDebug(
-      `get_activities → cleaned ids: ${ids?.length ?? 0} → ${cleaned.length}`,
-      cleaned,
-    );
-  }
+  if (cleaned.length === 0) return "No ids provided.";
 
   const missing = cleaned.filter((id) => !cache.has(id));
   if (missing.length > 0) {
     try {
       const fetched = await fetchNodesByIds(missing);
-      let scopeFiltered = 0;
       for (const id of missing) {
         const node = fetched.get(id) ?? null;
         // Scope guard: hide nodes from other apps so cross-app data
         // can't leak through tool calls.
         if (node && (node as { appName?: string }).appName !== appName) {
-          scopeFiltered++;
           cache.set(id, notFoundProfile(id));
           continue;
         }
         cache.set(id, node ? formatActivityProfile(id, node) : notFoundProfile(id));
       }
-      if (scopeFiltered > 0) {
-        aiDebug(
-          `get_activities → ${scopeFiltered} node(s) hidden by appName scope guard`,
-        );
-      }
     } catch (e) {
       const msg =
         e instanceof Error ? e.message : "Fetch failed for an unknown reason.";
-      aiDebug("get_activities → ERROR", { message: msg, error: e });
       return `get_activities error: ${msg}.`;
     }
-  } else {
-    aiDebug("get_activities → all ids served from cache, no Firestore read");
   }
 
   // Detect ids whose full profile still sits in the current message log;
@@ -269,23 +213,14 @@ const runGetActivities = async (
     const tag = `=== #${id} `;
     return currentLog.some((m) => m.role === "tool" && m.content.includes(tag));
   };
-  let pointerCount = 0;
   const parts = cleaned.map((id) => {
     if (stillInLog(id)) {
-      pointerCount++;
       return `=== #${id} ===\n(Already provided in an earlier tool result above; reuse that profile.)\n`;
     }
     return cache.get(id) ?? notFoundProfile(id);
   });
-  if (pointerCount > 0) {
-    aiDebug(
-      `get_activities → ${pointerCount} id(s) deduplicated against existing log`,
-    );
-  }
 
-  const formatted = parts.join("\n");
-  aiDebug("get_activities → formatted result fed to LLM:", formatted);
-  return formatted;
+  return parts.join("\n");
 };
 
 const executeToolCall = async (
@@ -294,7 +229,6 @@ const executeToolCall = async (
   cache: Map<string, string>,
   currentLog: ChatMsg[],
 ): Promise<string> => {
-  aiDebug(`tool call → ${call.name}`, { id: call.id, input: call.input });
   if (call.name === "search_activities") {
     const q = (call.input?.query ?? "") as string;
     return runSearchActivities(q, appName);
@@ -303,7 +237,6 @@ const executeToolCall = async (
     const ids = (call.input?.ids ?? []) as string[];
     return runGetActivities(ids, appName, cache, currentLog);
   }
-  aiDebug(`tool call → UNKNOWN tool: ${call.name}`);
   return `Unknown tool: ${call.name}. Available tools: search_activities, get_activities.`;
 };
 
@@ -565,14 +498,6 @@ export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
       { role: "user", content: q },
     ];
 
-    aiDebug("send → start", {
-      query: q,
-      provider: conf.prov,
-      model: conf.model,
-      historyMsgs: trimmed.length,
-      appName,
-    });
-
     let working: ChatMsg[] = initialMessages;
     let finalText = "";
 
@@ -580,18 +505,9 @@ export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
       for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
         // Last iteration: drop tools so the model must produce a final answer.
         const toolsForCall = i === MAX_TOOL_ITERATIONS - 1 ? undefined : TOOLS;
-        aiDebug(
-          `iter ${i} → calling LLM (${working.length} msgs, tools: ${toolsForCall ? "yes" : "no"})`,
-        );
-        const t0 = performance.now();
         const resp = await callLLM(conf, working, toolsForCall);
-        const ms = Math.round(performance.now() - t0);
 
         if (resp.kind === "text") {
-          aiDebug(
-            `iter ${i} → LLM returned TEXT in ${ms}ms (${resp.text.length} chars)`,
-            resp.text.slice(0, 200),
-          );
           finalText = resp.text;
           working = [
             ...working,
@@ -599,14 +515,6 @@ export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
           ];
           break;
         }
-
-        aiDebug(
-          `iter ${i} → LLM returned ${resp.calls.length} tool call(s) in ${ms}ms`,
-          {
-            preamble: resp.text?.slice(0, 200) ?? "",
-            calls: resp.calls.map((c) => ({ name: c.name, input: c.input })),
-          },
-        );
 
         const calls = resp.calls;
         setStatus(
@@ -659,10 +567,6 @@ export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
         ...prev,
         { kind: "assistant", text: finalText, modelLabel: modelLabel(conf) },
       ]);
-      aiDebug("send → done", {
-        finalChars: finalText.length,
-        totalMsgs: working.length,
-      });
     } catch (e) {
       const msg =
         e instanceof AiCallError
@@ -672,7 +576,6 @@ export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
             : "Something went wrong.";
       const details = e instanceof AiCallError ? e.details : undefined;
       const errStatus = e instanceof AiCallError ? e.status : undefined;
-      aiDebug("send → ERROR", { message: msg, status: errStatus, details });
       setTurns((prev) => [
         ...prev,
         { kind: "error", text: msg, details, status: errStatus },

--- a/src/pages/landing/_components/AiPanel.tsx
+++ b/src/pages/landing/_components/AiPanel.tsx
@@ -1258,12 +1258,12 @@ export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
         <Box
           sx={{
             display: "flex",
-            alignItems: "center",
+            alignItems: "flex-end",
             gap: 0.75,
             p: 0.5,
             pl: 2,
-            pr: 1,
-            borderRadius: 999,
+            pr: 0.5,
+            borderRadius: "22px",
             bgcolor: (t) =>
               t.palette.mode === "dark"
                 ? alpha(t.palette.background.paper, 0.85)
@@ -1285,7 +1285,7 @@ export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
             variant="standard"
             fullWidth
             multiline
-            maxRows={4}
+            maxRows={5}
             placeholder="Ask about the ontology…"
             value={input}
             onChange={(e) => setInput(e.target.value)}
@@ -1300,11 +1300,29 @@ export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
               input: { disableUnderline: true },
             }}
             sx={{
+              alignSelf: "stretch",
+              "& .MuiInputBase-root": {
+                py: 0.7,
+                pr: 0.5,
+              },
               "& .MuiInputBase-input": {
                 fontFamily: INTER,
                 fontSize: "0.88rem",
                 lineHeight: 1.45,
-                py: 0.7,
+                py: 0,
+                // Thin, subtle scrollbar that matches the message stream above.
+                scrollbarWidth: "thin",
+                scrollbarColor: (t) =>
+                  `${alpha(t.palette.text.primary, 0.18)} transparent`,
+                "&::-webkit-scrollbar": { width: 6 },
+                "&::-webkit-scrollbar-track": { background: "transparent" },
+                "&::-webkit-scrollbar-thumb": {
+                  background: (t) => alpha(t.palette.text.primary, 0.16),
+                  borderRadius: 3,
+                },
+                "&::-webkit-scrollbar-thumb:hover": {
+                  background: (t) => alpha(t.palette.text.primary, 0.28),
+                },
               },
               "& .MuiInputBase-input::placeholder": { opacity: 0.55 },
             }}
@@ -1315,6 +1333,8 @@ export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
             disableRipple
             sx={{
               flexShrink: 0,
+              alignSelf: "flex-end",
+              mb: 0.25,
               width: 30,
               height: 30,
               color: accent,

--- a/src/pages/landing/_components/AiPanel.tsx
+++ b/src/pages/landing/_components/AiPanel.tsx
@@ -52,7 +52,7 @@ import {
   MAX_TOOL_ITERATIONS,
   SYSTEM_PROMPT,
   TOOLS,
-  formatActivityProfiles,
+  formatActivityProfile,
   formatSearchResults,
   type SearchHit,
 } from "./aiContext";
@@ -204,9 +204,13 @@ const fetchNodesByIds = async (
   return out;
 };
 
+const notFoundProfile = (id: string) => `=== #${id} ===\n(Not found.)\n`;
+
 const runGetActivities = async (
   ids: string[],
   appName: string,
+  cache: Map<string, string>,
+  currentLog: ChatMsg[],
 ): Promise<string> => {
   aiDebug("get_activities → input", { ids, appName });
   const cleaned = Array.from(
@@ -228,38 +232,67 @@ const runGetActivities = async (
     );
   }
 
-  try {
-    const fetched = await fetchNodesByIds(cleaned);
-    let scopeFiltered = 0;
-    const profiles = cleaned.map((id) => {
-      const node = fetched.get(id) ?? null;
-      // Scope guard: if the node belongs to a different appName, hide it
-      // from the model so cross-app data can't leak through tool calls.
-      if (node && (node as { appName?: string }).appName !== appName) {
-        scopeFiltered++;
-        return { id, node: null };
+  const missing = cleaned.filter((id) => !cache.has(id));
+  if (missing.length > 0) {
+    try {
+      const fetched = await fetchNodesByIds(missing);
+      let scopeFiltered = 0;
+      for (const id of missing) {
+        const node = fetched.get(id) ?? null;
+        // Scope guard: hide nodes from other apps so cross-app data
+        // can't leak through tool calls.
+        if (node && (node as { appName?: string }).appName !== appName) {
+          scopeFiltered++;
+          cache.set(id, notFoundProfile(id));
+          continue;
+        }
+        cache.set(id, node ? formatActivityProfile(id, node) : notFoundProfile(id));
       }
-      return { id, node };
-    });
-    if (scopeFiltered > 0) {
-      aiDebug(
-        `get_activities → ${scopeFiltered} node(s) hidden by appName scope guard`,
-      );
+      if (scopeFiltered > 0) {
+        aiDebug(
+          `get_activities → ${scopeFiltered} node(s) hidden by appName scope guard`,
+        );
+      }
+    } catch (e) {
+      const msg =
+        e instanceof Error ? e.message : "Fetch failed for an unknown reason.";
+      aiDebug("get_activities → ERROR", { message: msg, error: e });
+      return `get_activities error: ${msg}.`;
     }
-    const formatted = formatActivityProfiles(profiles);
-    aiDebug("get_activities → formatted result fed to LLM:", formatted);
-    return formatted;
-  } catch (e) {
-    const msg =
-      e instanceof Error ? e.message : "Fetch failed for an unknown reason.";
-    aiDebug("get_activities → ERROR", { message: msg, error: e });
-    return `get_activities error: ${msg}.`;
+  } else {
+    aiDebug("get_activities → all ids served from cache, no Firestore read");
   }
+
+  // Detect ids whose full profile still sits in the current message log;
+  // emit a pointer instead of duplicating the blob in the prompt.
+  const stillInLog = (id: string) => {
+    const tag = `=== #${id} `;
+    return currentLog.some((m) => m.role === "tool" && m.content.includes(tag));
+  };
+  let pointerCount = 0;
+  const parts = cleaned.map((id) => {
+    if (stillInLog(id)) {
+      pointerCount++;
+      return `=== #${id} ===\n(Already provided in an earlier tool result above; reuse that profile.)\n`;
+    }
+    return cache.get(id) ?? notFoundProfile(id);
+  });
+  if (pointerCount > 0) {
+    aiDebug(
+      `get_activities → ${pointerCount} id(s) deduplicated against existing log`,
+    );
+  }
+
+  const formatted = parts.join("\n");
+  aiDebug("get_activities → formatted result fed to LLM:", formatted);
+  return formatted;
 };
 
 const executeToolCall = async (
   call: ToolCall,
   appName: string,
+  cache: Map<string, string>,
+  currentLog: ChatMsg[],
 ): Promise<string> => {
   aiDebug(`tool call → ${call.name}`, { id: call.id, input: call.input });
   if (call.name === "search_activities") {
@@ -268,7 +301,7 @@ const executeToolCall = async (
   }
   if (call.name === "get_activities") {
     const ids = (call.input?.ids ?? []) as string[];
-    return runGetActivities(ids, appName);
+    return runGetActivities(ids, appName, cache, currentLog);
   }
   aiDebug(`tool call → UNKNOWN tool: ${call.name}`);
   return `Unknown tool: ${call.name}. Available tools: search_activities, get_activities.`;
@@ -493,6 +526,11 @@ export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
 
   const streamRef = useRef<HTMLDivElement | null>(null);
 
+  // Session cache of formatted profile strings keyed by activity id.
+  // Survives turn-to-turn so a re-fetch of the same id skips Firestore;
+  // when paired with stillInLog(), also skips re-emitting the blob.
+  const profileCacheRef = useRef<Map<string, string>>(new Map());
+
   useEffect(() => {
     const existing = loadAiConf();
     if (existing) {
@@ -585,11 +623,17 @@ export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
           },
         ];
 
+        const logForDedup = working;
         const results = await Promise.all(
           calls.map(async (c) => ({
             id: c.id,
             name: c.name,
-            content: await executeToolCall(c, appName),
+            content: await executeToolCall(
+              c,
+              appName,
+              profileCacheRef.current,
+              logForDedup,
+            ),
           })),
         );
         for (const r of results) {
@@ -681,6 +725,7 @@ export const AiPanel: React.FC<Props> = ({ appName, navigateToNode }) => {
     setFormKey("");
     setTurns([]);
     setMsgLog([]);
+    profileCacheRef.current.clear();
     setEditingConf(false);
   };
 

--- a/src/pages/landing/_components/aiContext.ts
+++ b/src/pages/landing/_components/aiContext.ts
@@ -1,31 +1,118 @@
-// ──────────────────────────────────────────────────────────────
-// Navigate AI — ontology context builders
-// Ports the Process-Handbook pipeline (directory + detected-entity
-// profiles + keyword fallback) onto the `INode` shape used by Firestore.
-// ──────────────────────────────────────────────────────────────
+// System prompt + provider-neutral tool defs for the chat loop.
+// Prompt is static so caching hits across turns; tool schemas are
+// translated per provider in aiProviders.ts.
 
 import type { ICollection, INode } from "../../../types/INode";
 
-const flattenIds = (cols: ICollection[] | undefined): string[] => {
-  if (!Array.isArray(cols)) return [];
-  const ids: string[] = [];
-  for (const c of cols) {
-    for (const n of c?.nodes ?? []) {
-      if (n?.id) ids.push(n.id);
-    }
-  }
-  return ids;
+export type ToolDef = {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<
+      string,
+      {
+        type: "string" | "array" | "number" | "boolean";
+        description: string;
+        items?: { type: "string" };
+      }
+    >;
+    required: string[];
+  };
 };
 
-const resolveTitle = (
-  id: string,
-  nodes: { [id: string]: INode },
-): string => nodes[id]?.title?.trim() || id;
+export const TOOLS: ToolDef[] = [
+  {
+    name: "search_activities",
+    description:
+      "Semantic search across the ontology. Use this to find activities by concept, theme, or partial name. Returns up to 10 ranked candidates with id, title, and a short description. Use first when the user mentions an activity by name or describes one in their own words.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description:
+            "Free-text query. Can be a noun phrase ('transport'), a description ('moving things from place to place'), or a question fragment.",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "get_activities",
+    description:
+      "Fetch full profiles for one or more activities by id. Returns each activity's title, description, and all relations (generalizations, specializations, parts, isPartOf) with both ids and titles. Call this after search_activities to deep-dive on the most relevant matches, or to expand neighbours when answering structural questions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ids: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Activity ids to fetch. Cap of 20 per call. Pass multiple ids to batch — much more efficient than one call per id.",
+        },
+      },
+      required: ["ids"],
+    },
+  },
+];
 
-const resolveNames = (
-  ids: string[],
-  nodes: { [id: string]: INode },
-): string => ids.map((id) => resolveTitle(id, nodes)).join(", ");
+// Hard caps — enforced client-side regardless of what the model passes.
+export const MAX_TOOL_ITERATIONS = 8;
+export const MAX_GET_ACTIVITIES_BATCH = 20;
+export const MAX_SEARCH_RESULTS = 10;
+
+export const SYSTEM_PROMPT = `You are an expert assistant for the MIT ontology of activities — a taxonomy where each activity has four kinds of relations: generalizations (broader concepts), specializations (narrower kinds), parts (sub-activities), and isPartOf (larger activities it belongs to).
+
+You do not see the full ontology up front. Use the tools below to navigate it.
+
+TOOLS:
+- search_activities(query) — semantic search; returns up to 10 candidates with id, title, and a short description. Call first when the user mentions or describes an activity.
+- get_activities(ids) — fetch full profiles in batch (cap 20 ids per call). Returns title, description, and all relations with ids + titles.
+
+INSTRUCTIONS:
+- Answer the user's question using only data returned by the tools.
+- For structural questions (parts, specializations, relationships), fetch the relevant profiles via get_activities — they contain the ground truth.
+- Reference entries as **#ID Title** so the UI can make them clickable. Use the exact id from get_activities — never make one up.
+- Be precise with counts and names. Never invent entries or relationships not present in tool results.
+- You can use markdown: **bold**, \`code\`, ## headers, --- rules, and fenced code blocks.
+- If the tools do not return enough to answer confidently, say so.
+- Be concise but thorough.`;
+
+// Compact string formatters — every byte goes into the prompt.
+
+export type SearchHit = {
+  id: string;
+  title: string;
+  description?: string;
+};
+
+export const formatSearchResults = (
+  query: string,
+  hits: SearchHit[],
+): string => {
+  if (hits.length === 0) {
+    return `No matches for "${query}". Try a broader term, a paraphrase, or a related concept.`;
+  }
+  const lines = hits.slice(0, MAX_SEARCH_RESULTS).map((h) => {
+    const desc = (h.description ?? "").trim().replace(/\s+/g, " ").slice(0, 140);
+    return desc ? `#${h.id} ${h.title} — ${desc}` : `#${h.id} ${h.title}`;
+  });
+  return `${hits.length} match${hits.length === 1 ? "" : "es"} for "${query}":\n${lines.join("\n")}`;
+};
+
+const flattenLinks = (
+  cols: ICollection[] | undefined,
+): Array<{ id: string; title: string }> => {
+  if (!Array.isArray(cols)) return [];
+  const out: Array<{ id: string; title: string }> = [];
+  for (const c of cols) {
+    for (const n of c?.nodes ?? []) {
+      if (n?.id) out.push({ id: n.id, title: n.title || n.id });
+    }
+  }
+  return out;
+};
 
 const getDescription = (n: INode): string => {
   const p = n.properties as Record<string, unknown> | undefined;
@@ -37,196 +124,49 @@ const getDescription = (n: INode): string => {
   return "";
 };
 
-// ──────────────────────────────────────────────────────────────
-// Directory (cheap, cacheable). One line per node: `#id Title`.
-// ──────────────────────────────────────────────────────────────
+export const formatActivityProfile = (id: string, node: INode): string => {
+  const gens = flattenLinks(node.generalizations);
+  const specs = flattenLinks(node.specializations);
+  const parts = flattenLinks(node.properties?.parts as ICollection[] | undefined);
+  const isPartOf = flattenLinks(
+    node.properties?.isPartOf as ICollection[] | undefined,
+  );
+  const desc = getDescription(node);
 
-export const buildDirectory = (nodes: { [id: string]: INode }): string => {
+  const renderLinks = (
+    label: string,
+    items: Array<{ id: string; title: string }>,
+    cap: number,
+  ): string => {
+    if (items.length === 0) return "";
+    const shown = items.slice(0, cap);
+    const tail =
+      items.length > cap ? ` …and ${items.length - cap} more` : "";
+    const list = shown.map((l) => `#${l.id} ${l.title}`).join(", ");
+    return `${label} (${items.length}): ${list}${tail}\n`;
+  };
+
+  let out = `=== #${id} ${node.title ?? id} ===\n`;
+  if (desc) out += `Description: ${desc}\n`;
+  out += renderLinks("Generalizations", gens, 30);
+  out += renderLinks("Specializations", specs, 60);
+  out += renderLinks("Parts", parts, 60);
+  out += renderLinks("IsPartOf", isPartOf, 30);
+  return out;
+};
+
+export const formatActivityProfiles = (
+  profiles: Array<{ id: string; node: INode | null }>,
+): string => {
   const lines: string[] = [];
-  for (const n of Object.values(nodes)) {
-    if (!n?.title) continue;
-    lines.push(`#${n.id} ${n.title}`);
+  for (const p of profiles) {
+    if (!p.node) {
+      lines.push(`=== #${p.id} ===\n(Not found.)\n`);
+      continue;
+    }
+    lines.push(formatActivityProfile(p.id, p.node));
   }
   return lines.join("\n");
-};
-
-// ──────────────────────────────────────────────────────────────
-// Per-node profile — gen / spec / parts / isPartOf, all resolved to titles.
-// ──────────────────────────────────────────────────────────────
-
-export const buildProfile = (
-  id: string,
-  nodes: { [id: string]: INode },
-): string => {
-  const n = nodes[id];
-  if (!n) return "";
-  const gens = flattenIds(n.generalizations);
-  const specs = flattenIds(n.specializations);
-  const parts = flattenIds(n.properties?.parts as ICollection[] | undefined);
-  const isPartOf = flattenIds(
-    n.properties?.isPartOf as ICollection[] | undefined,
-  );
-  const desc = getDescription(n);
-
-  let p = `=== #${id} ${n.title ?? id} ===\n`;
-  if (desc) p += `Description: ${desc}\n`;
-  if (gens.length)
-    p += `Generalizations (${gens.length}): ${resolveNames(gens, nodes)}\n`;
-  if (specs.length) {
-    const shown = specs.slice(0, 60);
-    p += `Specializations (${specs.length}): ${resolveNames(shown, nodes)}${
-      specs.length > 60 ? ` …and ${specs.length - 60} more` : ""
-    }\n`;
-  }
-  if (parts.length)
-    p += `Parts (${parts.length}): ${resolveNames(parts, nodes)}\n`;
-  if (isPartOf.length)
-    p += `Part Of (${isPartOf.length}): ${resolveNames(isPartOf, nodes)}\n`;
-  return p;
-};
-
-// ──────────────────────────────────────────────────────────────
-// Entity detection — heuristic scoring on the user's question.
-// Returns top-5 likely entities to profile in detail.
-// ──────────────────────────────────────────────────────────────
-
-export type DetectedEntity = { id: string; score: number };
-
-export const detectEntities = (
-  rawQuery: string,
-  nodes: { [id: string]: INode },
-): DetectedEntity[] => {
-  const ql = rawQuery.toLowerCase();
-  const found: DetectedEntity[] = [];
-
-  for (const n of Object.values(nodes)) {
-    const tl = n.title?.toLowerCase();
-    if (!tl) continue;
-    if (tl === ql) found.push({ id: n.id, score: 100 });
-    else if (ql.includes(tl) && tl.length > 2)
-      found.push({ id: n.id, score: 50 + tl.length });
-    else if (tl.includes(ql)) found.push({ id: n.id, score: 40 });
-  }
-
-  const words = ql.split(/\s+/).filter((w) => w.length >= 3);
-  for (const n of Object.values(nodes)) {
-    const tl = n.title?.toLowerCase();
-    if (!tl) continue;
-    for (const w of words) {
-      if (tl === w) {
-        found.push({ id: n.id, score: 60 });
-        break;
-      } else if (
-        tl.startsWith(w + " ") ||
-        tl.endsWith(" " + w) ||
-        tl.includes(" " + w + " ")
-      ) {
-        found.push({ id: n.id, score: 30 });
-        break;
-      }
-    }
-  }
-
-  const seen = new Set<string>();
-  return found
-    .sort((a, b) => b.score - a.score)
-    .filter((f) => {
-      if (seen.has(f.id)) return false;
-      seen.add(f.id);
-      return true;
-    })
-    .slice(0, 5);
-};
-
-// ──────────────────────────────────────────────────────────────
-// Keyword scorer — fallback context (title match + short description snippet).
-// ──────────────────────────────────────────────────────────────
-
-export type KeywordHit = { id: string; score: number; title: string; desc: string };
-
-export const scoreKeywords = (
-  rawQuery: string,
-  nodes: { [id: string]: INode },
-): KeywordHit[] => {
-  const ql = rawQuery.toLowerCase();
-  const words = ql.split(/\s+/).filter((w) => w.length > 1);
-  const hits: KeywordHit[] = [];
-  for (const n of Object.values(nodes)) {
-    const t = (n.title ?? "").toLowerCase();
-    const d = getDescription(n).toLowerCase();
-    let score = 0;
-    for (const w of words) {
-      if (t.includes(w)) score += 3;
-      if (d.includes(w)) score += 1;
-    }
-    if (score > 0) {
-      hits.push({ id: n.id, score, title: n.title ?? n.id, desc: getDescription(n) });
-    }
-  }
-  return hits.sort((a, b) => b.score - a.score);
-};
-
-// ──────────────────────────────────────────────────────────────
-// Full system prompt assembly.
-// ──────────────────────────────────────────────────────────────
-
-export const buildSystemPrompt = (
-  query: string,
-  nodes: { [id: string]: INode },
-  directoryCached: string,
-): string => {
-  const detected = detectEntities(query, nodes);
-  const profiledIds = new Set<string>();
-  let profiles = "";
-  for (const d of detected) {
-    profiles += buildProfile(d.id, nodes) + "\n";
-    profiledIds.add(d.id);
-    // Profile the first-tier neighbours too (parts, gens, top-5 specs)
-    const n = nodes[d.id];
-    if (!n) continue;
-    const neighbourIds = [
-      ...flattenIds(n.properties?.parts as ICollection[] | undefined),
-      ...flattenIds(n.generalizations),
-      ...flattenIds(n.specializations).slice(0, 5),
-    ];
-    for (const nid of neighbourIds) {
-      if (!profiledIds.has(nid) && nodes[nid]) {
-        profiles += buildProfile(nid, nodes) + "\n";
-        profiledIds.add(nid);
-      }
-    }
-  }
-
-  const kw = scoreKeywords(query, nodes)
-    .slice(0, 20)
-    .filter((h) => !profiledIds.has(h.id))
-    .map(
-      (h) =>
-        `#${h.id} ${h.title}${h.desc ? ` — ${h.desc.slice(0, 80)}` : ""}`,
-    )
-    .join("\n");
-
-  const totalCount = Object.keys(nodes).length;
-
-  return (
-    `You are an expert on the MIT ontology of activities — a taxonomy of ` +
-    `${totalCount} activities maintained on this platform.\n\n` +
-    `COMPLETE DIRECTORY OF ALL ENTRIES (id + title only):\n` +
-    directoryCached +
-    `\n\n` +
-    (profiles
-      ? `DETAILED PROFILES OF RELEVANT ENTRIES (with all relationships):\n${profiles}\n`
-      : "") +
-    (kw ? `ADDITIONAL KEYWORD MATCHES:\n${kw}\n\n` : "\n") +
-    `INSTRUCTIONS:\n` +
-    `- Answer the user's question using only the data above.\n` +
-    `- For structural questions (parts, specializations, relationships), use the DETAILED PROFILES — they contain the ground truth.\n` +
-    `- Reference entries as **#ID Title** so the UI can make them clickable.\n` +
-    `- Be precise with counts and names. Never invent entries or relationships not present above.\n` +
-    `- You can use markdown: **bold**, \`code\`, ## headers, --- rules, and fenced code blocks.\n` +
-    `- If the data does not contain enough to answer confidently, say so.\n` +
-    `- Be concise but thorough.`
-  );
 };
 
 export default function AiContextPage() {

--- a/src/pages/landing/_components/aiProviders.ts
+++ b/src/pages/landing/_components/aiProviders.ts
@@ -1,13 +1,28 @@
-// ──────────────────────────────────────────────────────────────
-// Navigate AI — provider adapters, BYO-key, client-side only
-// ──────────────────────────────────────────────────────────────
+// Provider adapters for the BYO-key chat loop. Each provider's
+// request/response shape is translated in `build` and `parse`.
+
+import type { ToolDef } from "./aiContext";
 
 export type AiProviderId = "openrouter" | "anthropic" | "openai" | "google";
 
-export type ChatMsg = {
-  role: "system" | "user" | "assistant";
-  content: string;
+export type ToolCall = {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
 };
+
+export type ChatMsg = {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+  // assistant tool-call turns; content may be empty
+  toolCalls?: ToolCall[];
+  toolCallId?: string;
+  toolName?: string;
+};
+
+export type LLMResponse =
+  | { kind: "text"; text: string }
+  | { kind: "tool_calls"; text: string; calls: ToolCall[] };
 
 export type ProviderModel = {
   id: string;
@@ -24,8 +39,13 @@ type BuiltRequest = {
 export type ProviderConfig = {
   name: string;
   models: ProviderModel[];
-  build: (model: string, key: string, msgs: ChatMsg[]) => BuiltRequest;
-  parse?: (raw: unknown) => string;
+  build: (
+    model: string,
+    key: string,
+    msgs: ChatMsg[],
+    tools?: ToolDef[],
+  ) => BuiltRequest;
+  parse: (raw: unknown) => LLMResponse;
 };
 
 export type AiConf = {
@@ -34,8 +54,170 @@ export type AiConf = {
   key: string;
 };
 
-// Model IDs per provider. Conservative, real IDs; users can update if the
-// provider releases newer ones. Default item per provider is marked.
+// GPT-5 and the o1/o3 reasoning family rejected `max_tokens` and want
+// `max_completion_tokens` instead. Detect by model id (handles bare
+// names and OpenRouter's `openai/...` prefix).
+const openaiTokenField = (model: string): "max_tokens" | "max_completion_tokens" =>
+  /(^|\/)(gpt-5|o[13])/i.test(model) ? "max_completion_tokens" : "max_tokens";
+
+const toolsToOpenAI = (tools: ToolDef[]) =>
+  tools.map((t) => ({
+    type: "function" as const,
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.inputSchema,
+    },
+  }));
+
+const toolsToAnthropic = (tools: ToolDef[]) =>
+  tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    input_schema: t.inputSchema,
+  }));
+
+const toolsToGemini = (tools: ToolDef[]) => [
+  {
+    functionDeclarations: tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      parameters: {
+        // Gemini wants UPPERCASE type names
+        type: "OBJECT",
+        properties: Object.fromEntries(
+          Object.entries(t.inputSchema.properties).map(([k, v]) => [
+            k,
+            v.type === "array"
+              ? {
+                  type: "ARRAY",
+                  description: v.description,
+                  items: { type: "STRING" },
+                }
+              : { type: v.type.toUpperCase(), description: v.description },
+          ]),
+        ),
+        required: t.inputSchema.required,
+      },
+    })),
+  },
+];
+
+// OpenAI / OpenRouter share the same wire format.
+const msgsToOpenAI = (msgs: ChatMsg[]): unknown[] =>
+  msgs.map((m) => {
+    if (m.role === "tool") {
+      return {
+        role: "tool",
+        tool_call_id: m.toolCallId,
+        content: m.content,
+      };
+    }
+    if (m.role === "assistant" && m.toolCalls?.length) {
+      return {
+        role: "assistant",
+        content: m.content || null,
+        tool_calls: m.toolCalls.map((c) => ({
+          id: c.id,
+          type: "function",
+          function: {
+            name: c.name,
+            arguments: JSON.stringify(c.input),
+          },
+        })),
+      };
+    }
+    return { role: m.role, content: m.content };
+  });
+
+const msgsToAnthropic = (msgs: ChatMsg[]) => {
+  const out: Array<{ role: "user" | "assistant"; content: unknown }> = [];
+  for (const m of msgs) {
+    if (m.role === "system") continue; // Anthropic handles system separately.
+    if (m.role === "tool") {
+      out.push({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: m.toolCallId,
+            content: m.content,
+          },
+        ],
+      });
+      continue;
+    }
+    if (m.role === "assistant" && m.toolCalls?.length) {
+      const blocks: unknown[] = [];
+      if (m.content) blocks.push({ type: "text", text: m.content });
+      for (const c of m.toolCalls) {
+        blocks.push({
+          type: "tool_use",
+          id: c.id,
+          name: c.name,
+          input: c.input,
+        });
+      }
+      out.push({ role: "assistant", content: blocks });
+      continue;
+    }
+    out.push({ role: m.role, content: m.content });
+  }
+  return out;
+};
+
+const msgsToGemini = (msgs: ChatMsg[]) => {
+  // Gemini has no system role; merge system into the first user turn.
+  const sys = msgs.find((m) => m.role === "system")?.content ?? "";
+  const rest = msgs.filter((m) => m.role !== "system");
+
+  const parts = rest.map((m) => {
+    if (m.role === "tool") {
+      let parsed: unknown = m.content;
+      try {
+        parsed = JSON.parse(m.content);
+      } catch {
+        /* keep as string */
+      }
+      return {
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              name: m.toolName ?? "",
+              response:
+                typeof parsed === "object" && parsed !== null
+                  ? (parsed as Record<string, unknown>)
+                  : { content: m.content },
+            },
+          },
+        ],
+      };
+    }
+    if (m.role === "assistant" && m.toolCalls?.length) {
+      const blocks: unknown[] = [];
+      if (m.content) blocks.push({ text: m.content });
+      for (const c of m.toolCalls) {
+        blocks.push({ functionCall: { name: c.name, args: c.input } });
+      }
+      return { role: "model", parts: blocks };
+    }
+    return {
+      role: m.role === "assistant" ? "model" : "user",
+      parts: [{ text: m.content }],
+    };
+  });
+
+  if (sys && parts.length > 0 && parts[0].role === "user") {
+    const first = parts[0].parts[0] as { text?: string };
+    if (typeof first.text === "string") {
+      first.text = sys + "\n\n" + first.text;
+    }
+  }
+
+  return parts;
+};
+
 export const AI_PROVIDERS: Record<AiProviderId, ProviderConfig> = {
   openrouter: {
     name: "OpenRouter",
@@ -60,16 +242,26 @@ export const AI_PROVIDERS: Record<AiProviderId, ProviderConfig> = {
       { id: "google/gemini-3.1-flash", name: "Gemini 3.1 Flash" },
       { id: "google/gemini-2.0-flash", name: "Gemini 2.0 Flash" },
     ],
-    build(model, key, msgs) {
+    build(model, key, msgs, tools) {
+      const body: Record<string, unknown> = {
+        model,
+        messages: msgsToOpenAI(msgs),
+        [openaiTokenField(model)]: 4096,
+      };
+      if (tools?.length) {
+        body.tools = toolsToOpenAI(tools);
+        body.tool_choice = "auto";
+      }
       return {
         url: "https://openrouter.ai/api/v1/chat/completions",
         headers: {
           Authorization: `Bearer ${key}`,
           "Content-Type": "application/json",
         },
-        body: { model, messages: msgs, max_tokens: 4096 },
+        body,
       };
     },
+    parse: parseOpenAIResponse,
   },
 
   anthropic: {
@@ -93,13 +285,26 @@ export const AI_PROVIDERS: Record<AiProviderId, ProviderConfig> = {
         name: "Claude Haiku 4.5 (fast/cheap)",
       },
     ],
-    build(model, key, msgs) {
+    build(model, key, msgs, tools) {
       const sys = msgs.find((m) => m.role === "system")?.content ?? "";
-      const rest = msgs
-        .filter((m) => m.role !== "system")
-        .map((m) => ({ role: m.role, content: m.content }));
-      // cache_control on the system block lets Anthropic cache the ~20K-token
-      // ontology directory across turns (big cost win).
+      const body: Record<string, unknown> = {
+        model,
+        max_tokens: 4096,
+        // cache the static system prompt across turns
+        system: sys
+          ? [
+              {
+                type: "text",
+                text: sys,
+                cache_control: { type: "ephemeral" },
+              },
+            ]
+          : undefined,
+        messages: msgsToAnthropic(msgs),
+      };
+      if (tools?.length) {
+        body.tools = toolsToAnthropic(tools);
+      }
       return {
         url: "https://api.anthropic.com/v1/messages",
         headers: {
@@ -108,26 +313,10 @@ export const AI_PROVIDERS: Record<AiProviderId, ProviderConfig> = {
           "anthropic-dangerous-direct-browser-access": "true",
           "Content-Type": "application/json",
         },
-        body: {
-          model,
-          max_tokens: 4096,
-          system: sys
-            ? [
-                {
-                  type: "text",
-                  text: sys,
-                  cache_control: { type: "ephemeral" },
-                },
-              ]
-            : undefined,
-          messages: rest,
-        },
+        body,
       };
     },
-    parse(raw) {
-      const r = raw as { content?: Array<{ text?: string }> };
-      return r.content?.[0]?.text ?? JSON.stringify(raw);
-    },
+    parse: parseAnthropicResponse,
   },
 
   openai: {
@@ -139,16 +328,26 @@ export const AI_PROVIDERS: Record<AiProviderId, ProviderConfig> = {
       { id: "gpt-5.4-mini", name: "GPT-5.4 mini (cheap)" },
       { id: "gpt-5.4-nano", name: "GPT-5.4 nano (cheapest)" },
     ],
-    build(model, key, msgs) {
+    build(model, key, msgs, tools) {
+      const body: Record<string, unknown> = {
+        model,
+        messages: msgsToOpenAI(msgs),
+        [openaiTokenField(model)]: 4096,
+      };
+      if (tools?.length) {
+        body.tools = toolsToOpenAI(tools);
+        body.tool_choice = "auto";
+      }
       return {
         url: "https://api.openai.com/v1/chat/completions",
         headers: {
           Authorization: `Bearer ${key}`,
           "Content-Type": "application/json",
         },
-        body: { model, messages: msgs, max_tokens: 4096 },
+        body,
       };
     },
+    parse: parseOpenAIResponse,
   },
 
   google: {
@@ -168,20 +367,13 @@ export const AI_PROVIDERS: Record<AiProviderId, ProviderConfig> = {
       { id: "gemini-3.1-flash", name: "Gemini 3.1 Flash" },
       { id: "gemini-3.1-flash-lite", name: "Gemini 3.1 Flash Lite (cheapest)" },
     ],
-    build(model, key, msgs) {
-      // Gemini has no system role; merge the system block into the first
-      // user turn so the model still sees it.
-      const parts = msgs.map((m) => ({
-        role: m.role === "assistant" ? "model" : "user",
-        parts: [{ text: m.content }],
-      }));
-      if (msgs[0]?.role === "system") {
-        if (parts.length > 1) {
-          parts[1].parts[0].text = msgs[0].content + "\n\n" + parts[1].parts[0].text;
-          parts.shift();
-        } else {
-          parts[0].role = "user";
-        }
+    build(model, key, msgs, tools) {
+      const body: Record<string, unknown> = {
+        contents: msgsToGemini(msgs),
+        generationConfig: { maxOutputTokens: 4096 },
+      };
+      if (tools?.length) {
+        body.tools = toolsToGemini(tools);
       }
       return {
         url:
@@ -190,22 +382,195 @@ export const AI_PROVIDERS: Record<AiProviderId, ProviderConfig> = {
           ":generateContent?key=" +
           encodeURIComponent(key),
         headers: { "Content-Type": "application/json" },
-        body: {
-          contents: parts,
-          generationConfig: { maxOutputTokens: 4096 },
-        },
+        body,
       };
     },
-    parse(raw) {
-      const r = raw as {
-        candidates?: Array<{
-          content?: { parts?: Array<{ text?: string }> };
-        }>;
-      };
-      return r.candidates?.[0]?.content?.parts?.[0]?.text ?? JSON.stringify(raw);
-    },
+    parse: parseGeminiResponse,
   },
 };
+
+function parseOpenAIResponse(raw: unknown): LLMResponse {
+  const r = raw as {
+    choices?: Array<{
+      message?: {
+        content?: string | null;
+        tool_calls?: Array<{
+          id: string;
+          type?: string;
+          function?: { name?: string; arguments?: string };
+        }>;
+      };
+      finish_reason?: string;
+    }>;
+    usage?: { prompt_tokens?: number };
+  };
+  const choice = r.choices?.[0];
+  const msg = choice?.message;
+  const toolCalls = msg?.tool_calls;
+
+  if (toolCalls?.length) {
+    const calls: ToolCall[] = toolCalls
+      .filter((c) => c.function?.name)
+      .map((c) => {
+        let input: Record<string, unknown> = {};
+        try {
+          input = c.function?.arguments
+            ? (JSON.parse(c.function.arguments) as Record<string, unknown>)
+            : {};
+        } catch {
+          /* leave empty so handler can return a parse error */
+        }
+        return {
+          id: c.id,
+          name: c.function?.name ?? "",
+          input,
+        };
+      });
+    return { kind: "tool_calls", text: msg?.content ?? "", calls };
+  }
+
+  const content = msg?.content;
+  if (typeof content === "string" && content) {
+    return { kind: "text", text: content };
+  }
+
+  const finish = choice?.finish_reason;
+  const promptTokens = r.usage?.prompt_tokens;
+  if (finish === "length") {
+    throw new AiCallError(
+      promptTokens
+        ? `Prompt too large (${promptTokens.toLocaleString()} tokens) — the model ran out of token budget before producing any output.`
+        : "The model ran out of token budget before producing any output.",
+      undefined,
+      { reason: "empty-completion", finish_reason: finish, body: raw },
+    );
+  }
+  if (finish === "content_filter") {
+    throw new AiCallError(
+      "Response was blocked by the provider's content filter.",
+      undefined,
+      { reason: "content-filter", finish_reason: finish, body: raw },
+    );
+  }
+  throw new AiCallError("Provider returned an empty response.", undefined, {
+    reason: "empty-completion",
+    finish_reason: finish,
+    body: raw,
+  });
+}
+
+function parseAnthropicResponse(raw: unknown): LLMResponse {
+  const r = raw as {
+    content?: Array<{
+      type?: string;
+      text?: string;
+      id?: string;
+      name?: string;
+      input?: Record<string, unknown>;
+    }>;
+    stop_reason?: string;
+    usage?: { input_tokens?: number };
+  };
+  const blocks = r.content ?? [];
+  let text = "";
+  const calls: ToolCall[] = [];
+  for (const b of blocks) {
+    if (b.type === "text" && b.text) {
+      text += (text ? "\n" : "") + b.text;
+    } else if (b.type === "tool_use" && b.id && b.name) {
+      calls.push({ id: b.id, name: b.name, input: b.input ?? {} });
+    }
+  }
+
+  if (calls.length > 0) {
+    return { kind: "tool_calls", text, calls };
+  }
+  if (text) {
+    return { kind: "text", text };
+  }
+
+  const stop = r.stop_reason;
+  const promptTokens = r.usage?.input_tokens;
+  if (stop === "max_tokens") {
+    throw new AiCallError(
+      promptTokens
+        ? `Prompt too large (${promptTokens.toLocaleString()} tokens) — the model ran out of token budget before producing any output.`
+        : "The model ran out of token budget before producing any output.",
+      undefined,
+      { reason: "empty-completion", stop_reason: stop, body: raw },
+    );
+  }
+  throw new AiCallError("Provider returned an empty response.", undefined, {
+    reason: "empty-completion",
+    stop_reason: stop,
+    body: raw,
+  });
+}
+
+function parseGeminiResponse(raw: unknown): LLMResponse {
+  const r = raw as {
+    candidates?: Array<{
+      content?: {
+        parts?: Array<{
+          text?: string;
+          functionCall?: {
+            name?: string;
+            args?: Record<string, unknown>;
+          };
+        }>;
+      };
+      finishReason?: string;
+    }>;
+    usageMetadata?: { promptTokenCount?: number };
+  };
+  const parts = r.candidates?.[0]?.content?.parts ?? [];
+  let text = "";
+  const calls: ToolCall[] = [];
+  let fcCounter = 0;
+  for (const p of parts) {
+    if (p.text) {
+      text += (text ? "\n" : "") + p.text;
+    } else if (p.functionCall?.name) {
+      // Gemini doesn't return tool-call ids; synthesize one
+      calls.push({
+        id: `gemini-fc-${fcCounter++}`,
+        name: p.functionCall.name,
+        input: p.functionCall.args ?? {},
+      });
+    }
+  }
+
+  if (calls.length > 0) {
+    return { kind: "tool_calls", text, calls };
+  }
+  if (text) return { kind: "text", text };
+
+  const finish = r.candidates?.[0]?.finishReason;
+  const promptTokens = r.usageMetadata?.promptTokenCount;
+  if (finish === "MAX_TOKENS") {
+    throw new AiCallError(
+      promptTokens
+        ? `Prompt too large (${promptTokens.toLocaleString()} tokens) — the model ran out of token budget before producing any output.`
+        : "The model ran out of token budget before producing any output.",
+      undefined,
+      { reason: "empty-completion", finishReason: finish, body: raw },
+    );
+  }
+  if (finish === "SAFETY" || finish === "RECITATION") {
+    throw new AiCallError(
+      finish === "SAFETY"
+        ? "Response was blocked by the provider's safety filter."
+        : "Response was blocked because it would have recited copyrighted material.",
+      undefined,
+      { reason: "content-filter", finishReason: finish, body: raw },
+    );
+  }
+  throw new AiCallError("Provider returned an empty response.", undefined, {
+    reason: "empty-completion",
+    finishReason: finish,
+    body: raw,
+  });
+}
 
 export const defaultModel = (prov: AiProviderId): string => {
   const p = AI_PROVIDERS[prov];
@@ -217,10 +582,6 @@ export const modelLabel = (conf: AiConf): string => {
   if (!p) return `${conf.prov}/${conf.model}`;
   return p.models.find((m) => m.id === conf.model)?.name ?? conf.model;
 };
-
-// ──────────────────────────────────────────────────────────────
-// localStorage persistence
-// ──────────────────────────────────────────────────────────────
 
 const STORAGE_KEY = "navigate.aiConf";
 
@@ -262,10 +623,6 @@ export const clearAiConf = (): void => {
   }
 };
 
-// ──────────────────────────────────────────────────────────────
-// callLLM — one POST, provider-shaped request, normalized error
-// ──────────────────────────────────────────────────────────────
-
 export class AiCallError extends Error {
   status?: number;
   details?: unknown;
@@ -279,10 +636,11 @@ export class AiCallError extends Error {
 export const callLLM = async (
   conf: AiConf,
   messages: ChatMsg[],
-): Promise<string> => {
+  tools?: ToolDef[],
+): Promise<LLMResponse> => {
   const p = AI_PROVIDERS[conf.prov];
   if (!p) throw new AiCallError("Unknown provider");
-  const req = p.build(conf.model, conf.key, messages);
+  const req = p.build(conf.model, conf.key, messages, tools);
 
   let resp: Response;
   try {
@@ -322,8 +680,7 @@ export const callLLM = async (
       /* ignore */
     }
     if (resp.status === 401 || resp.status === 403) {
-      msg =
-        "Invalid or expired API key.";
+      msg = "Invalid or expired API key.";
     } else if (resp.status === 429) {
       msg = "Rate limit exceeded. Wait a moment and try again.";
     } else if (
@@ -349,17 +706,13 @@ export const callLLM = async (
   try {
     data = await resp.json();
   } catch {
-    throw new AiCallError(
-      "Malformed response from the provider.",
-      undefined,
-      {
-        reason: "parse",
-        url: req.url,
-        provider: conf.prov,
-        model: conf.model,
-        status: resp.status,
-      },
-    );
+    throw new AiCallError("Malformed response from the provider.", undefined, {
+      reason: "parse",
+      url: req.url,
+      provider: conf.prov,
+      model: conf.model,
+      status: resp.status,
+    });
   }
   const err = (data as { error?: { message?: string; code?: number } }).error;
   if (err) {
@@ -379,22 +732,15 @@ export const callLLM = async (
     });
   }
 
-  if (p.parse) return p.parse(data);
-  const oai = data as {
-    choices?: Array<{ message?: { content?: string } }>;
-  };
-  return oai.choices?.[0]?.message?.content ?? JSON.stringify(data);
+  return p.parse(data);
 };
 
-// ──────────────────────────────────────────────────────────────
-// verifyAiConf — lightweight "does this key actually work?" probe.
-// Sends a tiny one-token ping through the same adapter pipeline so the
-// provider does real auth + routing, and error mapping stays consistent
-// with callLLM (401/403/429/402 etc). Throws AiCallError on failure.
-// ──────────────────────────────────────────────────────────────
-
+// One-token ping; confirms auth + routing without running tools.
 export const verifyAiConf = async (conf: AiConf): Promise<void> => {
-  await callLLM(conf, [{ role: "user", content: "ping" }]);
+  const r = await callLLM(conf, [{ role: "user", content: "ping" }]);
+  if (r.kind !== "text" && r.kind !== "tool_calls") {
+    throw new AiCallError("Verification call returned an unexpected shape.");
+  }
 };
 
 export default function AiProvidersPage() {

--- a/src/pages/landing/navigate.tsx
+++ b/src/pages/landing/navigate.tsx
@@ -741,7 +741,7 @@ export const NavigateLandingSection = ({
               minHeight: 0,
             }}
           >
-            <AiPanel nodes={nodes} navigateToNode={navigateToNode} />
+            <AiPanel appName={appName} navigateToNode={navigateToNode} />
           </Box>
         </Grid>
 

--- a/src/pages/landing/navigate.tsx
+++ b/src/pages/landing/navigate.tsx
@@ -4,7 +4,9 @@ import {
   Chip,
   CircularProgress,
   Grid,
+  IconButton,
   InputAdornment,
+  Skeleton,
   Stack,
   TextField,
   ToggleButton,
@@ -15,6 +17,7 @@ import {
 } from "@mui/material";
 import {
   Search as SearchIcon,
+  Close as CloseIcon,
   ErrorOutline as ErrorOutlineIcon,
   ExploreOutlined as CompassIcon,
   AccountTreeOutlined as GraphIcon,
@@ -22,6 +25,8 @@ import {
 } from "@mui/icons-material";
 import {
   collection,
+  doc,
+  getDoc,
   getDocs,
   getFirestore,
   query as firestoreQuery,
@@ -32,6 +37,10 @@ import NodeGraph from "../../components/NodBody/NodeGraph";
 import { AiPanel } from "./_components/AiPanel";
 import type { ICollection, INode } from "../../types/INode";
 import { NODES } from "../../lib/firestoreClient/collections";
+import { Post } from "../../lib/utils/Post";
+import FullPageLogoLoading from "../../components/layouts/FullPageLogoLoading";
+
+type ChromaResult = { id: string; title: string };
 
 const INTER =
   '"Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif';
@@ -166,6 +175,28 @@ const RelationGroup: React.FC<{
 // ──────────────────────────────────────────────────────────────
 // Main Navigate section
 // ──────────────────────────────────────────────────────────────
+//
+// TODO(navigator-optimization): The navigator currently fetches each
+// focused node on demand and caches them locally — this avoids the
+// previous 50K-node eager load, but two things still want fixing:
+//
+//   1. Cache duplication. The platform (Ontology.tsx) maintains its own
+//      `relatedNodes` map. This component re-fetches nodes the platform
+//      may already have. The clean fix is to lift the cache up to
+//      `[id].tsx` and share `relatedNodes` + a single `fetchNode`
+//      between the two modes.
+//
+//   2. Stats pill + search-result descriptions. Both used to read from
+//      the full in-memory ontology. Stats are now disabled (see below).
+//      Search descriptions silently fall back to the chroma title when
+//      the result isn't in the local cache. The proper fix is to have
+//      `/searchChroma` return a description excerpt inline (it already
+//      touches the document during retrieval), and to surface stats
+//      from a server-side aggregate (a Cloud Function maintaining a
+//      per-app stats doc, or an `/api/ontology-stats` endpoint).
+//
+// Both of these are pure optimizations; the navigator's correctness
+// does not depend on them.
 
 export const NavigateLandingSection = ({
   isDark,
@@ -181,49 +212,62 @@ export const NavigateLandingSection = ({
   const theme = useTheme();
   const accent = theme.palette.primary.main;
 
-  const [nodes, setNodes] = useState<{ [id: string]: INode } | null>(null);
+  // Sparse, demand-populated cache. Starts empty; entries arrive as the
+  // user navigates. The compass and detail panel render the focused
+  // node's chips from inline link titles, so satellite nodes don't need
+  // to be in this cache for their labels to show — only the focused
+  // node itself does.
+  const [nodes, setNodes] = useState<{ [id: string]: INode }>({});
   const [loadError, setLoadError] = useState<string | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [view, setView] = useState<"compass" | "graph">("compass");
   const [sidebarTab, setSidebarTab] = useState<"search" | "ai">("search");
 
+  // Resolve the initial focused node with one targeted fetch — no full
+  // ontology load. Order: caller-supplied `initialNodeId`, else the
+  // app's root node.
   useEffect(() => {
+    if (activeId) return;
     let cancelled = false;
     (async () => {
       try {
         const db = getFirestore();
-        const q = firestoreQuery(
-          collection(db, NODES),
-          where("appName", "==", appName),
-          where("deleted", "==", false),
-        );
-        const snapshot = await getDocs(q);
-        if (cancelled) return;
-        const loaded: { [id: string]: INode } = {};
-        let root: string | null = null;
-        snapshot.forEach((doc) => {
-          const raw = doc.data() as Record<string, unknown>;
-          const data = { id: doc.id, ...raw } as INode;
-          loaded[doc.id] = data;
-          if (!root && (raw.root === true || raw.root === "true")) {
-            root = doc.id;
+        let resolved: INode | null = null;
+        if (initialNodeId) {
+          const snap = await getDoc(doc(collection(db, NODES), initialNodeId));
+          if (cancelled) return;
+          if (snap.exists()) {
+            resolved = { id: snap.id, ...snap.data() } as INode;
           }
-        });
-        setNodes(loaded);
-        // Prefer the caller-supplied initial node id when it's a valid
-        // node for this app; otherwise fall back to the app's root.
-        if (initialNodeId && loaded[initialNodeId]) {
-          setActiveId(initialNodeId);
-        } else {
-          setActiveId(root);
         }
+        if (!resolved && !cancelled) {
+          const rootSnap = await getDocs(
+            firestoreQuery(
+              collection(db, NODES),
+              where("appName", "==", appName),
+              where("deleted", "==", false),
+              where("root", "==", true),
+            ),
+          );
+          if (cancelled) return;
+          const rootDoc = rootSnap.docs[0];
+          if (rootDoc) {
+            resolved = { id: rootDoc.id, ...rootDoc.data() } as INode;
+          }
+        }
+        if (cancelled || !resolved) return;
+        const node = resolved;
+        setNodes((prev) =>
+          prev[node.id] ? prev : { ...prev, [node.id]: node },
+        );
+        setActiveId(node.id);
       } catch (e) {
         if (!cancelled) {
           const msg =
             e instanceof Error
               ? e.message
-              : "Failed to load ontology from Firestore.";
+              : "Failed to load the focused node from Firestore.";
           setLoadError(msg);
         }
       }
@@ -231,7 +275,7 @@ export const NavigateLandingSection = ({
     return () => {
       cancelled = true;
     };
-  }, [appName, initialNodeId]);
+  }, [appName, initialNodeId, activeId]);
 
   // Mirror the focused node into the URL hash so the back-to-platform
   // callback can read it, refreshes preserve focus, and the link is
@@ -256,22 +300,54 @@ export const NavigateLandingSection = ({
   // hashchange, so we won't loop on our own updates.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const onHashChange = () => {
+    let cancelled = false;
+    const onHashChange = async () => {
       const h = window.location.hash.replace(/^#/, "");
       if (!h.endsWith("/navigate")) return;
       const id = h.slice(0, -"/navigate".length);
-      if (id && nodes && nodes[id] && id !== activeId) {
+      if (!id || id === activeId) return;
+      if (nodes[id]) {
         setActiveId(id);
+        return;
+      }
+      try {
+        const db = getFirestore();
+        const snap = await getDoc(doc(collection(db, NODES), id));
+        if (cancelled || !snap.exists()) return;
+        const node = { id: snap.id, ...snap.data() } as INode;
+        setNodes((prev) => (prev[id] ? prev : { ...prev, [id]: node }));
+        setActiveId(id);
+      } catch (e) {
+        console.error("navigator hashchange fetch failed:", e);
       }
     };
     window.addEventListener("hashchange", onHashChange);
-    return () => window.removeEventListener("hashchange", onHashChange);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("hashchange", onHashChange);
+    };
   }, [nodes, activeId]);
 
+  // Navigate to a node. If it isn't cached locally, fetch it first and
+  // only then swap the focused id — the previous view stays put during
+  // the fetch (no jarring full-page loader between navigations).
   const navigateToNode = useCallback(
-    (id: string) => {
-      if (!nodes || !nodes[id]) return;
-      setActiveId(id);
+    async (id: string) => {
+      if (!id) return;
+      if (nodes[id]) {
+        setActiveId(id);
+        return;
+      }
+      try {
+        const db = getFirestore();
+        const snap = await getDoc(doc(collection(db, NODES), id));
+        if (!snap.exists()) return;
+        const node = { id: snap.id, ...snap.data() } as INode;
+        setNodes((prev) => (prev[id] ? prev : { ...prev, [id]: node }));
+        setActiveId(id);
+      } catch (e) {
+        console.error("navigator navigateToNode fetch failed:", e);
+      }
     },
     [nodes],
   );
@@ -292,72 +368,67 @@ export const NavigateLandingSection = ({
     });
   }, []);
 
-  // Search results: ranked flat list of nodes whose title matches the query.
-  // Empty query → empty list (left panel shows an empty-state prompt).
-  const searchResults = useMemo(() => {
-    if (!nodes) return [];
-    const q = query.trim().toLowerCase();
-    if (!q) return [];
-    const scored: Array<{ node: INode; score: number }> = [];
-    for (const node of Object.values(nodes)) {
-      const s = scoreMatch(node.title ?? "", q);
-      if (s > 0) scored.push({ node, score: s });
-    }
-    scored.sort((a, b) => {
-      if (b.score !== a.score) return b.score - a.score;
-      return (a.node.title ?? "").localeCompare(b.node.title ?? "");
-    });
-    return scored.slice(0, 200).map((s) => s.node);
-  }, [query, nodes]);
+  // Chroma-backed search — fires only on Enter or Search-icon click. The
+  // ranked id+title list returned by /searchChroma is paired with the
+  // already-loaded `nodes` map to render description previews where
+  // available.
+  const [submittedQuery, setSubmittedQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<ChromaResult[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
 
-  // Header stats: process count, undirected relationship count (gen/spec +
-  // parts/isPartOf are inverse pairs, so we count directed links and halve),
-  // and max specialization depth via BFS from any root-flagged node.
-  const stats = useMemo(() => {
-    if (!nodes) return null;
-    const values = Object.values(nodes);
-    const processes = values.length;
-
-    let directed = 0;
-    for (const n of values) {
-      directed += countLinks(n.generalizations);
-      directed += countLinks(n.specializations);
-      directed += countLinks(n.properties?.parts as ICollection[] | undefined);
-      directed += countLinks(
-        n.properties?.isPartOf as ICollection[] | undefined,
+  const runSearch = useCallback(async () => {
+    const q = query.trim();
+    if (!q || searchLoading) return;
+    setSubmittedQuery(q);
+    setSearchLoading(true);
+    setSearchError(null);
+    try {
+      const response = await Post<{ results?: ChromaResult[] }>(
+        "/searchChroma",
+        {
+          query: q,
+          skillsFuture: true,
+          appName,
+        },
       );
+      setSearchResults(response?.results ?? []);
+    } catch (e) {
+      console.error("searchChroma error:", e);
+      setSearchResults([]);
+      setSearchError("Search failed. Please try again.");
+    } finally {
+      setSearchLoading(false);
     }
-    const relationships = Math.round(directed / 2);
+  }, [query, searchLoading, appName]);
 
-    const roots = values.filter((n) => {
-      const r = (n as unknown as { root?: unknown }).root;
-      return r === true || r === "true";
-    });
-    let depth = 0;
-    const visited = new Set<string>();
-    let frontier: string[] = roots.map((r) => r.id);
-    frontier.forEach((id) => visited.add(id));
-    while (frontier.length && depth < 64) {
-      const next: string[] = [];
-      for (const id of frontier) {
-        const node = nodes[id];
-        if (!node) continue;
-        for (const col of node.specializations ?? []) {
-          for (const child of col?.nodes ?? []) {
-            if (child?.id && !visited.has(child.id) && nodes[child.id]) {
-              visited.add(child.id);
-              next.push(child.id);
-            }
-          }
-        }
-      }
-      if (next.length === 0) break;
-      depth += 1;
-      frontier = next;
+  const clearSearch = useCallback(() => {
+    setQuery("");
+    setSubmittedQuery("");
+    setSearchResults([]);
+    setSearchError(null);
+  }, []);
+
+  // Reset to the empty state when the input is cleared by hand so a stale
+  // result list doesn't linger after the user erases their query.
+  useEffect(() => {
+    if (query.trim() === "") {
+      setSubmittedQuery("");
+      setSearchResults([]);
+      setSearchError(null);
     }
+  }, [query]);
 
-    return { processes, relationships, depth };
-  }, [nodes]);
+  // Header stats — disabled while the navigator is in the on-demand
+  // fetching mode (see top-of-file TODO). Computing processes /
+  // relationships / depth requires the whole ontology in memory, which
+  // is exactly what we removed. The pill renders only when this is
+  // non-null, so leaving it null hides the pill cleanly.
+  // (The `as` cast preserves the wider type so the existing
+  // `{stats && (...)}` JSX block still typechecks.)
+  const stats = null as
+    | { processes: number; relationships: number; depth: number }
+    | null;
 
   // Loading / error states
   if (loadError) {
@@ -395,31 +466,12 @@ export const NavigateLandingSection = ({
     );
   }
 
-  if (!nodes || !activeId) {
-    return (
-      <Box
-        sx={{
-          height: "100vh",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          flexDirection: "column",
-          gap: 2,
-          bgcolor: "background.default",
-        }}
-      >
-        <CircularProgress size={28} thickness={4} />
-        <Typography
-          sx={{
-            fontFamily: INTER,
-            fontSize: "0.85rem",
-            color: "text.secondary",
-          }}
-        >
-          Loading the ontology of activities…
-        </Typography>
-      </Box>
-    );
+  // Loader appears only when we genuinely have nothing to render — i.e.
+  // the focused node hasn't been resolved yet, or its full doc isn't in
+  // the local cache. Mid-navigation re-fetches don't trigger this; the
+  // previous focused view stays visible until the next one is ready.
+  if (!activeId || !nodes[activeId]) {
+    return <FullPageLogoLoading />;
   }
 
   const activeNode = nodes[activeId];
@@ -573,7 +625,18 @@ export const NavigateLandingSection = ({
               size="small"
               placeholder="Search activities…"
               value={query}
-              onChange={(e) => setQuery(e.target.value)}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                if (searchError) setSearchError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void runSearch();
+                } else if (e.key === "Escape") {
+                  clearSearch();
+                }
+              }}
               autoComplete="off"
               slotProps={{
                 input: {
@@ -582,6 +645,73 @@ export const NavigateLandingSection = ({
                       <SearchIcon
                         sx={{ color: "text.secondary", fontSize: 18 }}
                       />
+                    </InputAdornment>
+                  ),
+                  endAdornment: (
+                    <InputAdornment position="end" sx={{ ml: 0 }}>
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 0.25,
+                          width: query.trim() ? "auto" : 0,
+                          minWidth: 0,
+                          overflow: "hidden",
+                          transition: "width 0.15s ease",
+                        }}
+                      >
+                        <IconButton
+                          size="small"
+                          onClick={() => void runSearch()}
+                          disabled={!query.trim() || searchLoading}
+                          aria-label="Search"
+                          sx={{
+                            width: 26,
+                            height: 26,
+                            color: accent,
+                            bgcolor: alpha(accent, 0.12),
+                            transition: "background-color 0.15s ease",
+                            "&:hover": {
+                              bgcolor: alpha(accent, 0.2),
+                            },
+                            "&.Mui-disabled": {
+                              color: "text.disabled",
+                              bgcolor: (t) =>
+                                alpha(t.palette.text.primary, 0.05),
+                            },
+                          }}
+                        >
+                          {searchLoading ? (
+                            <CircularProgress
+                              size={12}
+                              thickness={5}
+                              sx={{ color: "inherit" }}
+                            />
+                          ) : (
+                            <SearchIcon sx={{ fontSize: 14 }} />
+                          )}
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          onClick={clearSearch}
+                          disabled={!query.trim()}
+                          aria-label="Clear search"
+                          sx={{
+                            width: 26,
+                            height: 26,
+                            color: "text.secondary",
+                            "&:hover": {
+                              color: "error.main",
+                              bgcolor: (t) =>
+                                t.palette.mode === "dark"
+                                  ? alpha(t.palette.error.main, 0.14)
+                                  : alpha(t.palette.error.main, 0.08),
+                            },
+                          }}
+                        >
+                          <CloseIcon sx={{ fontSize: 14 }} />
+                        </IconButton>
+                      </Box>
                     </InputAdornment>
                   ),
                 },
@@ -651,10 +781,49 @@ export const NavigateLandingSection = ({
                     lineHeight: 1.5,
                   }}
                 >
-                  Type a keyword to find matching activities across the
-                  ontology.
+                  Type a keyword and press Enter to search the ontology.
                 </Typography>
               </Box>
+            ) : searchLoading ? (
+              <Stack spacing={0.75} sx={{ mt: 1 }}>
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <Skeleton
+                    key={i}
+                    variant="rounded"
+                    height={48}
+                    sx={{
+                      borderRadius: 1.5,
+                      bgcolor: (t) => alpha(t.palette.text.primary, 0.06),
+                    }}
+                  />
+                ))}
+              </Stack>
+            ) : searchError ? (
+              <Typography
+                sx={{
+                  mt: 3,
+                  textAlign: "center",
+                  fontSize: "0.8rem",
+                  fontFamily: INTER,
+                  color: "error.main",
+                }}
+              >
+                {searchError}
+              </Typography>
+            ) : query.trim() !== submittedQuery ? (
+              <Typography
+                sx={{
+                  mt: 3,
+                  textAlign: "center",
+                  fontSize: "0.78rem",
+                  fontFamily: INTER,
+                  color: "text.disabled",
+                  lineHeight: 1.5,
+                }}
+              >
+                Press <strong>Enter</strong> or click the search button to
+                find &ldquo;{query.trim()}&rdquo;.
+              </Typography>
             ) : searchResults.length === 0 ? (
               <Typography
                 sx={{
@@ -665,19 +834,24 @@ export const NavigateLandingSection = ({
                   color: "text.disabled",
                 }}
               >
-                No activities match &ldquo;{query.trim()}&rdquo;.
+                No activities match &ldquo;{submittedQuery}&rdquo;.
               </Typography>
             ) : (
               <Stack spacing={0.5}>
-                {searchResults.map((n) => {
-                  const isActive = n.id === activeId;
-                  const desc = getDescription(n);
+                {searchResults.map((r) => {
+                  const isActive = r.id === activeId;
+                  // Chroma payload is {id, title}; pair with the locally
+                  // loaded node map to surface a description preview when
+                  // available, else fall back to the chroma title only.
+                  const fullNode = nodes[r.id];
+                  const title = fullNode?.title ?? r.title;
+                  const desc = fullNode ? getDescription(fullNode) : "";
                   return (
                     <Box
-                      key={n.id}
+                      key={r.id}
                       role="button"
                       tabIndex={0}
-                      onClick={() => navigateToNode(n.id)}
+                      onClick={() => navigateToNode(r.id)}
                       sx={{
                         p: 1.1,
                         borderRadius: 1.5,
@@ -706,7 +880,7 @@ export const NavigateLandingSection = ({
                           lineHeight: 1.3,
                         }}
                       >
-                        {n.title}
+                        {title}
                       </Typography>
                       {desc && (
                         <Typography

--- a/src/pages/landing/navigate.tsx
+++ b/src/pages/landing/navigate.tsx
@@ -35,10 +35,19 @@ import {
 import NodeCompass from "../../components/NodBody/NodeCompass";
 import NodeGraph from "../../components/NodBody/NodeGraph";
 import { AiPanel } from "./_components/AiPanel";
-import type { ICollection, INode } from "../../types/INode";
+import type { ICollection, INode, TreeData } from "../../types/INode";
 import { NODES } from "../../lib/firestoreClient/collections";
 import { Post } from "../../lib/utils/Post";
 import FullPageLogoLoading from "../../components/layouts/FullPageLogoLoading";
+import {
+  batchGetNodesByIds,
+  buildPathTreeWithSiblings,
+  collectSpecializationChildIds,
+  mapTreeAtId,
+  replaceWithOneLevel,
+  resolvePathIds,
+} from "../../lib/utils/loadOutlineFromPathIds";
+import { fetchSingleNode } from "../../lib/utils/ontology.helpers";
 
 type ChromaResult = { id: string; title: string };
 
@@ -352,19 +361,76 @@ export const NavigateLandingSection = ({
     [nodes],
   );
 
-  // Graph view's expansion state lives here so it survives toggling between
-  // compass ↔ graph (either view unmounts when the toggle switches away).
-  // Reset whenever the active node changes — a fresh focus is a fresh tree.
-  const [graphExpanded, setGraphExpanded] = useState<Set<string>>(new Set());
+  // Graph view: hierarchy from root → focused, with all siblings at each level.
+  const [hierarchyTree, setHierarchyTree] = useState<TreeData[] | null>(null);
+
   useEffect(() => {
-    setGraphExpanded(new Set());
-  }, [activeId]);
-  const toggleGraphExpand = useCallback((id: string) => {
-    setGraphExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
+    if (!activeId) return;
+    const focused = nodes[activeId];
+    if (!focused) return;
+    let cancelled = false;
+    setHierarchyTree(null);
+    (async () => {
+      try {
+        const db = getFirestore();
+        const { pathIds } = await resolvePathIds(focused, (id) =>
+          fetchSingleNode(db, id, appName),
+        );
+        if (cancelled) return;
+        const byId = await batchGetNodesByIds(db, pathIds, appName);
+        if (cancelled) return;
+        if (!byId[focused.id]) byId[focused.id] = focused;
+        const childIds = pathIds.flatMap((id) =>
+          byId[id] ? collectSpecializationChildIds(byId[id]) : [],
+        );
+        const childrenById = await batchGetNodesByIds(db, childIds, appName);
+        if (cancelled) return;
+        const tree = buildPathTreeWithSiblings(
+          pathIds,
+          byId,
+          childrenById,
+          focused.id,
+        );
+        setHierarchyTree(tree);
+      } catch (e) {
+        console.error("navigator hierarchy-build failed:", e);
+        // Fall back to an empty tree so the graph view doesn't hang on
+        // the spinner forever.
+        if (!cancelled) setHierarchyTree([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeId, nodes, appName]);
+
+  const expandGraphNode = useCallback(
+    async (treeId: string, nodeId: string) => {
+      const db = getFirestore();
+      const full = await fetchSingleNode(db, nodeId, appName);
+      if (!full) return;
+      const childIds = collectSpecializationChildIds(full);
+      const childDocs = await batchGetNodesByIds(db, childIds, appName);
+      const merged: Record<string, INode> = {
+        ...childDocs,
+        [full.id]: full,
+      };
+      setHierarchyTree((prev) =>
+        prev ? replaceWithOneLevel(prev, treeId, full, merged) : prev,
+      );
+    },
+    [appName],
+  );
+
+  const collapseGraphNode = useCallback((treeId: string) => {
+    setHierarchyTree((prev) => {
+      if (!prev) return prev;
+      return mapTreeAtId(prev, treeId, (n) => ({
+        ...n,
+        children: [],
+        outlineLoadChildren: true,
+        hasUnresolvedChildren: true,
+      }));
     });
   }, []);
 
@@ -939,12 +1005,11 @@ export const NavigateLandingSection = ({
             />
           ) : (
             <NodeGraph
-              currentVisibleNode={activeNode}
-              relatedNodes={nodes}
-              navigateToNode={navigateToNode}
+              hierarchyTree={hierarchyTree}
+              focusedId={activeId}
+              onExpandNode={expandGraphNode}
+              onCollapseNode={collapseGraphNode}
               borderless
-              expanded={graphExpanded}
-              onToggleExpand={toggleGraphExpand}
             />
           )}
 

--- a/src/pages/landing/navigate.tsx
+++ b/src/pages/landing/navigate.tsx
@@ -456,6 +456,7 @@ export const NavigateLandingSection = ({
           query: q,
           skillsFuture: true,
           appName,
+          resultsNum: 100,
         },
       );
       setSearchResults(response?.results ?? []);


### PR DESCRIPTION
Hi @samadouhra 

This PR includes all changes related to optimization of new navigator view.

Changes include:

- Removed the bulk load of all nodes; the navigator now fetches each node on demand as the user navigates.
- Replaced the "send the entire ontology as a string" prompt with a loop; the model browses the ontology via `search_activities` and `get_activities` calls instead.
- Updated prompt to match the new flow.
- The navigator's search panel now uses `chroma` like the default `SearchSidebar`.
- Updated the graph view inside navigator to work with the per-node loading model.