### PR TITLE
Pre-compute NodeChange.diffValue at write time

### DIFF
--- a/src/components/ActiveUsers/ActivityDetails.tsx
+++ b/src/components/ActiveUsers/ActivityDetails.tsx
@@ -8,6 +8,7 @@ import {
   IconButton,
 } from "@mui/material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import SubdirectoryArrowRightIcon from "@mui/icons-material/SubdirectoryArrowRight";
 import { alpha } from "@mui/material/styles";
 import OptimizedAvatar from "../Chat/OptimizedAvatar";
 import { getChangeDescription } from "@components/lib/utils/helpers";
@@ -34,6 +35,8 @@ const ActivityDetails = ({
   const isHighlighted = isSelected || selectedDiffNode?.id === activity.id;
   const changeSummary = getChangeDescription(activity, "");
   const nodeTitle = nodes[activity.nodeId]?.title || activity.fullNode?.title;
+  const triggeredBy = activity.triggeredBy;
+  const isChildLog = !!triggeredBy;
 
   const relativeFromNow = () => {
     const t = dayjs(new Date(activity.modifiedAt.toDate())).fromNow();
@@ -99,12 +102,15 @@ const ActivityDetails = ({
   );
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", mt: 2 }}>
+    <Box
+      sx={{ display: "flex", flexDirection: "column", mt: isChildLog ? 1 : 2 }}
+    >
       <Paper
         elevation={0}
         sx={(theme) => ({
           mx: 2,
-          p: 3,
+          ml: isChildLog ? 8 : 2,
+          p: isChildLog ? 1.75 : 3,
           borderRadius: 3,
           border: "1px solid",
           borderColor: isHighlighted
@@ -112,6 +118,12 @@ const ActivityDetails = ({
             : theme.palette.mode === "dark"
               ? alpha(theme.palette.common.white, 0.22)
               : alpha(theme.palette.grey[700], 0.35),
+          ...(isChildLog
+            ? {
+                borderLeft: "3px dashed",
+                borderLeftColor: alpha(theme.palette.warning.main, 0.55),
+              }
+            : {}),
           bgcolor: isHighlighted
             ? alpha(
                 theme.palette.warning.main,
@@ -120,23 +132,25 @@ const ActivityDetails = ({
             : theme.palette.mode === "dark"
               ? alpha(theme.palette.common.black, 0.2)
               : theme.palette.background.paper,
+          opacity: isChildLog && !isHighlighted ? 0.92 : 1,
           boxShadow: isHighlighted
             ? `0 0 0 1px ${alpha(theme.palette.warning.main, 0.35)}, ${theme.shadows[2]}`
             : theme.palette.mode === "dark"
               ? `0 1px 0 ${alpha(theme.palette.common.white, 0.06)} inset`
               : theme.shadows[1],
           transition:
-            "box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease",
+            "box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease, opacity 0.2s ease",
           "&:hover": {
             borderColor: isHighlighted
               ? undefined
               : theme.palette.mode === "dark"
                 ? alpha(theme.palette.common.white, 0.32)
                 : alpha(theme.palette.grey[700], 0.5),
+            opacity: 1,
           },
         })}
       >
-        <Stack spacing={1.5}>
+        <Stack spacing={isChildLog ? 1 : 1.5}>
           <Stack
             direction="row"
             alignItems="stretch"
@@ -151,8 +165,10 @@ const ActivityDetails = ({
                 alignItems: "center",
               }}
             >
-              {!modifiedByDetails && <Box sx={{ py: 0.25 }}>{TimeLabel}</Box>}
-              {modifiedByDetails && (
+              {(!modifiedByDetails || isChildLog) && (
+                <Box sx={{ py: 0.25 }}>{TimeLabel}</Box>
+              )}
+              {modifiedByDetails && !isChildLog && (
                 <Stack
                   direction="row"
                   alignItems="center"
@@ -244,10 +260,10 @@ const ActivityDetails = ({
                   borderRadius: 999,
                   textTransform: "none",
                   fontWeight: 600,
-                  fontSize: "0.8125rem",
-                  px: 2.25,
-                  py: 0.65,
-                  minWidth: 92,
+                  fontSize: isChildLog ? "0.75rem" : "0.8125rem",
+                  px: isChildLog ? 1.5 : 2.25,
+                  py: isChildLog ? 0.4 : 0.65,
+                  minWidth: isChildLog ? 70 : 92,
                   boxShadow: "none",
                   ...(isHighlighted
                     ? {
@@ -372,43 +388,94 @@ const ActivityDetails = ({
             role="status"
             aria-label="Activity summary and node"
             sx={(theme) => ({
-              py: 1.25,
-              px: 1.5,
+              py: isChildLog ? 0 : 1.25,
+              px: isChildLog ? 0 : 1.5,
               borderRadius: 1.25,
-              border: "1px solid",
+              border: isChildLog ? "none" : "1px solid",
               borderColor: alpha(theme.palette.warning.main, 0.45),
-              bgcolor: alpha(
-                theme.palette.warning.main,
-                theme.palette.mode === "dark" ? 0.14 : 0.08,
-              ),
+              bgcolor: isChildLog
+                ? "transparent"
+                : alpha(
+                    theme.palette.warning.main,
+                    theme.palette.mode === "dark" ? 0.14 : 0.08,
+                  ),
               boxShadow:
-                theme.palette.mode === "dark"
-                  ? `0 0 0 1px ${alpha(theme.palette.common.white, 0.04)} inset`
-                  : "none",
+                isChildLog || theme.palette.mode !== "dark"
+                  ? "none"
+                  : `0 0 0 1px ${alpha(theme.palette.common.white, 0.04)} inset`,
             })}
           >
-            <Typography
-              variant="overline"
-              sx={{
-                display: "block",
-                fontSize: "0.65rem",
-                fontWeight: 700,
-                letterSpacing: "0.12em",
-                color: "warning.main",
-                lineHeight: 1.2,
-                mb: 0.5,
-              }}
-            >
-              What changed
-            </Typography>
+            {!isChildLog && (
+              <Typography
+                variant="overline"
+                sx={{
+                  display: "block",
+                  fontSize: "0.65rem",
+                  fontWeight: 700,
+                  letterSpacing: "0.12em",
+                  color: "warning.main",
+                  lineHeight: 1.2,
+                  mb: 0.5,
+                }}
+              >
+                What changed
+              </Typography>
+            )}
+            {triggeredBy && (
+              <Tooltip
+                title={`Triggered by ${triggeredBy.nodeTitle || "another node"}`}
+                placement="top"
+                arrow
+                slotProps={timeTooltipSlotProps}
+              >
+                <Box
+                  sx={(theme) => ({
+                    mb: 1,
+                    px: 1,
+                    py: 0.4,
+                    borderRadius: 999,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 0.5,
+                    fontSize: "0.75rem",
+                    fontWeight: 600,
+                    letterSpacing: "-0.005em",
+                    color: "warning.main",
+                    border: "1px dashed",
+                    borderColor: alpha(theme.palette.warning.main, 0.55),
+                    bgcolor: alpha(
+                      theme.palette.warning.main,
+                      theme.palette.mode === "dark" ? 0.1 : 0.06,
+                    ),
+                    transition:
+                      "background-color 0.15s ease, border-color 0.15s ease",
+                  })}
+                >
+                  <SubdirectoryArrowRightIcon sx={{ fontSize: 14 }} />
+                  Triggered by edit on
+                  <Box
+                    component="span"
+                    sx={{
+                      maxWidth: 220,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      fontWeight: 800,
+                    }}
+                  >
+                    {`"${triggeredBy.nodeTitle || "another node"}"`}
+                  </Box>
+                </Box>
+              </Tooltip>
+            )}
             <Typography
               component="p"
               sx={{
                 m: 0,
-                fontSize: "0.9375rem",
-                fontWeight: 600,
+                fontSize: isChildLog ? "0.8125rem" : "0.9375rem",
+                fontWeight: isChildLog ? 500 : 600,
                 lineHeight: 1.5,
-                color: "text.primary",
+                color: isChildLog ? "text.secondary" : "text.primary",
                 letterSpacing: "-0.01em",
                 wordBreak: "break-word",
               }}
@@ -420,13 +487,13 @@ const ActivityDetails = ({
                 component="p"
                 sx={{
                   m: 0,
-                  mt: 1.25,
-                  fontWeight: 800,
-                  fontSize: "1.25rem",
+                  mt: isChildLog ? 0.5 : 1.25,
+                  fontWeight: isChildLog ? 600 : 800,
+                  fontSize: isChildLog ? "0.875rem" : "1.25rem",
                   lineHeight: 1.35,
                   letterSpacing: "-0.02em",
                   wordBreak: "break-word",
-                  color: "text.primary",
+                  color: isChildLog ? "text.secondary" : "text.primary",
                 }}
               >
                 {nodeTitle}

--- a/src/components/ActiveUsers/ActivityDetails.tsx
+++ b/src/components/ActiveUsers/ActivityDetails.tsx
@@ -6,9 +6,12 @@ import {
   Tooltip,
   Stack,
   IconButton,
+  Collapse,
 } from "@mui/material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import SubdirectoryArrowRightIcon from "@mui/icons-material/SubdirectoryArrowRight";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import { alpha } from "@mui/material/styles";
 import OptimizedAvatar from "../Chat/OptimizedAvatar";
 import { getChangeDescription } from "@components/lib/utils/helpers";
@@ -24,19 +27,26 @@ const ActivityDetails = ({
   modifiedByDetails,
   selectedDiffNode,
   nodes,
+  childActivities,
+  nested = false,
 }: {
   activity: NodeChange;
   displayDiff: Function;
   modifiedByDetails?: any;
   selectedDiffNode: any;
   nodes: { [nodeId: string]: any };
+  childActivities?: (NodeChange & { id: string })[];
+  nested?: boolean;
 }) => {
   const [isSelected, setIsSelected] = useState(false);
+  const [childrenExpanded, setChildrenExpanded] = useState(false);
   const isHighlighted = isSelected || selectedDiffNode?.id === activity.id;
   const changeSummary = getChangeDescription(activity, "");
   const nodeTitle = nodes[activity.nodeId]?.title || activity.fullNode?.title;
   const triggeredBy = activity.triggeredBy;
   const isChildLog = !!triggeredBy;
+  const childCount = childActivities?.length ?? 0;
+  const hasChildren = childCount > 0 && !isChildLog;
 
   const relativeFromNow = () => {
     const t = dayjs(new Date(activity.modifiedAt.toDate())).fromNow();
@@ -103,13 +113,17 @@ const ActivityDetails = ({
 
   return (
     <Box
-      sx={{ display: "flex", flexDirection: "column", mt: isChildLog ? 1 : 2 }}
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        mt: nested ? 0 : isChildLog ? 1 : 2,
+      }}
     >
       <Paper
         elevation={0}
         sx={(theme) => ({
-          mx: 2,
-          ml: isChildLog ? 8 : 2,
+          mx: nested ? 0 : 2,
+          ml: nested ? 0 : 2,
           p: isChildLog ? 1.75 : 3,
           borderRadius: 3,
           border: "1px solid",
@@ -421,7 +435,7 @@ const ActivityDetails = ({
                 What changed
               </Typography>
             )}
-            {triggeredBy && (
+            {triggeredBy && !nested && (
               <Tooltip
                 title={`Triggered by ${triggeredBy.nodeTitle || "another node"}`}
                 placement="top"
@@ -488,12 +502,12 @@ const ActivityDetails = ({
                 sx={{
                   m: 0,
                   mt: isChildLog ? 0.5 : 1.25,
-                  fontWeight: isChildLog ? 600 : 800,
-                  fontSize: isChildLog ? "0.875rem" : "1.25rem",
+                  fontWeight: isChildLog ? 700 : 800,
+                  fontSize: isChildLog ? "0.9375rem" : "1.25rem",
                   lineHeight: 1.35,
                   letterSpacing: "-0.02em",
                   wordBreak: "break-word",
-                  color: isChildLog ? "text.secondary" : "text.primary",
+                  color: "text.primary",
                 }}
               >
                 {nodeTitle}
@@ -553,6 +567,62 @@ const ActivityDetails = ({
                   }}
                 />
               </Box>
+            </Box>
+          )}
+
+          {hasChildren && (
+            <Box sx={{ pt: 1.25 }}>
+              <Box sx={{ display: "flex", justifyContent: "flex-start" }}>
+                <Button
+                  onClick={() => setChildrenExpanded((v) => !v)}
+                  startIcon={
+                    childrenExpanded ? (
+                      <ExpandMoreIcon fontSize="small" />
+                    ) : (
+                      <ChevronRightIcon fontSize="small" />
+                    )
+                  }
+                  size="small"
+                  variant="text"
+                  disableElevation
+                  aria-expanded={childrenExpanded}
+                  aria-controls={`triggered-changes-${activity.id ?? "anon"}`}
+                  sx={(theme) => ({
+                    textTransform: "none",
+                    fontSize: "0.8125rem",
+                    fontWeight: 600,
+                    color: "warning.main",
+                    px: 2,
+                    py: 0.85,
+                    minWidth: 0,
+                    borderRadius: 999,
+                    "&:hover": {
+                      bgcolor: alpha(theme.palette.warning.main, 0.1),
+                    },
+                  })}
+                >
+                  {childrenExpanded ? "Hide" : "Show"} {childCount} triggered
+                  change{childCount === 1 ? "" : "s"}
+                </Button>
+              </Box>
+              <Collapse
+                in={childrenExpanded}
+                unmountOnExit
+                id={`triggered-changes-${activity.id ?? "anon"}`}
+              >
+                <Stack spacing={1} sx={{ mt: 1 }}>
+                  {childActivities!.map((child) => (
+                    <ActivityDetails
+                      key={child.id}
+                      activity={child}
+                      displayDiff={displayDiff}
+                      selectedDiffNode={selectedDiffNode}
+                      nodes={nodes}
+                      nested
+                    />
+                  ))}
+                </Stack>
+              </Collapse>
             </Box>
           )}
         </Stack>

--- a/src/components/ActiveUsers/HistoryTab.tsx
+++ b/src/components/ActiveUsers/HistoryTab.tsx
@@ -6,7 +6,7 @@ import {
   Button,
   Slide,
 } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   collection,
   getFirestore,
@@ -20,6 +20,7 @@ import {
 } from "firebase/firestore";
 import { NodeChange } from "@components/types/INode";
 import { NODES_LOGS } from "@components/lib/firestoreClient/collections";
+import { groupActivityLogs } from "@components/lib/utils/groupActivityLogs";
 import { RiveComponentMemoized } from "../Common/RiveComponentExtended";
 import ActivityDetails from "./ActivityDetails";
 
@@ -380,6 +381,9 @@ const NodeActivity = ({
     }
   };
 
+  // Pull child logs out of the top-level feed and hand them to their parent
+  const grouped = useMemo(() => groupActivityLogs(logs), [logs]);
+
   if (loading) {
     return <LoadingState />;
   }
@@ -439,7 +443,7 @@ const NodeActivity = ({
 
       <>
         {logs.length > 0 &&
-          logs.map((log) => (
+          grouped.items.map((log) => (
             <Slide key={log.id} direction="down" in={true} timeout={900}>
               <Box>
                 <ActivityDetails
@@ -449,6 +453,7 @@ const NodeActivity = ({
                   modifiedByDetails={activeUsers[log.modifiedBy]}
                   selectedDiffNode={selectedDiffNode}
                   nodes={nodes}
+                  childActivities={grouped.childrenByParent.get(log.id)}
                 />
               </Box>
             </Slide>

--- a/src/components/ActiveUsers/NodeActivity.tsx
+++ b/src/components/ActiveUsers/NodeActivity.tsx
@@ -1,6 +1,6 @@
 import { Box, CircularProgress, Typography, Button } from "@mui/material";
 import { keyframes } from "@mui/system";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   collection,
   getFirestore,
@@ -15,6 +15,7 @@ import {
 import { NodeChange } from "@components/types/INode";
 import { NODES_LOGS } from "@components/lib/firestoreClient/collections";
 import { SCROLL_BAR_STYLE } from "@components/lib/CONSTANTS";
+import { groupActivityLogs } from "@components/lib/utils/groupActivityLogs";
 import ActivityDetails from "./ActivityDetails";
 
 const floatTimelineCard = keyframes`
@@ -150,6 +151,9 @@ const NodeActivity = ({
       setLoadingMore(false);
     }
   };
+
+  // Pull child logs out of the top-level feed and add them to their parent
+  const grouped = useMemo(() => groupActivityLogs(logs), [logs]);
 
   if (loading) {
     return (
@@ -341,7 +345,7 @@ const NodeActivity = ({
 
       {logs.length > 0 && (
         <>
-          {logs.map((log: NodeChange & { id: string }) => (
+          {grouped.items.map((log: NodeChange & { id: string }) => (
             <ActivityDetails
               key={log.id}
               activity={log}
@@ -349,6 +353,7 @@ const NodeActivity = ({
               modifiedByDetails={activeUsers[log.modifiedBy]}
               selectedDiffNode={selectedDiffNode}
               nodes={nodes}
+              childActivities={grouped.childrenByParent.get(log.id)}
             />
           ))}
 

--- a/src/components/ActiveUsers/UserActivity.tsx
+++ b/src/components/ActiveUsers/UserActivity.tsx
@@ -7,7 +7,7 @@ import {
   Typography,
   Pagination,
 } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   collection,
   doc,
@@ -23,6 +23,7 @@ import {
 import { NodeChange } from "@components/types/INode";
 import { NODES_LOGS } from "@components/lib/firestoreClient/collections";
 import { getChangeDescription } from "@components/lib/utils/helpers";
+import { groupActivityLogs } from "@components/lib/utils/groupActivityLogs";
 import { RiveComponentMemoized } from "../Common/RiveComponentExtended";
 import { SCROLL_BAR_STYLE } from "@components/lib/CONSTANTS";
 import ActivityDetails from "./ActivityDetails";
@@ -127,6 +128,9 @@ const UserActivity = ({
     }
   };
 
+  // Pull child logs out of the top-level feed and hand them to their parent
+  const grouped = useMemo(() => groupActivityLogs(logs), [logs]);
+
   if (loading) {
     return (
       <Box
@@ -186,13 +190,14 @@ const UserActivity = ({
 
       {logs.length > 0 && (
         <>
-          {logs.map((log) => (
+          {grouped.items.map((log) => (
             <ActivityDetails
               key={log.id}
               activity={log}
               displayDiff={displayDiff}
               selectedDiffNode={selectedDiffNode}
               nodes={nodes}
+              childActivities={grouped.childrenByParent.get(log.id)}
             />
           ))}
 

--- a/src/components/LinkNode/LinkNode.tsx
+++ b/src/components/LinkNode/LinkNode.tsx
@@ -65,7 +65,7 @@ In this example, `ChildNode` is used to display a child node with the given prop
 - Error handling is implemented in the `deleteSubOntologyEditable` function, but it is important to ensure that proper error handling is in place throughout the application.
 - The component does not directly mutate the state but uses provided functions to handle state changes, ensuring a unidirectional data flow.
  */
-import { NODES } from "@components/lib/firestoreClient/collections";
+import { NODES, NODES_LOGS } from "@components/lib/firestoreClient/collections";
 import useConfirmDialog from "@components/lib/hooks/useConfirmDialog";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 import AddIcon from "@mui/icons-material/Add";
@@ -86,6 +86,7 @@ import {
   INodePath,
   ILinkNode,
   ICollection,
+  NodeChange,
 } from "@components/types/INode";
 import {
   Box,
@@ -242,6 +243,14 @@ const LinkNode = ({
     type: "specializations" | "generalizations",
     removeNodeId: string,
     removeIdFrom: string,
+    parentLog?: {
+      logId: string;
+      nodeId: string;
+      nodeTitle: string;
+      changeType: NodeChange["changeType"];
+    },
+    uname?: string,
+    childAppName?: string,
   ) => {
     const specOrGenDoc = await getDoc(doc(collection(db, NODES), removeIdFrom));
     let removeFrom: "specializations" | "generalizations" = "specializations";
@@ -251,6 +260,9 @@ const LinkNode = ({
     }
     if (specOrGenDoc.exists()) {
       const specOrGenData = specOrGenDoc.data() as INode;
+      const previousValue = JSON.parse(
+        JSON.stringify(specOrGenData[removeFrom]),
+      );
       for (let collection of specOrGenData[removeFrom]) {
         collection.nodes = collection.nodes.filter(
           (c: { id: string }) => c.id !== removeNodeId,
@@ -260,6 +272,21 @@ const LinkNode = ({
       await updateDoc(specOrGenDoc.ref, {
         [`${removeFrom}`]: specOrGenData[removeFrom],
       });
+
+      if (parentLog && uname) {
+        saveNewChangeLog(db, {
+          nodeId: removeIdFrom,
+          modifiedBy: uname,
+          modifiedProperty: removeFrom,
+          previousValue,
+          newValue: specOrGenData[removeFrom],
+          modifiedAt: new Date(),
+          changeType: "remove element",
+          fullNode: specOrGenData,
+          triggeredBy: parentLog,
+          ...(childAppName ? { appName: childAppName } : {}),
+        });
+      }
     }
   };
 
@@ -391,6 +418,13 @@ const LinkNode = ({
         );
         if (nodeDoc.exists()) {
           const nodeData = nodeDoc.data() as INode;
+          const parentLogId = doc(collection(db, NODES_LOGS)).id;
+          const parentLog = {
+            logId: parentLogId,
+            nodeId: currentVisibleNode?.id,
+            nodeTitle: nodeData.title ?? "",
+            changeType: "remove element" as const,
+          };
           const previousValue = JSON.parse(
             JSON.stringify(
               nodeData[property as "specializations" | "generalizations"],
@@ -415,6 +449,9 @@ const LinkNode = ({
               property as "specializations" | "generalizations",
               currentVisibleNode?.id,
               linkId,
+              parentLog,
+              user?.uname,
+              appName,
             );
           }
           if (shouldBeRemovedFromParent && linkNode && !linkNode.nodeType) {
@@ -521,18 +558,22 @@ const LinkNode = ({
             }
           }
 
-          saveNewChangeLog(db, {
-            nodeId: currentVisibleNode?.id,
-            modifiedBy: user?.uname,
-            modifiedProperty: property,
-            previousValue,
-            newValue:
-              nodeData[property as "specializations" | "generalizations"],
-            modifiedAt: new Date(),
-            changeType: "remove element",
-            fullNode: currentVisibleNode,
-            ...(appName ? { appName } : {}),
-          });
+          saveNewChangeLog(
+            db,
+            {
+              nodeId: currentVisibleNode?.id,
+              modifiedBy: user?.uname,
+              modifiedProperty: property,
+              previousValue,
+              newValue:
+                nodeData[property as "specializations" | "generalizations"],
+              modifiedAt: new Date(),
+              changeType: "remove element",
+              fullNode: currentVisibleNode,
+              ...(appName ? { appName } : {}),
+            },
+            parentLogId,
+          );
 
           // Instant tree update for local user
           if (onInstantTreeUpdate) {
@@ -568,7 +609,10 @@ const LinkNode = ({
               relatedNodes,
             );
           }
-          if (property === "specializations" || property === "generalizations") {
+          if (
+            property === "specializations" ||
+            property === "generalizations"
+          ) {
             await triggerUpdateDerivedPaths([currentVisibleNode.id, linkId]);
           }
         }

--- a/src/components/OntologyComponents/Node.tsx
+++ b/src/components/OntologyComponents/Node.tsx
@@ -101,7 +101,10 @@ import {
   INodeTypes,
   MainSpecializations,
 } from "@components/types/INode";
-import { NODES } from "@components/lib/firestoreClient/collections";
+import {
+  NODES,
+  NODES_LOGS,
+} from "@components/lib/firestoreClient/collections";
 import NodeBody from "../NodBody/NodeBody";
 import NodeCompass from "../NodBody/NodeCompass";
 
@@ -1143,8 +1146,24 @@ const Node = ({
           return;
         }
 
+        const parentLogId = doc(collection(db, NODES_LOGS)).id;
+        const parentLog = {
+          logId: parentLogId,
+          nodeId,
+          nodeTitle: nodeData.title ?? "",
+          changeType: "modify elements" as const,
+        };
+
         for (let linkId of removedElements) {
-          await unlinkPropertyOf(db, selectedProperty, nodeId, linkId);
+          await unlinkPropertyOf(
+            db,
+            selectedProperty,
+            nodeId,
+            linkId,
+            parentLog,
+            user?.uname,
+            appName,
+          );
         }
 
         // Update links for specializations/generalizations
@@ -1160,6 +1179,9 @@ const Node = ({
               : "specializations",
             relatedNodes,
             db,
+            parentLog,
+            user?.uname,
+            appName,
           );
           nodeData[selectedProperty] = newValue;
         } else {
@@ -1323,17 +1345,21 @@ const Node = ({
           });
         }
 
-        saveNewChangeLog(db, {
-          nodeId: nodeId,
-          modifiedBy: user?.uname,
-          modifiedProperty: selectedProperty,
-          previousValue,
-          newValue: newValue,
-          modifiedAt: new Date(),
-          changeType: "modify elements",
-          fullNode: nodeData,
-          ...(appName ? { appName } : {}),
-        });
+        saveNewChangeLog(
+          db,
+          {
+            nodeId: nodeId,
+            modifiedBy: user?.uname,
+            modifiedProperty: selectedProperty,
+            previousValue,
+            newValue: newValue,
+            modifiedAt: new Date(),
+            changeType: "modify elements",
+            fullNode: nodeData,
+            ...(appName ? { appName } : {}),
+          },
+          parentLogId,
+        );
 
         // Instant tree update for local user
         if (onInstantTreeUpdate) {

--- a/src/components/OntologyComponents/Node.tsx
+++ b/src/components/OntologyComponents/Node.tsx
@@ -1842,18 +1842,20 @@ const Node = ({
               onInstantTreeUpdate={onInstantTreeUpdate}
             />
 
-            {/* compass: focused single-node radial graph */}
-            <NodeCompass
-              currentVisibleNode={currentVisibleNode}
-              relatedNodes={relatedNodes}
-              navigateToNode={navigateToNode}
-              requireModifierToZoom
-              onOpenInNavigator={
-                onOpenInNavigator
-                  ? () => onOpenInNavigator(currentVisibleNode.id)
-                  : undefined
-              }
-            />
+            {/* hidden in diff view */}
+            {!selectedDiffNode && (
+              <NodeCompass
+                currentVisibleNode={currentVisibleNode}
+                relatedNodes={relatedNodes}
+                navigateToNode={navigateToNode}
+                requireModifierToZoom
+                onOpenInNavigator={
+                  onOpenInNavigator
+                    ? () => onOpenInNavigator(currentVisibleNode.id)
+                    : undefined
+                }
+              />
+            )}
 
             {/* actors of the node if it's exist */}
             {currentVisibleNode?.properties.hasOwnProperty("actor") && (

--- a/src/components/Sidebar/ToolbarSidebar.tsx
+++ b/src/components/Sidebar/ToolbarSidebar.tsx
@@ -987,7 +987,21 @@ const ToolbarSidebar = ({
       ? data.fullNode?.propertyType[data.modifiedProperty]
       : "";
 
-    if (
+    // Records written after the diffValue pipeline shipped already carry the
+    // pre-computed diff (see `computeDiffValue` in `src/lib/utils/diffValue.ts`),
+    // so the UI skips the recomputation entirely and just hands the stored
+    // `diffValue` to the renderer through the same `detailsOfChange.comparison`
+    // contract the legacy path uses. The `fromDiffValue` marker lets the
+    // renderer indicate visually that no UI-side diffing happened.
+    //
+    // Only legacy records lacking `diffValue` fall through to the in-place
+    // diff via the helper functions.
+    if (data.diffValue) {
+      data.detailsOfChange = {
+        comparison: data.diffValue,
+        fromDiffValue: true,
+      };
+    } else if (
       (modified_property_type ||
         data.modifiedProperty === "isPartOf" ||
         data.modifiedProperty === "parts" ||
@@ -1021,6 +1035,8 @@ const ToolbarSidebar = ({
       if (targetProperty) {
         let firstChangedNodeId = null;
 
+        // `detailsOfChange.comparison` is set above for both pipelines —
+        // pre-computed `diffValue` (new) or freshly diffed (legacy).
         if (data.detailsOfChange?.comparison) {
           for (const collection of data.detailsOfChange.comparison) {
             const changedNode = collection.nodes.find(

--- a/src/components/Sidebar/ToolbarSidebar.tsx
+++ b/src/components/Sidebar/ToolbarSidebar.tsx
@@ -987,15 +987,7 @@ const ToolbarSidebar = ({
       ? data.fullNode?.propertyType[data.modifiedProperty]
       : "";
 
-    // Records written after the diffValue pipeline shipped already carry the
-    // pre-computed diff (see `computeDiffValue` in `src/lib/utils/diffValue.ts`),
-    // so the UI skips the recomputation entirely and just hands the stored
-    // `diffValue` to the renderer through the same `detailsOfChange.comparison`
-    // contract the legacy path uses. The `fromDiffValue` marker lets the
-    // renderer indicate visually that no UI-side diffing happened.
-    //
-    // Only legacy records lacking `diffValue` fall through to the in-place
-    // diff via the helper functions.
+    // Fast path: stored `diffValue` skips the UI-side diff entirely.
     if (data.diffValue) {
       data.detailsOfChange = {
         comparison: data.diffValue,
@@ -1035,8 +1027,6 @@ const ToolbarSidebar = ({
       if (targetProperty) {
         let firstChangedNodeId = null;
 
-        // `detailsOfChange.comparison` is set above for both pipelines —
-        // pre-computed `diffValue` (new) or freshly diffed (legacy).
         if (data.detailsOfChange?.comparison) {
           for (const collection of data.detailsOfChange.comparison) {
             const changedNode = collection.nodes.find(

--- a/src/components/Sidebar/ToolbarSidebar.tsx
+++ b/src/components/Sidebar/ToolbarSidebar.tsx
@@ -991,7 +991,6 @@ const ToolbarSidebar = ({
     if (data.diffValue) {
       data.detailsOfChange = {
         comparison: data.diffValue,
-        fromDiffValue: true,
       };
     } else if (
       (modified_property_type ||

--- a/src/components/StructuredProperty/CollectionStructure.tsx
+++ b/src/components/StructuredProperty/CollectionStructure.tsx
@@ -42,7 +42,10 @@ import {
   getFirestore,
   updateDoc,
 } from "firebase/firestore";
-import { NODES } from "@components/lib/firestoreClient/collections";
+import {
+  NODES,
+  NODES_LOGS,
+} from "@components/lib/firestoreClient/collections";
 import {
   DndContext,
   DragOverlay,
@@ -907,22 +910,56 @@ const CollectionStructure = ({
           return next;
         });
 
-        saveNewChangeLog(db, {
+        // Snapshot currentNode's specializations before / after the nodeBId
+        // removal so the parent log carries an actual element-level diff.
+        // `unlinkPropertyOf` above only mutates Firestore — the local
+        // `currentVisibleNode` object is untouched — so deriving here matches
+        // the on-write state. We deliberately do NOT use the `propertyValue`
+        // prop because that has been run through `processCollectionData` in
+        // StructuredProperty.tsx (pagination, `allNodes` / `loadedCount`
+        // annotations) and isn't a clean ICollection[] shape for
+        // `computeDiffValue`.
+        //
+        // Shallow rebuild: `.map` creates new collection wrappers and
+        // `.filter` returns a new nodes array, so nothing in
+        // `currentVisibleNode` is mutated. ILinkNode objects are shared but
+        // never mutated downstream (codebase invariant — every spec/gen
+        // write site assigns a new array or pushes onto one, never touches
+        // existing link objects).
+        const previousSpecializations: ICollection[] =
+          currentVisibleNode.specializations || [];
+        const newSpecializations: ICollection[] = previousSpecializations.map(
+          (col) => ({
+            ...col,
+            nodes: col.nodes.filter((n: ILinkNode) => n.id !== nodeBId),
+          }),
+        );
+
+        // Reserve a parent-log id up-front so the child log on nodeB can
+        // stamp `triggeredBy.logId` referencing the same doc that the parent
+        // log below will write to. Mirrors the pattern used in
+        // `handleSaveLinkChanges` (Node.tsx) and
+        // `unlinkSpecializationOrGeneralization` (LinkNode.tsx).
+        //
+        // Note: we deliberately do NOT thread `parentLog` into the
+        // `unlinkPropertyOf` call above. That call's effect *is* the parent
+        // mutation (currentNode losing nodeB from specializations), so its
+        // child-log emission would duplicate the explicit parent log here.
+        const parentLogId = doc(collection(db, NODES_LOGS)).id;
+        const parentLog = {
+          logId: parentLogId,
           nodeId: currentNodeId,
-          modifiedBy: user.uname,
-          modifiedProperty: "specializations",
-          previousValue: propertyValue,
-          newValue: null,
-          modifiedAt: new Date(),
-          changeType: "modify elements",
-          changeDetails: {
-            action: "nest-specialization",
-            movedNode: nodeBId,
-            newParent: nodeAId,
-          },
-          fullNode: currentVisibleNode,
-          ...(appName ? { appName } : {}),
-        });
+          nodeTitle: currentVisibleNode.title ?? "",
+          changeType: "modify elements" as const,
+        };
+
+        // Child log first, parent second — matches the codebase convention
+        // (helpers `unlinkPropertyOf` / `updateLinks` / `removeNodeLink` all
+        // write children before the orchestrator writes the parent). With
+        // `modifiedAt: new Date()` captured per call, this ensures the
+        // parent ends up with the later timestamp, so DESC-by-modifiedAt
+        // queries (UserActivity, NodeActivity, HistoryTab) place the parent
+        // above its children.
         saveNewChangeLog(db, {
           nodeId: nodeBId,
           modifiedBy: user.uname,
@@ -938,7 +975,28 @@ const CollectionStructure = ({
           },
           fullNode: nodeBData,
           ...(appName ? { appName } : {}),
+          triggeredBy: parentLog,
         });
+        saveNewChangeLog(
+          db,
+          {
+            nodeId: currentNodeId,
+            modifiedBy: user.uname,
+            modifiedProperty: "specializations",
+            previousValue: previousSpecializations,
+            newValue: newSpecializations,
+            modifiedAt: new Date(),
+            changeType: "modify elements",
+            changeDetails: {
+              action: "nest-specialization",
+              movedNode: nodeBId,
+              newParent: nodeAId,
+            },
+            fullNode: currentVisibleNode,
+            ...(appName ? { appName } : {}),
+          },
+          parentLogId,
+        );
 
         // Instant tree update: move nodeBId from currentNode's subtree to nodeA's subtree
         if (onInstantTreeUpdate) {

--- a/src/components/StructuredProperty/CollectionStructure.tsx
+++ b/src/components/StructuredProperty/CollectionStructure.tsx
@@ -953,30 +953,6 @@ const CollectionStructure = ({
           changeType: "modify elements" as const,
         };
 
-        // Child log first, parent second — matches the codebase convention
-        // (helpers `unlinkPropertyOf` / `updateLinks` / `removeNodeLink` all
-        // write children before the orchestrator writes the parent). With
-        // `modifiedAt: new Date()` captured per call, this ensures the
-        // parent ends up with the later timestamp, so DESC-by-modifiedAt
-        // queries (UserActivity, NodeActivity, HistoryTab) place the parent
-        // above its children.
-        saveNewChangeLog(db, {
-          nodeId: nodeBId,
-          modifiedBy: user.uname,
-          modifiedProperty: "generalizations",
-          previousValue: nodeBData.generalizations,
-          newValue: nodeBGeneralizations,
-          modifiedAt: new Date(),
-          changeType: "modify elements",
-          changeDetails: {
-            action: "nest-specialization",
-            removedParent: currentNodeId,
-            newParent: nodeAId,
-          },
-          fullNode: nodeBData,
-          ...(appName ? { appName } : {}),
-          triggeredBy: parentLog,
-        });
         saveNewChangeLog(
           db,
           {
@@ -997,6 +973,23 @@ const CollectionStructure = ({
           },
           parentLogId,
         );
+        saveNewChangeLog(db, {
+          nodeId: nodeBId,
+          modifiedBy: user.uname,
+          modifiedProperty: "generalizations",
+          previousValue: nodeBData.generalizations,
+          newValue: nodeBGeneralizations,
+          modifiedAt: new Date(),
+          changeType: "modify elements",
+          changeDetails: {
+            action: "nest-specialization",
+            removedParent: currentNodeId,
+            newParent: nodeAId,
+          },
+          fullNode: nodeBData,
+          ...(appName ? { appName } : {}),
+          triggeredBy: parentLog,
+        });
 
         // Instant tree update: move nodeBId from currentNode's subtree to nodeA's subtree
         if (onInstantTreeUpdate) {

--- a/src/components/StructuredProperty/CollectionStructure.tsx
+++ b/src/components/StructuredProperty/CollectionStructure.tsx
@@ -910,22 +910,8 @@ const CollectionStructure = ({
           return next;
         });
 
-        // Snapshot currentNode's specializations before / after the nodeBId
-        // removal so the parent log carries an actual element-level diff.
-        // `unlinkPropertyOf` above only mutates Firestore — the local
-        // `currentVisibleNode` object is untouched — so deriving here matches
-        // the on-write state. We deliberately do NOT use the `propertyValue`
-        // prop because that has been run through `processCollectionData` in
-        // StructuredProperty.tsx (pagination, `allNodes` / `loadedCount`
-        // annotations) and isn't a clean ICollection[] shape for
-        // `computeDiffValue`.
-        //
-        // Shallow rebuild: `.map` creates new collection wrappers and
-        // `.filter` returns a new nodes array, so nothing in
-        // `currentVisibleNode` is mutated. ILinkNode objects are shared but
-        // never mutated downstream (codebase invariant — every spec/gen
-        // write site assigns a new array or pushes onto one, never touches
-        // existing link objects).
+        // Snapshot specializations before/after nodeBId removal — `unlinkPropertyOf`
+        // above mutated Firestore but not `currentVisibleNode` locally.
         const previousSpecializations: ICollection[] =
           currentVisibleNode.specializations || [];
         const newSpecializations: ICollection[] = previousSpecializations.map(
@@ -935,16 +921,9 @@ const CollectionStructure = ({
           }),
         );
 
-        // Reserve a parent-log id up-front so the child log on nodeB can
-        // stamp `triggeredBy.logId` referencing the same doc that the parent
-        // log below will write to. Mirrors the pattern used in
-        // `handleSaveLinkChanges` (Node.tsx) and
-        // `unlinkSpecializationOrGeneralization` (LinkNode.tsx).
-        //
-        // Note: we deliberately do NOT thread `parentLog` into the
-        // `unlinkPropertyOf` call above. That call's effect *is* the parent
-        // mutation (currentNode losing nodeB from specializations), so its
-        // child-log emission would duplicate the explicit parent log here.
+        // Reserve a parent-log id so the child log on nodeB can reference it via
+        // `triggeredBy.logId`. Not passed to `unlinkPropertyOf` above because that
+        // call is itself part of the parent mutation.
         const parentLogId = doc(collection(db, NODES_LOGS)).id;
         const parentLog = {
           logId: parentLogId,

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -1239,6 +1239,14 @@ const StructuredProperty = ({
               : "2px solid orange",
         }}
       >
+        {/*
+         * Single rendering path. `displayDiff` ensures
+         * `detailsOfChange.comparison` is populated for both pipelines —
+         * the pre-computed `diffValue` (new) or the in-place
+         * `diffCollections` recompute (legacy). The `fromDiffValue` flag on
+         * `detailsOfChange` lets `VisualizeTheProperty` indicate visually
+         * which pipeline the data came from.
+         */}
         <VisualizeTheProperty
           currentImprovement={selectedDiffNode || currentImprovement}
           property={property}

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -1239,14 +1239,7 @@ const StructuredProperty = ({
               : "2px solid orange",
         }}
       >
-        {/*
-         * Single rendering path. `displayDiff` ensures
-         * `detailsOfChange.comparison` is populated for both pipelines —
-         * the pre-computed `diffValue` (new) or the in-place
-         * `diffCollections` recompute (legacy). The `fromDiffValue` flag on
-         * `detailsOfChange` lets `VisualizeTheProperty` indicate visually
-         * which pipeline the data came from.
-         */}
+        {/* Both pipelines feed `detailsOfChange.comparison`; `fromDiffValue` flags the new path. */}
         <VisualizeTheProperty
           currentImprovement={selectedDiffNode || currentImprovement}
           property={property}

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -1239,7 +1239,6 @@ const StructuredProperty = ({
               : "2px solid orange",
         }}
       >
-        {/* Both pipelines feed `detailsOfChange.comparison`; `fromDiffValue` flags the new path. */}
         <VisualizeTheProperty
           currentImprovement={selectedDiffNode || currentImprovement}
           property={property}

--- a/src/components/StructuredProperty/VisualizeTheProperty.tsx
+++ b/src/components/StructuredProperty/VisualizeTheProperty.tsx
@@ -240,6 +240,18 @@ const VisualizeTheProperty: React.FC<CollectionListProps> = ({
             )}
           </Typography>
         </Tooltip>
+        {currentImprovement?.detailsOfChange?.fromDiffValue && (
+          <Typography
+            sx={{
+              ml: 2,
+              fontSize: "14px",
+              fontStyle: "italic",
+              color: "lightblue",
+            }}
+          >
+            (coming from diff)
+          </Typography>
+        )}
       </Box>
       {renderValue(currentImprovement.detailsOfChange?.comparison || [])}
     </Box>

--- a/src/components/StructuredProperty/VisualizeTheProperty.tsx
+++ b/src/components/StructuredProperty/VisualizeTheProperty.tsx
@@ -10,6 +10,8 @@ import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
 import AddIcon from "@mui/icons-material/Add";
 import RemoveIcon from "@mui/icons-material/Remove";
 import FiberManualRecordIcon from "@mui/icons-material/FiberManualRecord";
+import ToggleOnIcon from "@mui/icons-material/ToggleOn";
+import ToggleOffIcon from "@mui/icons-material/ToggleOff";
 
 type CollectionListProps = {
   currentImprovement: any;
@@ -139,6 +141,14 @@ const VisualizeTheProperty: React.FC<CollectionListProps> = ({
                         fontSize: "27px",
                       }}
                     />
+                  ) : node.optionalChange === "added" ? (
+                    <ToggleOnIcon
+                      sx={{ color: "green", mr: "3px", fontSize: "27px" }}
+                    />
+                  ) : node.optionalChange === "removed" ? (
+                    <ToggleOffIcon
+                      sx={{ color: "red", mr: "3px", fontSize: "27px" }}
+                    />
                   ) : (
                     <FiberManualRecordIcon
                       sx={{
@@ -170,10 +180,31 @@ const VisualizeTheProperty: React.FC<CollectionListProps> = ({
                     {node.title || getTitle(nodes, node.id)}
                   </Typography>
 
-                  {node.optional && (
-                    <Tooltip title={"optional"} placement="top">
+                  {(node.optional || node.optionalChange === "removed") && (
+                    <Tooltip
+                      title={
+                        node.optionalChange === "added"
+                          ? "marked optional"
+                          : node.optionalChange === "removed"
+                            ? "no longer optional"
+                            : "optional"
+                      }
+                      placement="top"
+                    >
                       <Typography
-                        sx={{ color: "orange", marginLeft: "9px" }}
+                        sx={{
+                          color:
+                            node.optionalChange === "added"
+                              ? "green"
+                              : node.optionalChange === "removed"
+                                ? "red"
+                                : "orange",
+                          textDecoration:
+                            node.optionalChange === "removed"
+                              ? "line-through"
+                              : "",
+                          marginLeft: "9px",
+                        }}
                       >{`(O)`}</Typography>
                     </Tooltip>
                   )}

--- a/src/components/StructuredProperty/VisualizeTheProperty.tsx
+++ b/src/components/StructuredProperty/VisualizeTheProperty.tsx
@@ -271,18 +271,6 @@ const VisualizeTheProperty: React.FC<CollectionListProps> = ({
             )}
           </Typography>
         </Tooltip>
-        {currentImprovement?.detailsOfChange?.fromDiffValue && (
-          <Typography
-            sx={{
-              ml: 2,
-              fontSize: "14px",
-              fontStyle: "italic",
-              color: "lightblue",
-            }}
-          >
-            (coming from diff)
-          </Typography>
-        )}
       </Box>
       {renderValue(currentImprovement.detailsOfChange?.comparison || [])}
     </Box>

--- a/src/lib/utils/diffValue.ts
+++ b/src/lib/utils/diffValue.ts
@@ -1,23 +1,9 @@
 /**
- * Producer for `NodeChange.diffValue` — the pre-computed, ready-to-render
- * representation of a collection-typed change. Computed at write time inside
- * `saveNewChangeLog` so the UI never has to re-diff or resolve titles when
- * displaying history.
- *
- * Returns `null` for changeTypes that have no collection diff representation
- * (`change text`, `add images`, `add property`, `add node`, `delete node`,
- * etc.). Callers should treat `null` as "no diffValue field on this record"
- * and the UI falls back to its legacy rendering path.
- *
- * Title resolution is purely local — every `ILinkNode` inside
- * `previousValue` / `newValue` is expected to carry its `title` (set by
- * whichever caller wrote the link into the live document). The producer
- * never reaches outside the `NodeChange` to fetch titles, so the function
- * stays synchronous and historical entries render correctly even after a
- * node is renamed or unloaded from the local cache.
- *
- * Mirrors the runtime behaviour of `diffCollections` / `diffSortedCollections`
- * in `helpers.ts`, but emits the typed `DiffCollection[]` shape.
+ * Computes `NodeChange.diffValue` at write time so the UI never re-diffs.
+ * Returns `null` for non-collection changeTypes (caller falls back to the
+ * legacy render path). Titles are read off `ILinkNode.title` on the change —
+ * never fetched — so the function stays synchronous and historical entries
+ * are stable across renames.
  */
 
 import {
@@ -27,12 +13,7 @@ import {
   NodeChange,
 } from "@components/types/INode";
 
-/**
- * `NodeChange.changeType` values that produce a `diffValue`. All other
- * changeTypes (text edits, image add/remove, schema changes, node create/
- * delete, etc.) are renderable directly from `previousValue` / `newValue` and
- * carry no `diffValue`.
- */
+/** `NodeChange.changeType` values that produce a `diffValue`. */
 const COLLECTION_CHANGE_TYPES: ReadonlySet<NodeChange["changeType"]> = new Set([
   "add element",
   "remove element",
@@ -62,10 +43,6 @@ export const computeDiffValue = (
     : diffCollectionContents(previous, next);
 };
 
-// ---------------------------------------------------------------------------
-// Internals
-// ---------------------------------------------------------------------------
-
 const asCollections = (value: any): ICollection[] | null => {
   if (!Array.isArray(value)) return null;
   for (const v of value) {
@@ -81,13 +58,7 @@ const asCollections = (value: any): ICollection[] | null => {
   return value as ICollection[];
 };
 
-/**
- * Build a `DiffLinkNode` from a source `ILinkNode` carried inside
- * `previousValue` / `newValue`. The source's `title` is taken verbatim — it
- * is the snapshot at edit time, set by whichever caller wrote the link into
- * the live document. If `title` is missing, we fall back to the empty
- * string rather than throwing.
- */
+/** Build a `DiffLinkNode` from a source `ILinkNode`, snapshotting its title. */
 const buildDiffNode = (
   id: string,
   source: { title?: string; optional?: boolean },
@@ -140,10 +111,7 @@ const diffCollectionContents = (
     const newNodes = new Map((newCollection?.nodes || []).map((n) => [n.id, n]));
     const ids = new Set<string>([...oldNodes.keys(), ...newNodes.keys()]);
 
-    // Detect within-collection reorders: of the IDs present in BOTH sides of
-    // this collection, anything not in their LCS is one of the items that
-    // actually moved relative to the others. Skipped when the collection only
-    // exists on one side — there's no order to compare.
+    // Within-collection reorders: IDs missing from `stableIds` are the ones that moved.
     let stableIds: Set<string> = new Set();
     if (oldCollection && newCollection) {
       const sharedOldOrder = oldCollection.nodes
@@ -178,12 +146,7 @@ const diffCollectionContents = (
           }),
         );
       } else {
-        // Node is in both old and new of the same collection. Two annotations
-        // can fire here, independently and orthogonally:
-        //   * `sort` — moved relative to the other shared nodes (LCS-minimal).
-        //   * `optionalChange` — the `optional` boolean flipped, e.g. the
-        //     toggle-optional path in InheritedPartsViewerEdit.tsx that logs
-        //     a `modify elements` change differing only on this boolean.
+        // In both sides — annotate `sort` if reordered, `optionalChange` if the flag flipped.
         const oldOptional = !!oldNodes.get(id)?.optional;
         const newOptional = !!newNodes.get(id)?.optional;
         const optionalChange =
@@ -232,12 +195,7 @@ const diffCollectionContents = (
   return result;
 };
 
-/**
- * Mirrors `diffSortedCollections` for the `sort collections` changeType
- * (reordering of containers). Stable collections are kept in place; moved
- * ones get `changeType: "sort"` plus an `added`/`removed` pair at the new and
- * old positions.
- */
+/** Diff for the `sort collections` changeType (container reordering). */
 const diffSortedCollections = (
   oldValue: ICollection[],
   newValue: ICollection[],
@@ -292,15 +250,7 @@ const lcsCollectionNames = (
   );
 
 /**
- * Generic LCS: returns the set of values that appear in the longest common
- * subsequence of `a` and `b`. Used for two purposes:
- *   1. Finding stable collections during `sort collections` diffs.
- *   2. Finding stable nodes inside a collection during within-collection
- *      reorder detection.
- *
- * Tiebreaker (when `dp[i-1][j] === dp[i][j-1]` we move `i--`) matches
- * `findLcsNames` in helpers.ts:1599-1637 so emitted diffs stay byte-identical
- * to the legacy renderer's behaviour for the existing `sort collections` case.
+ * Returns values that appear in the same relative order in both `a` and `b`, the items that didn't move. 
  */
 const longestCommonSubsequence = <T>(a: T[], b: T[]): Set<T> => {
   const m = a.length;

--- a/src/lib/utils/diffValue.ts
+++ b/src/lib/utils/diffValue.ts
@@ -1,0 +1,272 @@
+/**
+ * Producer for `NodeChange.diffValue` — the pre-computed, ready-to-render
+ * representation of a collection-typed change. Computed at write time inside
+ * `saveNewChangeLog` so the UI never has to re-diff or resolve titles when
+ * displaying history.
+ *
+ * Returns `null` for changeTypes that have no collection diff representation
+ * (`change text`, `add images`, `add property`, `add node`, `delete node`,
+ * etc.). Callers should treat `null` as "no diffValue field on this record"
+ * and the UI falls back to its legacy rendering path.
+ *
+ * Title resolution is purely local — every `ILinkNode` inside
+ * `previousValue` / `newValue` is expected to carry its `title` (set by
+ * whichever caller wrote the link into the live document). The producer
+ * never reaches outside the `NodeChange` to fetch titles, so the function
+ * stays synchronous and historical entries render correctly even after a
+ * node is renamed or unloaded from the local cache.
+ *
+ * Mirrors the runtime behaviour of `diffCollections` / `diffSortedCollections`
+ * in `helpers.ts`, but emits the typed `DiffCollection[]` shape.
+ */
+
+import {
+  DiffCollection,
+  DiffLinkNode,
+  ICollection,
+  NodeChange,
+} from "@components/types/INode";
+
+/**
+ * `NodeChange.changeType` values that produce a `diffValue`. All other
+ * changeTypes (text edits, image add/remove, schema changes, node create/
+ * delete, etc.) are renderable directly from `previousValue` / `newValue` and
+ * carry no `diffValue`.
+ */
+const COLLECTION_CHANGE_TYPES: ReadonlySet<NodeChange["changeType"]> = new Set([
+  "add element",
+  "remove element",
+  "add elements",
+  "remove elements",
+  "modify elements",
+  "sort elements",
+  "add collection",
+  "delete collection",
+  "sort collections",
+]);
+
+export const hasDiffValue = (changeType: NodeChange["changeType"]): boolean =>
+  COLLECTION_CHANGE_TYPES.has(changeType);
+
+export const computeDiffValue = (
+  change: NodeChange,
+): DiffCollection[] | null => {
+  if (!hasDiffValue(change.changeType)) return null;
+
+  const previous = asCollections(change.previousValue);
+  const next = asCollections(change.newValue);
+  if (!previous || !next) return null;
+
+  return change.changeType === "sort collections"
+    ? diffSortedCollections(previous, next)
+    : diffCollectionContents(previous, next);
+};
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+const asCollections = (value: any): ICollection[] | null => {
+  if (!Array.isArray(value)) return null;
+  for (const v of value) {
+    if (
+      !v ||
+      typeof v !== "object" ||
+      typeof v.collectionName !== "string" ||
+      !Array.isArray(v.nodes)
+    ) {
+      return null;
+    }
+  }
+  return value as ICollection[];
+};
+
+/**
+ * Build a `DiffLinkNode` from a source `ILinkNode` carried inside
+ * `previousValue` / `newValue`. The source's `title` is taken verbatim — it
+ * is the snapshot at edit time, set by whichever caller wrote the link into
+ * the live document. If `title` is missing, we fall back to the empty
+ * string rather than throwing.
+ */
+const buildDiffNode = (
+  id: string,
+  source: { title?: string; optional?: boolean },
+  marker?: { change?: "added" | "removed"; sort?: boolean },
+): DiffLinkNode => {
+  const node: DiffLinkNode = { id, title: source.title || "" };
+  if (source.optional) node.optional = true;
+  if (marker?.change) node.change = marker.change;
+  if (marker?.sort) node.changeType = "sort";
+  return node;
+};
+
+/**
+ * Mirrors `diffCollections` in `helpers.ts` but emits `DiffCollection[]`.
+ * Used for everything except `sort collections`.
+ */
+const diffCollectionContents = (
+  oldValue: ICollection[],
+  newValue: ICollection[],
+): DiffCollection[] => {
+  const oldMap = new Map(oldValue.map((c) => [c.collectionName, c]));
+  const newMap = new Map(newValue.map((c) => [c.collectionName, c]));
+  const allCollectionNames = new Set([...oldMap.keys(), ...newMap.keys()]);
+
+  // Where each node lived on each side — used to detect cross-collection moves.
+  const oldNodeToCollection = new Map<string, string>();
+  for (const { collectionName, nodes } of oldValue) {
+    for (const n of nodes) oldNodeToCollection.set(n.id, collectionName);
+  }
+  const newNodeToCollection = new Map<string, string>();
+  for (const { collectionName, nodes } of newValue) {
+    for (const n of nodes) newNodeToCollection.set(n.id, collectionName);
+  }
+
+  const result: DiffCollection[] = [];
+
+  for (const collectionName of allCollectionNames) {
+    const oldCollection = oldMap.get(collectionName);
+    const newCollection = newMap.get(collectionName);
+
+    const isAddedCollection = !oldCollection && !!newCollection;
+    const isRemovedCollection = !!oldCollection && !newCollection;
+
+    const oldNodes = new Map((oldCollection?.nodes || []).map((n) => [n.id, n]));
+    const newNodes = new Map((newCollection?.nodes || []).map((n) => [n.id, n]));
+    const ids = new Set<string>([...oldNodes.keys(), ...newNodes.keys()]);
+
+    const merged: DiffLinkNode[] = [];
+    for (const id of ids) {
+      const inOld = oldNodes.has(id);
+      const inNew = newNodes.has(id);
+      const source = (newNodes.get(id) ?? oldNodes.get(id))!;
+
+      if (!inOld && inNew) {
+        const movedFrom = oldNodeToCollection.get(id);
+        merged.push(
+          buildDiffNode(id, source, {
+            change: "added",
+            sort: !!movedFrom && movedFrom !== collectionName,
+          }),
+        );
+      } else if (inOld && !inNew) {
+        const movedTo = newNodeToCollection.get(id);
+        merged.push(
+          buildDiffNode(id, source, {
+            change: "removed",
+            sort: !!movedTo && movedTo !== collectionName,
+          }),
+        );
+      } else {
+        merged.push(buildDiffNode(id, source));
+      }
+    }
+
+    // Order: nodes present in `new` first, in their new order; then leftovers
+    // (i.e. removed nodes) at the end, preserving their old relative order.
+    if (newCollection) {
+      const newOrder = newCollection.nodes.map((n) => n.id);
+      merged.sort((a, b) => {
+        const aIn = newNodes.has(a.id);
+        const bIn = newNodes.has(b.id);
+        if (aIn && bIn) return newOrder.indexOf(a.id) - newOrder.indexOf(b.id);
+        if (aIn && !bIn) return -1;
+        if (!aIn && bIn) return 1;
+        return 0;
+      });
+    }
+
+    const collection: DiffCollection = { collectionName, nodes: merged };
+    if (isAddedCollection) collection.change = "added";
+    else if (isRemovedCollection) collection.change = "removed";
+    result.push(collection);
+  }
+
+  return result;
+};
+
+/**
+ * Mirrors `diffSortedCollections` for the `sort collections` changeType
+ * (reordering of containers). Stable collections are kept in place; moved
+ * ones get `changeType: "sort"` plus an `added`/`removed` pair at the new and
+ * old positions.
+ */
+const diffSortedCollections = (
+  oldValue: ICollection[],
+  newValue: ICollection[],
+): DiffCollection[] => {
+  const oldOrder = new Map(oldValue.map((c, i) => [c.collectionName, i]));
+  const newMap = new Map(newValue.map((c) => [c.collectionName, c]));
+  const stable = lcsCollectionNames(oldValue, newValue);
+
+  const projectNodes = (nodes: ICollection["nodes"]): DiffLinkNode[] =>
+    nodes.map((n) => buildDiffNode(n.id, n));
+
+  const result: DiffCollection[] = newValue.map((newCol) => {
+    const isStable = stable.has(newCol.collectionName);
+    const wasInOld = oldOrder.has(newCol.collectionName);
+    const base: DiffCollection = {
+      collectionName: newCol.collectionName,
+      nodes: projectNodes(newCol.nodes),
+    };
+    if (isStable) return base;
+    if (wasInOld) return { ...base, changeType: "sort", change: "added" };
+    return { ...base, change: "added" };
+  });
+
+  // Splice removed/moved-source rows back in at their old indices, biggest
+  // index first so earlier indices stay valid.
+  const pending: { index: number; col: DiffCollection }[] = [];
+  oldValue.forEach((oldCol, oldIndex) => {
+    if (stable.has(oldCol.collectionName)) return;
+    const isInNew = newMap.has(oldCol.collectionName);
+    const col: DiffCollection = {
+      collectionName: oldCol.collectionName,
+      nodes: projectNodes(oldCol.nodes),
+      change: "removed",
+    };
+    if (isInNew) col.changeType = "sort";
+    pending.push({ index: oldIndex, col });
+  });
+  pending
+    .sort((a, b) => b.index - a.index)
+    .forEach(({ index, col }) => result.splice(index, 0, col));
+
+  return result;
+};
+
+const lcsCollectionNames = (
+  oldValue: ICollection[],
+  newValue: ICollection[],
+): Set<string> => {
+  const oldNames = oldValue.map((c) => c.collectionName);
+  const newNames = newValue.map((c) => c.collectionName);
+  const m = oldNames.length;
+  const n = newNames.length;
+  const dp = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        oldNames[i - 1] === newNames[j - 1]
+          ? dp[i - 1][j - 1] + 1
+          : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+  const result = new Set<string>();
+  let i = m;
+  let j = n;
+  while (i > 0 && j > 0) {
+    if (oldNames[i - 1] === newNames[j - 1]) {
+      result.add(oldNames[i - 1]);
+      i--;
+      j--;
+    } else if (dp[i - 1][j] > dp[i][j - 1]) {
+      // Tiebreaker matches `findLcsNames` in helpers.ts:1599-1637 so the
+      // emitted diff is byte-identical to the legacy renderer's behaviour.
+      i--;
+    } else {
+      j--;
+    }
+  }
+  return result;
+};

--- a/src/lib/utils/diffValue.ts
+++ b/src/lib/utils/diffValue.ts
@@ -91,12 +91,17 @@ const asCollections = (value: any): ICollection[] | null => {
 const buildDiffNode = (
   id: string,
   source: { title?: string; optional?: boolean },
-  marker?: { change?: "added" | "removed"; sort?: boolean },
+  marker?: {
+    change?: "added" | "removed";
+    sort?: boolean;
+    optionalChange?: "added" | "removed";
+  },
 ): DiffLinkNode => {
   const node: DiffLinkNode = { id, title: source.title || "" };
   if (source.optional) node.optional = true;
   if (marker?.change) node.change = marker.change;
   if (marker?.sort) node.changeType = "sort";
+  if (marker?.optionalChange) node.optionalChange = marker.optionalChange;
   return node;
 };
 
@@ -135,6 +140,21 @@ const diffCollectionContents = (
     const newNodes = new Map((newCollection?.nodes || []).map((n) => [n.id, n]));
     const ids = new Set<string>([...oldNodes.keys(), ...newNodes.keys()]);
 
+    // Detect within-collection reorders: of the IDs present in BOTH sides of
+    // this collection, anything not in their LCS is one of the items that
+    // actually moved relative to the others. Skipped when the collection only
+    // exists on one side — there's no order to compare.
+    let stableIds: Set<string> = new Set();
+    if (oldCollection && newCollection) {
+      const sharedOldOrder = oldCollection.nodes
+        .map((n) => n.id)
+        .filter((id) => newNodes.has(id));
+      const sharedNewOrder = newCollection.nodes
+        .map((n) => n.id)
+        .filter((id) => oldNodes.has(id));
+      stableIds = longestCommonSubsequence(sharedOldOrder, sharedNewOrder);
+    }
+
     const merged: DiffLinkNode[] = [];
     for (const id of ids) {
       const inOld = oldNodes.has(id);
@@ -158,7 +178,34 @@ const diffCollectionContents = (
           }),
         );
       } else {
-        merged.push(buildDiffNode(id, source));
+        // Node is in both old and new of the same collection. Two annotations
+        // can fire here, independently and orthogonally:
+        //   * `sort` — moved relative to the other shared nodes (LCS-minimal).
+        //   * `optionalChange` — the `optional` boolean flipped, e.g. the
+        //     toggle-optional path in InheritedPartsViewerEdit.tsx that logs
+        //     a `modify elements` change differing only on this boolean.
+        const oldOptional = !!oldNodes.get(id)?.optional;
+        const newOptional = !!newNodes.get(id)?.optional;
+        const optionalChange =
+          oldOptional === newOptional
+            ? undefined
+            : newOptional
+              ? ("added" as const)
+              : ("removed" as const);
+        const moved = !stableIds.has(id);
+        const marker: {
+          sort?: boolean;
+          optionalChange?: "added" | "removed";
+        } = {};
+        if (moved) marker.sort = true;
+        if (optionalChange) marker.optionalChange = optionalChange;
+        merged.push(
+          buildDiffNode(
+            id,
+            source,
+            Object.keys(marker).length ? marker : undefined,
+          ),
+        );
       }
     }
 
@@ -238,31 +285,44 @@ const diffSortedCollections = (
 const lcsCollectionNames = (
   oldValue: ICollection[],
   newValue: ICollection[],
-): Set<string> => {
-  const oldNames = oldValue.map((c) => c.collectionName);
-  const newNames = newValue.map((c) => c.collectionName);
-  const m = oldNames.length;
-  const n = newNames.length;
+): Set<string> =>
+  longestCommonSubsequence(
+    oldValue.map((c) => c.collectionName),
+    newValue.map((c) => c.collectionName),
+  );
+
+/**
+ * Generic LCS: returns the set of values that appear in the longest common
+ * subsequence of `a` and `b`. Used for two purposes:
+ *   1. Finding stable collections during `sort collections` diffs.
+ *   2. Finding stable nodes inside a collection during within-collection
+ *      reorder detection.
+ *
+ * Tiebreaker (when `dp[i-1][j] === dp[i][j-1]` we move `i--`) matches
+ * `findLcsNames` in helpers.ts:1599-1637 so emitted diffs stay byte-identical
+ * to the legacy renderer's behaviour for the existing `sort collections` case.
+ */
+const longestCommonSubsequence = <T>(a: T[], b: T[]): Set<T> => {
+  const m = a.length;
+  const n = b.length;
   const dp = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0));
   for (let i = 1; i <= m; i++) {
     for (let j = 1; j <= n; j++) {
       dp[i][j] =
-        oldNames[i - 1] === newNames[j - 1]
+        a[i - 1] === b[j - 1]
           ? dp[i - 1][j - 1] + 1
           : Math.max(dp[i - 1][j], dp[i][j - 1]);
     }
   }
-  const result = new Set<string>();
+  const result = new Set<T>();
   let i = m;
   let j = n;
   while (i > 0 && j > 0) {
-    if (oldNames[i - 1] === newNames[j - 1]) {
-      result.add(oldNames[i - 1]);
+    if (a[i - 1] === b[j - 1]) {
+      result.add(a[i - 1]);
       i--;
       j--;
     } else if (dp[i - 1][j] > dp[i][j - 1]) {
-      // Tiebreaker matches `findLcsNames` in helpers.ts:1599-1637 so the
-      // emitted diff is byte-identical to the legacy renderer's behaviour.
       i--;
     } else {
       j--;

--- a/src/lib/utils/groupActivityLogs.ts
+++ b/src/lib/utils/groupActivityLogs.ts
@@ -1,0 +1,44 @@
+import { NodeChange } from "@components/types/INode";
+
+type LogWithId = NodeChange & { id: string };
+
+export type GroupedActivityLogs<T> = {
+  items: T[];
+  childrenByParent: Map<string, T[]>;
+};
+
+
+export const groupActivityLogs = <T extends LogWithId>(
+  logs: T[],
+): GroupedActivityLogs<T> => {
+  const byId = new Map<string, T>();
+  for (const log of logs) byId.set(log.id, log);
+
+  const childrenByParent = new Map<string, T[]>();
+  const items: T[] = [];
+
+  for (const log of logs) {
+    const parentId = log.triggeredBy?.logId;
+    if (parentId && byId.has(parentId)) {
+      const arr = childrenByParent.get(parentId);
+      if (arr) arr.push(log);
+      else childrenByParent.set(parentId, [log]);
+    } else {
+      // True root, or orphaned child whose parent isn't in `logs`
+      items.push(log);
+    }
+  }
+
+  // Children oldest-first inside their group
+  const toMs = (t: any): number => {
+    if (!t) return 0;
+    if (typeof t.toMillis === "function") return t.toMillis();
+    if (typeof t.getTime === "function") return t.getTime();
+    return 0;
+  };
+  for (const arr of childrenByParent.values()) {
+    arr.sort((a, b) => toMs(a.modifiedAt) - toMs(b.modifiedAt));
+  }
+
+  return { items, childrenByParent };
+};

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -33,6 +33,7 @@ import {
 import { NodeChange } from "@components/types/INode";
 import moment from "moment";
 import { capitalizeFirstLetter } from "./string.utils";
+import { computeDiffValue } from "./diffValue";
 import { User } from "@components/types/IAuth";
 import {
   getBrowser,
@@ -592,6 +593,14 @@ const updateProperty = async (
 
 export const saveNewChangeLog = (db: any, data: NodeChange) => {
   if (!data.modifiedBy) return;
+  // Pre-compute the renderable diff so the UI never has to re-derive it.
+  // `computeDiffValue` returns null for non-collection changeTypes; in that
+  // case `diffValue` is left absent and consumers fall back to
+  // `previousValue` / `newValue` directly. Titles are read straight off the
+  // link nodes inside `previousValue` / `newValue` — callers are responsible
+  // for populating `ILinkNode.title` on every live write.
+  const diffValue = computeDiffValue(data);
+  if (diffValue) data.diffValue = diffValue;
   const changeUseRef = doc(collection(db, NODES_LOGS));
   setDoc(changeUseRef, data);
   const userRef = doc(collection(db, USERS), data.modifiedBy);

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -92,10 +92,7 @@ export const unlinkPropertyOf = async (
     | string,
   removeNodeId: string,
   removeFromId: string,
-  // When set, the spec/gen reciprocal write below also emits a child
-  // `NodeChange` linked to the user-initiated parent log. Other branches
-  // (parts/isPartOf, propertyOf) intentionally remain silent for now —
-  // see the scope-narrowing discussion in the diffValue/triggeredBy refactor.
+  // When set, makes a child log linked to this parent
   parentLog?: {
     logId: string;
     nodeId: string;
@@ -103,8 +100,7 @@ export const unlinkPropertyOf = async (
     changeType: NodeChange["changeType"];
   },
   uname?: string,
-  // Required for the child log to survive `appName` filters in
-  // HistoryTab / UserActivity. Mirrors the same field on the parent log.
+  // Mirrors parentLog.appName so child logs aren't filtered out
   appName?: string,
 ) => {
   if (!removeFromId) return;
@@ -134,8 +130,7 @@ export const unlinkPropertyOf = async (
   if (unlinkFromDoc.exists()) {
     const unlinkFromData = unlinkFromDoc.data() as INode;
     if (removeFrom === "generalizations" || removeFrom === "specializations") {
-      // Snapshot pre-mutation state so the child log's `previousValue` is
-      // independent of the in-place filter below.
+      // Snapshot before the in-place filter below.
       const previousValue = JSON.parse(
         JSON.stringify(unlinkFromData[removeFrom]),
       );
@@ -625,17 +620,9 @@ const updateProperty = async (
 };
 
 /**
- * Writes a NodeChange entry to NODES_LOGS and returns the doc id used.
- *
- * `preGeneratedId` lets the caller reserve a doc id up-front via
- * `doc(collection(db, NODES_LOGS)).id` so it can be referenced by the
- * `triggeredBy.logId` field on subsequent child logs *before* the parent log's
- * own write resolves. Firestore decides ids client-side, so this is safe even
- * though `setDoc` below is fire-and-forget — the id we hand back exists in
- * the database before any consumer reads it.
- *
- * Returns `undefined` for the `!modifiedBy` skip path so callers can detect
- * "no log written, do not attach children to me" without inspecting the data.
+ * Writes a NodeChange to NODES_LOGS and returns the doc id (or `undefined` if
+ * skipped due to missing `modifiedBy`). Pass `preGeneratedId` to reserve the
+ * id up-front so child logs can reference it via `triggeredBy.logId`.
  */
 export const saveNewChangeLog = (
   db: any,
@@ -643,12 +630,6 @@ export const saveNewChangeLog = (
   preGeneratedId?: string,
 ): string | undefined => {
   if (!data.modifiedBy) return undefined;
-  // Pre-compute the renderable diff so the UI never has to re-derive it.
-  // `computeDiffValue` returns null for non-collection changeTypes; in that
-  // case `diffValue` is left absent and consumers fall back to
-  // `previousValue` / `newValue` directly. Titles are read straight off the
-  // link nodes inside `previousValue` / `newValue` — callers are responsible
-  // for populating `ILinkNode.title` on every live write.
   const diffValue = computeDiffValue(data);
   if (diffValue) data.diffValue = diffValue;
   const changeUseRef = preGeneratedId
@@ -1503,9 +1484,7 @@ export const updateLinks = async (
   linkType: "specializations" | "generalizations",
   nodes: { [nodeId: string]: INode },
   db: any,
-  // When set, each successful push also emits a child log on `childId`
-  // linked to the user-initiated parent log. Callers that aren't part of
-  // the user-edit orchestration (e.g. clones) leave this undefined.
+  // When set, each push also emits a child log on `childId` linked to this parent.
   parentLog?: {
     logId: string;
     nodeId: string;
@@ -1513,8 +1492,7 @@ export const updateLinks = async (
     changeType: NodeChange["changeType"];
   },
   uname?: string,
-  // Required for the child log to survive `appName` filters in
-  // HistoryTab / UserActivity. Mirrors the same field on the parent log.
+  // Mirrors parentLog.appName so child logs aren't filtered out.
   appName?: string,
 ) => {
   for (let childId of links) {
@@ -1529,8 +1507,7 @@ export const updateLinks = async (
       (collection) => collection.collectionName === "main",
     );
     if (indexElmt === -1) {
-      // Snapshot pre-mutation so child log's `previousValue` is stable
-      // regardless of which branch below mutates `childLinks`.
+      // Snapshot before the in-place mutations below.
       const previousValue = JSON.parse(JSON.stringify(childLinks));
       if (mainCollection) {
         mainCollection.nodes.push(newLink);

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -92,6 +92,20 @@ export const unlinkPropertyOf = async (
     | string,
   removeNodeId: string,
   removeFromId: string,
+  // When set, the spec/gen reciprocal write below also emits a child
+  // `NodeChange` linked to the user-initiated parent log. Other branches
+  // (parts/isPartOf, propertyOf) intentionally remain silent for now —
+  // see the scope-narrowing discussion in the diffValue/triggeredBy refactor.
+  parentLog?: {
+    logId: string;
+    nodeId: string;
+    nodeTitle: string;
+    changeType: NodeChange["changeType"];
+  },
+  uname?: string,
+  // Required for the child log to survive `appName` filters in
+  // HistoryTab / UserActivity. Mirrors the same field on the parent log.
+  appName?: string,
 ) => {
   if (!removeFromId) return;
 
@@ -120,6 +134,11 @@ export const unlinkPropertyOf = async (
   if (unlinkFromDoc.exists()) {
     const unlinkFromData = unlinkFromDoc.data() as INode;
     if (removeFrom === "generalizations" || removeFrom === "specializations") {
+      // Snapshot pre-mutation state so the child log's `previousValue` is
+      // independent of the in-place filter below.
+      const previousValue = JSON.parse(
+        JSON.stringify(unlinkFromData[removeFrom]),
+      );
       for (let collection of unlinkFromData[removeFrom]) {
         collection.nodes = collection.nodes.filter(
           (n: { id: string }) => n.id !== removeNodeId,
@@ -128,6 +147,20 @@ export const unlinkPropertyOf = async (
       await updateDoc(unlinkFromDoc.ref, {
         [`${removeFrom}`]: unlinkFromData[removeFrom],
       });
+      if (parentLog && uname) {
+        saveNewChangeLog(db, {
+          nodeId: removeFromId,
+          modifiedBy: uname,
+          modifiedProperty: removeFrom,
+          previousValue,
+          newValue: unlinkFromData[removeFrom],
+          modifiedAt: new Date(),
+          changeType: "remove element",
+          fullNode: unlinkFromData,
+          triggeredBy: parentLog,
+          ...(appName ? { appName } : {}),
+        });
+      }
     } else {
       if (
         (removeFrom === "parts" || removeFrom === "isPartOf") &&
@@ -591,8 +624,25 @@ const updateProperty = async (
   return batch;
 };
 
-export const saveNewChangeLog = (db: any, data: NodeChange) => {
-  if (!data.modifiedBy) return;
+/**
+ * Writes a NodeChange entry to NODES_LOGS and returns the doc id used.
+ *
+ * `preGeneratedId` lets the caller reserve a doc id up-front via
+ * `doc(collection(db, NODES_LOGS)).id` so it can be referenced by the
+ * `triggeredBy.logId` field on subsequent child logs *before* the parent log's
+ * own write resolves. Firestore decides ids client-side, so this is safe even
+ * though `setDoc` below is fire-and-forget — the id we hand back exists in
+ * the database before any consumer reads it.
+ *
+ * Returns `undefined` for the `!modifiedBy` skip path so callers can detect
+ * "no log written, do not attach children to me" without inspecting the data.
+ */
+export const saveNewChangeLog = (
+  db: any,
+  data: NodeChange,
+  preGeneratedId?: string,
+): string | undefined => {
+  if (!data.modifiedBy) return undefined;
   // Pre-compute the renderable diff so the UI never has to re-derive it.
   // `computeDiffValue` returns null for non-collection changeTypes; in that
   // case `diffValue` is left absent and consumers fall back to
@@ -601,7 +651,9 @@ export const saveNewChangeLog = (db: any, data: NodeChange) => {
   // for populating `ILinkNode.title` on every live write.
   const diffValue = computeDiffValue(data);
   if (diffValue) data.diffValue = diffValue;
-  const changeUseRef = doc(collection(db, NODES_LOGS));
+  const changeUseRef = preGeneratedId
+    ? doc(collection(db, NODES_LOGS), preGeneratedId)
+    : doc(collection(db, NODES_LOGS));
   setDoc(changeUseRef, data);
   const userRef = doc(collection(db, USERS), data.modifiedBy);
   if (data.modifiedBy !== "ouhrac") {
@@ -624,6 +676,7 @@ export const saveNewChangeLog = (db: any, data: NodeChange) => {
     }
     updateDoc(nodeRef, updatesObject);
   }
+  return changeUseRef.id;
 };
 
 export const getChangeDescription = (
@@ -1450,6 +1503,19 @@ export const updateLinks = async (
   linkType: "specializations" | "generalizations",
   nodes: { [nodeId: string]: INode },
   db: any,
+  // When set, each successful push also emits a child log on `childId`
+  // linked to the user-initiated parent log. Callers that aren't part of
+  // the user-edit orchestration (e.g. clones) leave this undefined.
+  parentLog?: {
+    logId: string;
+    nodeId: string;
+    nodeTitle: string;
+    changeType: NodeChange["changeType"];
+  },
+  uname?: string,
+  // Required for the child log to survive `appName` filters in
+  // HistoryTab / UserActivity. Mirrors the same field on the parent log.
+  appName?: string,
 ) => {
   for (let childId of links) {
     const childData = nodes[childId];
@@ -1463,6 +1529,9 @@ export const updateLinks = async (
       (collection) => collection.collectionName === "main",
     );
     if (indexElmt === -1) {
+      // Snapshot pre-mutation so child log's `previousValue` is stable
+      // regardless of which branch below mutates `childLinks`.
+      const previousValue = JSON.parse(JSON.stringify(childLinks));
       if (mainCollection) {
         mainCollection.nodes.push(newLink);
         const childRef = doc(collection(db, NODES), childId);
@@ -1478,6 +1547,20 @@ export const updateLinks = async (
         const childRef = doc(collection(db, NODES), childId);
         await updateDoc(childRef, {
           [linkType]: childLinks,
+        });
+      }
+      if (parentLog && uname) {
+        saveNewChangeLog(db, {
+          nodeId: childId,
+          modifiedBy: uname,
+          modifiedProperty: linkType,
+          previousValue,
+          newValue: childLinks,
+          modifiedAt: new Date(),
+          changeType: "add element",
+          fullNode: childData,
+          triggeredBy: parentLog,
+          ...(appName ? { appName } : {}),
         });
       }
     }

--- a/src/types/INode.ts
+++ b/src/types/INode.ts
@@ -208,6 +208,27 @@ export type NodeChange = {
    * case.
    */
   diffValue?: DiffCollection[];
+  /**
+   * Present on "child" logs — system-generated entries written as a
+   * side-effect of a user's direct edit (the "parent log"). The parent log is
+   * always a direct user action; child logs are reciprocal mutations on
+   * related nodes. `modifiedBy` on child logs attributes to the same user as
+   * the parent.
+   *
+   * Currently emitted for `generalizations` ↔ `specializations` edits via
+   * `unlinkPropertyOf` (removed reciprocals) and `updateLinks` (added
+   * reciprocals). `parts` ↔ `isPartOf`, `propertyOf` side-effects, and
+   * node-deletion cleanup are out of scope and remain orphaned.
+   *
+   * `nodeTitle` is snapshotted at write time so the activity-feed badge can
+   * render without a Firestore lookup or relying on the in-memory cache.
+   */
+  triggeredBy?: {
+    logId: string;
+    nodeId: string;
+    nodeTitle: string;
+    changeType: NodeChange["changeType"];
+  };
 };
 
 export type DiffLinkNode = {

--- a/src/types/INode.ts
+++ b/src/types/INode.ts
@@ -190,39 +190,9 @@ export type NodeChange = {
   appName?: string;
   detailsOfChange?: any;
   logLLMId?: string;
-  /**
-   * Pre-computed, ready-to-render diff for collection-typed changes
-   * (`add element`, `remove element`, `add elements`, `remove elements`,
-   * `modify elements`, `sort elements`, `add collection`, `delete collection`,
-   * `sort collections`).
-   *
-   * Populated at write time by `saveNewChangeLog` via `computeDiffValue`, so
-   * the UI can render history without re-diffing or resolving titles. Titles
-   * are snapshotted into each `DiffLinkNode.title`, which means historical
-   * entries display the title that existed at the time of the edit even after
-   * a node is later renamed or removed from the local cache.
-   *
-   * Absent for non-collection changeTypes (`change text`, `add images`, etc.)
-   * and for legacy records written before the field was introduced — callers
-   * must fall back to recomputing from `previousValue` / `newValue` in that
-   * case.
-   */
+  /** Pre-computed diff for collection-typed changes */
   diffValue?: DiffCollection[];
-  /**
-   * Present on "child" logs — system-generated entries written as a
-   * side-effect of a user's direct edit (the "parent log"). The parent log is
-   * always a direct user action; child logs are reciprocal mutations on
-   * related nodes. `modifiedBy` on child logs attributes to the same user as
-   * the parent.
-   *
-   * Currently emitted for `generalizations` ↔ `specializations` edits via
-   * `unlinkPropertyOf` (removed reciprocals) and `updateLinks` (added
-   * reciprocals). `parts` ↔ `isPartOf`, `propertyOf` side-effects, and
-   * node-deletion cleanup are out of scope and remain orphaned.
-   *
-   * `nodeTitle` is snapshotted at write time so the activity-feed badge can
-   * render without a Firestore lookup or relying on the in-memory cache.
-   */
+  /** Set on child logs to point at the parent log */
   triggeredBy?: {
     logId: string;
     nodeId: string;
@@ -234,21 +204,20 @@ export type NodeChange = {
 export type DiffLinkNode = {
   id: string;
   title: string;
-  // "added": node present only in the new state
-  // "removed": node present only in the old state
-  // node is unchanged if both values are empty
+  /** "added" / "removed" relative to the previous state; absent if unchanged. */
   change?: "added" | "removed";
-  changeType?: "sort"; // node moved between collections
+  /** Node moved between collections. */
+  changeType?: "sort";
   optional?: boolean;
   optionalChange?: "added" | "removed";
 };
 
 export type DiffCollection = {
   collectionName: string;
-  // "added": collection appeared in the new state
-  // "removed": collection disappeared from the new state
-  change?: "added" | "removed"; 
-  changeType?: "sort"; //collection itself moved
+  /** "added" / "removed" relative to the previous state; absent if unchanged. */
+  change?: "added" | "removed";
+  /** Collection itself moved (only for `sort collections` diffs). */
+  changeType?: "sort";
   nodes: DiffLinkNode[];
 };
 

--- a/src/types/INode.ts
+++ b/src/types/INode.ts
@@ -190,6 +190,44 @@ export type NodeChange = {
   appName?: string;
   detailsOfChange?: any;
   logLLMId?: string;
+  /**
+   * Pre-computed, ready-to-render diff for collection-typed changes
+   * (`add element`, `remove element`, `add elements`, `remove elements`,
+   * `modify elements`, `sort elements`, `add collection`, `delete collection`,
+   * `sort collections`).
+   *
+   * Populated at write time by `saveNewChangeLog` via `computeDiffValue`, so
+   * the UI can render history without re-diffing or resolving titles. Titles
+   * are snapshotted into each `DiffLinkNode.title`, which means historical
+   * entries display the title that existed at the time of the edit even after
+   * a node is later renamed or removed from the local cache.
+   *
+   * Absent for non-collection changeTypes (`change text`, `add images`, etc.)
+   * and for legacy records written before the field was introduced — callers
+   * must fall back to recomputing from `previousValue` / `newValue` in that
+   * case.
+   */
+  diffValue?: DiffCollection[];
+};
+
+export type DiffLinkNode = {
+  id: string;
+  title: string;
+  // "added": node present only in the new state
+  // "removed": node present only in the old state
+  // node is unchanged if both values are empty
+  change?: "added" | "removed";
+  changeType?: "sort"; // node moved between collections
+  optional?: boolean;
+};
+
+export type DiffCollection = {
+  collectionName: string;
+  // "added": collection appeared in the new state
+  // "removed": collection disappeared from the new state
+  change?: "added" | "removed"; 
+  changeType?: "sort"; //collection itself moved
+  nodes: DiffLinkNode[];
 };
 
 export type PromptChange = {

--- a/src/types/INode.ts
+++ b/src/types/INode.ts
@@ -240,6 +240,7 @@ export type DiffLinkNode = {
   change?: "added" | "removed";
   changeType?: "sort"; // node moved between collections
   optional?: boolean;
+  optionalChange?: "added" | "removed";
 };
 
 export type DiffCollection = {


### PR DESCRIPTION
Hi @samadouhra

  This PR includes all changes related to pre-computing diffs for history entries at write time so the UI no longer re-derives them on every render.

  Changes include:

  - Added `NodeChange.diffValue` that is calculated by a new `computeDiffValue` helper inside `saveNewChangeLog`. Titles are snapshotted into the diff, fixing the empty-title bug
  - The history view reads stored `diffValue` directly when present
  - Added `NodeChange.triggeredBy` so child logs generated will link back to the user-initiated parent log for specializations ↔ generalizations edits and from the specialization-nesting flow
  - Added an optional-toggle identifier and a same-collection reorder indicator to the diff; and updated UI to correctly render them