### PR TITLE
Fix platform issues related to Navigator and NodeCompass

### DIFF
--- a/src/components/NodBody/NodeCompass.tsx
+++ b/src/components/NodBody/NodeCompass.tsx
@@ -46,6 +46,11 @@ import {
 
 type Props = {
   currentVisibleNode: INode;
+  /**
+   * Lookup of nearby nodes by id. Used *only* as a title fallback for
+   * satellites whose `ILinkNode.title` is missing on the focused node's
+   * own link arrays.
+   */
   relatedNodes: { [id: string]: INode };
   navigateToNode: (nodeId: string) => void;
   /** Height of the compass canvas. Pass a number (px) or any CSS length/calc string. Defaults to 540px. */
@@ -345,20 +350,7 @@ const NodeCompass: React.FC<Props> = ({
     ],
   );
 
-  // Inheritance-resolved parts
-  const inheritanceRef = currentVisibleNode.inheritance?.parts?.ref ?? null;
-  const inheritedFromNode = inheritanceRef
-    ? relatedNodes[inheritanceRef]
-    : null;
-  const resolvedParts = useMemo<ICollection[] | null>(() => {
-    if (inheritanceRef) {
-      const inh = inheritedFromNode?.properties?.parts;
-      return Array.isArray(inh) ? (inh as ICollection[]) : null;
-    }
-    const direct = currentVisibleNode.properties?.parts;
-    return Array.isArray(direct) ? (direct as ICollection[]) : null;
-  }, [inheritanceRef, inheritedFromNode, currentVisibleNode.properties?.parts]);
-
+  // Parts are read straight from this node's `properties.parts` and will no longer follow `inheritance.parts.ref`.
   const ids = useMemo(
     () => ({
       left: flattenIds(currentVisibleNode.generalizations),
@@ -366,9 +358,11 @@ const NodeCompass: React.FC<Props> = ({
       top: flattenIds(
         currentVisibleNode.properties?.isPartOf as ICollection[] | undefined,
       ),
-      bottom: flattenIds(resolvedParts),
+      bottom: flattenIds(
+        currentVisibleNode.properties?.parts as ICollection[] | undefined,
+      ),
     }),
-    [currentVisibleNode, resolvedParts],
+    [currentVisibleNode],
   );
 
   const layout = useMemo(
@@ -401,9 +395,9 @@ const NodeCompass: React.FC<Props> = ({
     collect(
       currentVisibleNode.properties?.isPartOf as ICollection[] | undefined,
     );
-    collect(resolvedParts);
+    collect(currentVisibleNode.properties?.parts as ICollection[] | undefined);
     return m;
-  }, [currentVisibleNode, resolvedParts]);
+  }, [currentVisibleNode]);
 
   const lPad = layout.effectiveL1X + COMPASS.N1W / 2 + COMPASS.LABEL_PAD;
   const tPad = layout.effectiveL1Y + COMPASS.N1H / 2 + COMPASS.LABEL_PAD;

--- a/src/components/NodBody/NodeGraph.tsx
+++ b/src/components/NodBody/NodeGraph.tsx
@@ -202,6 +202,7 @@ type WalkedNode = {
   title: string;
   hasChildren: boolean;
   hasUnresolved: boolean;
+  wasUserExpanded: boolean;
   parentTreeId: string | null;
 };
 
@@ -224,6 +225,10 @@ function walkHierarchy(tree: TreeData[]): WalkedNode[] {
         !!node.outlineLoadChildren ||
         (!!node.hasUnresolvedChildren &&
           (!node.children || node.children.length === 0)),
+      wasUserExpanded:
+        node.outlineLoadChildren === false &&
+        Array.isArray(node.children) &&
+        node.children.length > 0,
       parentTreeId,
     });
     if (node.children) {
@@ -270,16 +275,12 @@ const NodeGraph: React.FC<Props> = ({
     [theme.palette.primary.main, isDark],
   );
 
+  // Sets for spinner loader
   const [expandingTreeIds, setExpandingTreeIds] = useState<Set<string>>(
     new Set(),
   );
-  // Path-interior nodes are NOT added here — their children belong to
-  // the canonical hierarchy, not a user expansion. That's what makes
-  // collapse safe: clicks on them don't match and become no-ops.
-  const [userExpanded, setUserExpanded] = useState<Set<string>>(new Set());
   useEffect(() => {
     setExpandingTreeIds(new Set());
-    setUserExpanded(new Set());
   }, [focusedId]);
 
   const { nodes, edges } = useMemo(() => {
@@ -333,7 +334,7 @@ const NodeGraph: React.FC<Props> = ({
           role,
           color: colors[role],
           canExpand: n.hasUnresolved,
-          isExpanded: userExpanded.has(n.treeId),
+          isExpanded: n.wasUserExpanded,
           isExpanding: expandingTreeIds.has(n.treeId),
           treeId: n.treeId,
           nodeId: n.nodeId,
@@ -370,7 +371,7 @@ const NodeGraph: React.FC<Props> = ({
     }
 
     return { nodes: rfNodes, edges: rfEdges };
-  }, [hierarchyTree, focusedId, colors, expandingTreeIds, userExpanded]);
+  }, [hierarchyTree, focusedId, colors, expandingTreeIds]);
 
   const [rfInstance, setRfInstance] = useState<ReactFlowInstance | null>(null);
 
@@ -386,22 +387,14 @@ const NodeGraph: React.FC<Props> = ({
   const onNodeClick = useCallback(
     (_e: React.MouseEvent, node: Node) => {
       const d = node.data as unknown as GraphNodeData;
-      if (userExpanded.has(d.treeId)) {
+      if (d.isExpanded) {
         onCollapseNode(d.treeId, d.nodeId);
-        setUserExpanded((prev) => {
-          const next = new Set(prev);
-          next.delete(d.treeId);
-          return next;
-        });
         return;
       }
       if (!d.canExpand) return;
       if (expandingTreeIds.has(d.treeId)) return;
       setExpandingTreeIds((prev) => new Set(prev).add(d.treeId));
       Promise.resolve(onExpandNode(d.treeId, d.nodeId))
-        .then(() => {
-          setUserExpanded((prev) => new Set(prev).add(d.treeId));
-        })
         .catch((err) => console.error("graph expand failed:", err))
         .finally(() => {
           setExpandingTreeIds((prev) => {
@@ -411,7 +404,7 @@ const NodeGraph: React.FC<Props> = ({
           });
         });
     },
-    [onExpandNode, onCollapseNode, expandingTreeIds, userExpanded],
+    [onExpandNode, onCollapseNode, expandingTreeIds],
   );
 
   if (!hierarchyTree) {

--- a/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
@@ -1167,6 +1167,76 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                             >
                               <Tooltip
                                 title={
+                                  entry.toOptional
+                                    ? "Mark as required"
+                                    : "Mark as optional"
+                                }
+                                placement="top"
+                              >
+                                <Box
+                                  component="button"
+                                  type="button"
+                                  onMouseDown={(e: React.MouseEvent) => {
+                                    e.stopPropagation();
+                                  }}
+                                  onClick={(e: React.MouseEvent) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    toggleOptional(entry.to);
+                                  }}
+                                  sx={{
+                                    cursor: "pointer",
+                                    textTransform: "none",
+                                    fontSize: 12,
+                                    fontWeight: entry.toOptional ? 700 : 600,
+                                    color: entry.toOptional
+                                      ? "#f2a43a"
+                                      : (theme) =>
+                                          theme.palette.mode === "light"
+                                            ? "#111827"
+                                            : "#f3f4f6",
+                                    width: 28,
+                                    height: 28,
+                                    flexShrink: 0,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    borderRadius: "50%",
+                                    border: entry.toOptional
+                                      ? "1px solid rgba(242, 164, 58, 0.55)"
+                                      : (theme) =>
+                                          theme.palette.mode === "light"
+                                            ? "1px solid #d0d5dd"
+                                            : "1px solid #3b3b3b",
+                                    background: entry.toOptional
+                                      ? (theme) =>
+                                          theme.palette.mode === "light"
+                                            ? "linear-gradient(180deg, #f8fafc 0%, #e8edf3 100%)"
+                                            : "linear-gradient(180deg, #2b2f39 0%, #1d2129 100%)"
+                                      : (theme) =>
+                                          theme.palette.mode === "light"
+                                            ? "linear-gradient(180deg, #ffffff 0%, #f3f5f8 100%)"
+                                            : "linear-gradient(180deg, #17191f 0%, #101217 100%)",
+                                    boxShadow: entry.toOptional
+                                      ? (theme) =>
+                                          theme.palette.mode === "light"
+                                            ? "inset 0 0 0 1px rgba(242, 164, 58, 0.22)"
+                                            : "inset 0 0 0 1px rgba(255, 187, 86, 0.16)"
+                                      : "none",
+                                    transition: "all 0.2s ease",
+                                    "&:hover": {
+                                      background: (theme) =>
+                                        theme.palette.mode === "light"
+                                          ? "rgba(15, 23, 42, 0.05)"
+                                          : "rgba(255, 255, 255, 0.06)",
+                                    },
+                                  }}
+                                >
+                                  (o)
+                                </Box>
+                              </Tooltip>
+                              <Tooltip
+                                title={
                                   !isSelectOpen
                                     ? allNodes[entry.to]?.title || ""
                                     : ""
@@ -1205,8 +1275,8 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                                         ? "white"
                                         : "black",
                                     fontSize: "0.9rem",
-                                    maxWidth: 250,
-                                    width: "100%",
+                                    flex: 1,
+                                    minWidth: 0,
                                     borderRadius: "15px",
                                     backgroundColor: (theme) =>
                                       theme.palette.background.paper,
@@ -1332,73 +1402,6 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                                     ),
                                   )}
                                 </Select>
-                              </Tooltip>
-                              <Tooltip
-                                title={
-                                  entry.toOptional
-                                    ? "Mark as required"
-                                    : "Mark as optional"
-                                }
-                                placement="top"
-                              >
-                                <Box
-                                  component="button"
-                                  type="button"
-                                  onMouseDown={(e: React.MouseEvent) => {
-                                    e.stopPropagation();
-                                  }}
-                                  onClick={(e: React.MouseEvent) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    toggleOptional(entry.to);
-                                  }}
-                                  sx={{
-                                    cursor: "pointer",
-                                    textTransform: "none",
-                                    fontSize: 12,
-                                    fontWeight: entry.toOptional ? 700 : 600,
-                                    color: entry.toOptional
-                                      ? "#f2a43a"
-                                      : (theme) =>
-                                          theme.palette.mode === "light"
-                                            ? "#111827"
-                                            : "#f3f4f6",
-                                    px: 1.5,
-                                    py: 0.5,
-                                    minHeight: 28,
-                                    borderRadius: "999px",
-                                    border: entry.toOptional
-                                      ? "1px solid rgba(242, 164, 58, 0.55)"
-                                      : (theme) =>
-                                          theme.palette.mode === "light"
-                                            ? "1px solid #d0d5dd"
-                                            : "1px solid #3b3b3b",
-                                    background: entry.toOptional
-                                      ? (theme) =>
-                                          theme.palette.mode === "light"
-                                            ? "linear-gradient(180deg, #f8fafc 0%, #e8edf3 100%)"
-                                            : "linear-gradient(180deg, #2b2f39 0%, #1d2129 100%)"
-                                      : (theme) =>
-                                          theme.palette.mode === "light"
-                                            ? "linear-gradient(180deg, #ffffff 0%, #f3f5f8 100%)"
-                                            : "linear-gradient(180deg, #17191f 0%, #101217 100%)",
-                                    boxShadow: entry.toOptional
-                                      ? (theme) =>
-                                          theme.palette.mode === "light"
-                                            ? "inset 0 0 0 1px rgba(242, 164, 58, 0.22)"
-                                            : "inset 0 0 0 1px rgba(255, 187, 86, 0.16)"
-                                      : "none",
-                                    transition: "all 0.2s ease",
-                                    "&:hover": {
-                                      background: (theme) =>
-                                        theme.palette.mode === "light"
-                                          ? "rgba(15, 23, 42, 0.05)"
-                                          : "rgba(255, 255, 255, 0.06)",
-                                    },
-                                  }}
-                                >
-                                  (o)
-                                </Box>
                               </Tooltip>
                             </Box>
                           ) : null

--- a/src/pages/Ontology.tsx
+++ b/src/pages/Ontology.tsx
@@ -137,7 +137,6 @@ import { MemoizedToolbarSidebar } from "@components/components/Sidebar/ToolbarSi
 import { NodeChange } from "@components/types/INode";
 import GuidLines from "@components/components/Guidelines/GuideLines";
 import SearchSideBar from "@components/components/SearchSideBar/SearchSideBar";
-import Head from "next/head";
 import DraggableTree from "@components/components/OntologyComponents/DraggableTree";
 import { TreeApi } from "react-arborist";
 import { capitalizeFirstLetter } from "@components/lib/utils/string.utils";
@@ -188,9 +187,12 @@ export const tokenize = (str: string) => {
 const Ontology = ({
   appName,
   onOpenInNavigator,
+  onFocusedTitleChange,
 }: {
   appName: string;
   onOpenInNavigator?: (nodeId: string) => void;
+  // Reported up to the parent component, which owns the <title> tag.
+  onFocusedTitleChange?: (title: string | null) => void;
 }) => {
   const db = getFirestore();
   const rtdb = getDatabase();
@@ -313,6 +315,12 @@ const Ontology = ({
   useEffect(() => {
     hasInstantUpdateRef.current = hasInstantUpdate;
   }, [hasInstantUpdate]);
+
+  // Report the focused node's title up to the parent
+  useEffect(() => {
+    const title = currentVisibleNode?.title;
+    if (title) onFocusedTitleChange?.(title);
+  }, [currentVisibleNode?.title, onFocusedTitleChange]);
 
   // Instant tree update callback for instant UI feedback
   const handleInstantTreeUpdate = useCallback(
@@ -2062,12 +2070,6 @@ const Ontology = ({
             : "linear-gradient(150deg, #ffffff 0%, #8fa0b8 40%, #c8d6e8 70%, #eef4fc 100%)",
       }}
     >
-      <Head>
-        <title>
-          {currentVisibleNode ? currentVisibleNode.title : "1ontology"}
-        </title>
-      </Head>
-
       {/* Mobile Header */}
       {isMobile && (
         <Box

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Box, ThemeProvider, useTheme } from "@mui/material";
+import Head from "next/head";
 import withAuthUser from "@components/components/hoc/withAuthUser";
 import Ontology from "./Ontology";
 import { NavigateLandingSection } from "./landing/navigate";
@@ -27,6 +28,8 @@ const SkillsFuture = () => {
   const [mode, setMode] = useState<Mode>("platform");
   const [navInitialNodeId, setNavInitialNodeId] = useState<string | null>(null);
   const [hasVisitedNavigator, setHasVisitedNavigator] = useState(false);
+  const [platformTitle, setPlatformTitle] = useState<string | null>(null);
+  const [navigatorTitle, setNavigatorTitle] = useState<string | null>(null);
 
   useEffect(() => {
     if (!router.isReady) return;
@@ -83,12 +86,21 @@ const SkillsFuture = () => {
 
   if (!appName) return null;
 
+  const tabTitle =
+    (mode === "navigate"
+      ? navigatorTitle ?? platformTitle
+      : platformTitle ?? navigatorTitle) ?? "Ontology of Collective Intelligence";
+
   return (
     <>
+      <Head>
+        <title>{tabTitle}</title>
+      </Head>
       <Box sx={{ display: mode === "platform" ? "block" : "none" }}>
         <Ontology
           appName={appName}
           onOpenInNavigator={openInNavigator}
+          onFocusedTitleChange={setPlatformTitle}
         />
       </Box>
       {hasVisitedNavigator && (
@@ -101,6 +113,7 @@ const SkillsFuture = () => {
               appName={appName}
               initialNodeId={navInitialNodeId}
               onBackToPlatform={backToPlatform}
+              onFocusedTitleChange={setNavigatorTitle}
             />
           </ThemeProvider>
         </Box>

--- a/src/pages/landing/navigate.tsx
+++ b/src/pages/landing/navigate.tsx
@@ -212,11 +212,14 @@ export const NavigateLandingSection = ({
   appName,
   initialNodeId,
   onBackToPlatform,
+  onFocusedTitleChange,
 }: {
   isDark: boolean;
   appName: string;
   initialNodeId?: string | null;
   onBackToPlatform: () => void;
+  // Reported up to the parent component, which owns the <title> tag.
+  onFocusedTitleChange?: (title: string | null) => void;
 }) => {
   const theme = useTheme();
   const accent = theme.palette.primary.main;
@@ -303,6 +306,13 @@ export const NavigateLandingSection = ({
       );
     }
   }, [activeId]);
+
+  // Report the focused node's title up to the parent
+  useEffect(() => {
+    if (!activeId) return;
+    const title = nodes[activeId]?.title;
+    if (title) onFocusedTitleChange?.(title);
+  }, [activeId, nodes, onFocusedTitleChange]);
 
   // Re-seed activeId when the URL hash is updated externally — e.g. the
   // platform firing "Open in Navigator" again while the navigator is still


### PR DESCRIPTION
Hi @samadouhra,

This PR fixes several platform issues that I shared during the standup.

Changes include:

* removing `inheritance ref` lookup from `NodeCompass`
* updating the tab title dynamically based on whether the user is viewing `Ontology` or `Navigator`
* fixing the expanded state issue in the Navigator graph view, where expanded nodes could not be collapsed after unmounting
* updating the UI for the Inherited Parts Editor
