### PR TITLE
Fix Outline View not loading chevrons properly

### DIFF
--- a/src/lib/utils/loadOutlineFromPathIds.ts
+++ b/src/lib/utils/loadOutlineFromPathIds.ts
@@ -389,10 +389,13 @@ export function mergePreservedSubtrees(
   oldChildren: TreeData[] | undefined,
 ): TreeData[] {
   if (!oldChildren?.length) return newChildren;
-  const byNodeId = new Map(oldChildren.map((c) => [c.nodeId, c]));
+  // Key by "id": categories share nodeId and would cause visual inconsistencies
+  const byId = new Map(oldChildren.map((c) => [c.id, c]));
   return newChildren.map((nc) => {
-    const prev = byNodeId.get(nc.nodeId);
-    if (prev) {
+    const prev = byId.get(nc.id);
+    // Only keep old row if it has loaded children; let fresh data win otherwise
+    const prevHasLoadedSubtree = !!prev?.children && prev.children.length > 0;
+    if (prev && prevHasLoadedSubtree) {
       return {
         ...nc,
         children: prev.children,


### PR DESCRIPTION
Hi @samadouhra

This PR is to fix an Outline view path loading issue. The issue was caused by the data returned from fetch not being properly merged with the existing UI state, causing necessary chevrons to not appear after expanding nodes.

The issue happened because placeholder rows with empty children were being preserved over the newly fetched data during the merge step. I've fixed it by properly merging the fetched data and only preserving rows that already have a loaded subtree.

It also fixes an issue where category rows could incorrectly swap children because the merge was keyed by nodeId instead of the unique row id.
