### PR TITLE
Reload outline on navigation even after a recent edit to outline

### DIFF
--- a/src/components/OntologyComponents/DraggableTree.tsx
+++ b/src/components/OntologyComponents/DraggableTree.tsx
@@ -265,10 +265,10 @@ function DraggableTree({
           allChildren: node.children ? [...node.children] : undefined,
         };
 
-        // Always render all children directly (no pagination "Show … more" nodes).
-        if (node.children) processedNode.children = [...node.children];
+        // Always assign a children array (empty) so react-arborist classifies every node as a drop target
+        processedNode.children = node.children ? [...node.children] : [];
 
-        if (processedNode.children) {
+        if (processedNode.children.length > 0) {
           processedNode.children = processTreeData(processedNode.children);
         }
 

--- a/src/components/OntologyComponents/DraggableTree.tsx
+++ b/src/components/OntologyComponents/DraggableTree.tsx
@@ -722,21 +722,31 @@ function DraggableTree({
 
       // Update shared tree state with local update to prevent glitch when treeViewData updates
       if (onInstantTreeUpdate) {
-        // Clean the newData to remove pagination properties
+        // Drop pagination/loading fields and keep lazy flags so chevrons persist after edits
         const cleanTreeData = (data: PaginatedTreeData[]): TreeData[] => {
           return data
-            .filter((node) => !node.isLoadMore)
-            .map((node) => ({
-              id: node.id,
-              nodeId: node.nodeId,
-              name: node.name,
-              nodeType: node.nodeType,
-              category: node.category,
-              unclassified: node.unclassified,
-              children: node.children
-                ? cleanTreeData(node.children)
-                : undefined,
-            }));
+            .filter((node) => !node.isLoadMore && !node.isLoadingPlaceholder)
+            .map((node) => {
+              const {
+                isLoadMore,
+                isLoadingPlaceholder,
+                parentId,
+                totalChildren,
+                loadedChildren,
+                allChildren,
+                isTopLoader,
+                isBottomLoader,
+                loadDirection,
+                children,
+                ...rest
+              } = node;
+              return {
+                ...rest,
+                children: children
+                  ? cleanTreeData(children as PaginatedTreeData[])
+                  : undefined,
+              } as TreeData;
+            });
         };
 
         onInstantTreeUpdate(() => cleanTreeData(newData));

--- a/src/components/OntologyComponents/DraggableTree.tsx
+++ b/src/components/OntologyComponents/DraggableTree.tsx
@@ -15,7 +15,13 @@ import {
   unlinkPropertyOf,
   updateLinksForInheritance,
 } from "@components/lib/utils/helpers";
-import { collection, doc, getFirestore, updateDoc } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDoc,
+  getFirestore,
+  updateDoc,
+} from "firebase/firestore";
 import { ICollection, TreeData } from "@components/types/INode";
 import { NODES } from "@components/lib/firestoreClient/collections";
 import { useAuth } from "../context/AuthContext";
@@ -627,6 +633,19 @@ function DraggableTree({
     try {
       if (!editEnabled || !user?.uname) return;
 
+      // Fetch from Firestore if the node isn't in the relatedNodes cache
+      const ensureNodeDoc = async (nodeId: string): Promise<any | null> => {
+        if (nodes[nodeId]) return nodes[nodeId];
+        try {
+          const snap = await getDoc(doc(collection(db, NODES), nodeId));
+          if (!snap.exists()) return null;
+          return { id: snap.id, ...snap.data() };
+        } catch (e) {
+          console.error("ensureNodeDoc failed for", nodeId, e);
+          return null;
+        }
+      };
+
       const draggedNodes = args.dragNodes.map((node) => node.data);
       if (draggedNodes[0].isLoadMore) {
         return;
@@ -727,7 +746,13 @@ function DraggableTree({
         const parentId = args.parentId;
         if (parentId) {
           const nodeRef = doc(collection(db, NODES), parentId);
-          const nodeData = nodes[parentId];
+          const nodeData = await ensureNodeDoc(parentId);
+          if (!nodeData) {
+            setSnackbarMessage(
+              "Could not load parent node; reorder not saved.",
+            );
+            return;
+          }
           const specializations = nodeData.specializations;
           const previousValue = JSON.parse(JSON.stringify(specializations));
           const draggedElement = args.dragIds[0];
@@ -750,7 +775,7 @@ function DraggableTree({
             newValue: newSpecializations,
             modifiedAt: new Date(),
             changeType: "sort collections",
-            fullNode: nodes[parentId],
+            fullNode: nodeData,
             ...(appName ? { appName } : {}),
           });
         }
@@ -759,7 +784,11 @@ function DraggableTree({
 
       if (toParent.nodeId === fromParents[0].nodeId) {
         const nodeRef = doc(collection(db, NODES), toParent.nodeId);
-        const nodeData = nodes[toParent.nodeId];
+        const nodeData = await ensureNodeDoc(toParent.nodeId);
+        if (!nodeData) {
+          setSnackbarMessage("Could not load parent node; reorder not saved.");
+          return;
+        }
 
         // Determine source and target collection names
         let from = "main";
@@ -865,7 +894,7 @@ function DraggableTree({
             newValue: specializations,
             modifiedAt: new Date(),
             changeType: "sort elements",
-            fullNode: nodes[toParent.nodeId],
+            fullNode: nodeData,
             ...(appName ? { appName } : {}),
           });
           return;
@@ -923,7 +952,7 @@ function DraggableTree({
             newValue: specializations,
             modifiedAt: new Date(),
             changeType: "sort elements",
-            fullNode: nodes[toParent.nodeId],
+            fullNode: nodeData,
             ...(appName ? { appName } : {}),
           });
           return;
@@ -949,10 +978,14 @@ function DraggableTree({
       const addedLinks = [toParent.nodeId];
       const removedLinks = [generalizationId];
       const specializationId = draggedNodes[0].nodeId;
-      const specializationData = nodes[specializationId];
+      const specializationData = await ensureNodeDoc(specializationId);
+      if (!specializationData) {
+        setSnackbarMessage("Could not load dragged node; move not saved.");
+        return;
+      }
       const newLinks = [toParent.nodeId];
 
-      const newGeneralizations = nodes[specializationId].generalizations;
+      const newGeneralizations = specializationData.generalizations;
       const previousValue = JSON.parse(JSON.stringify(newGeneralizations));
 
       newGeneralizations[0].nodes = newGeneralizations[0].nodes.filter(
@@ -974,7 +1007,11 @@ function DraggableTree({
         await unlinkPropertyOf(db, "generalizations", specializationId, linkId);
       }
 
-      const newGeneralizationData = nodes[toParent.nodeId];
+      const newGeneralizationData = await ensureNodeDoc(toParent.nodeId);
+      if (!newGeneralizationData) {
+        setSnackbarMessage("Could not load target node; move not saved.");
+        return;
+      }
       const specializations = newGeneralizationData.specializations;
       const previousSValue = JSON.parse(JSON.stringify(specializations));
 
@@ -1021,7 +1058,7 @@ function DraggableTree({
         newValue: newGeneralizations,
         modifiedAt: new Date(),
         changeType: "modify elements",
-        fullNode: nodes[specializationId],
+        fullNode: specializationData,
         ...(appName ? { appName } : {}),
       });
 
@@ -1033,7 +1070,7 @@ function DraggableTree({
         newValue: specializations,
         modifiedAt: new Date(),
         changeType: "modify elements",
-        fullNode: nodes[toParent.nodeId],
+        fullNode: newGeneralizationData,
         ...(appName ? { appName } : {}),
       });
 

--- a/src/components/OntologyComponents/drag.tree.module.css
+++ b/src/components/OntologyComponents/drag.tree.module.css
@@ -158,9 +158,9 @@
 }
 
 .node:global(.willReceiveDrop) {
-    background: rgba(76, 175, 80, 0.2);
+    background: var(--tree-hover-bg, rgba(0, 0, 0, 0.04));
     color: inherit;
-    box-shadow: inset 0 0 0 1px rgba(76, 175, 80, 0.55);
+    box-shadow: inset 0 0 0 1px rgba(145, 158, 171, 0.55);
 }
 
 

--- a/src/lib/utils/loadOutlineFromPathIds.ts
+++ b/src/lib/utils/loadOutlineFromPathIds.ts
@@ -384,28 +384,42 @@ export async function resolvePathIds(
   return { pathIds: chain, usedPrimaryParentFallback: true };
 }
 
+/**
+ * Carry loaded subtrees from `oldTree` into `newTree` where row ids match
+ * so that old expansion survives when outline is rebuilt by navigation
+ */
 export function mergePreservedSubtrees(
-  newChildren: TreeData[],
-  oldChildren: TreeData[] | undefined,
+  newTree: TreeData[],
+  oldTree: TreeData[] | undefined,
 ): TreeData[] {
-  if (!oldChildren?.length) return newChildren;
-  // Key by "id": categories share nodeId and would cause visual inconsistencies
-  const byId = new Map(oldChildren.map((c) => [c.id, c]));
-  return newChildren.map((nc) => {
-    const prev = byId.get(nc.id);
-    // Only keep old row if it has loaded children; let fresh data win otherwise
-    const prevHasLoadedSubtree = !!prev?.children && prev.children.length > 0;
-    if (prev && prevHasLoadedSubtree) {
+  if (!oldTree?.length) return newTree;
+  const oldById = new Map(oldTree.map((row) => [row.id, row]));
+  return newTree.map((newRow) => {
+    const oldRow = oldById.get(newRow.id);
+    // No prior row with this id, nothing to merge
+    if (!oldRow) return newRow;
+    // "Loaded" = has real children; rows have empty array to show a chevron without loading
+    const newHasLoaded = !!newRow.children && newRow.children.length > 0;
+    const oldHasLoaded = !!oldRow.children && oldRow.children.length > 0;
+    // newRow is lazy but oldRow has the user's expansion: keep oldRow's subtree and lazy flags
+    if (!newHasLoaded && oldHasLoaded) {
       return {
-        ...nc,
-        children: prev.children,
-        outlineSpineOnly: prev.outlineSpineOnly,
-        outlineLoadChildren: prev.outlineLoadChildren,
+        ...newRow,
+        children: oldRow.children,
+        outlineSpineOnly: oldRow.outlineSpineOnly,
+        outlineLoadChildren: oldRow.outlineLoadChildren,
         hasUnresolvedChildren:
-          prev.hasUnresolvedChildren ?? nc.hasUnresolvedChildren,
+          oldRow.hasUnresolvedChildren ?? newRow.hasUnresolvedChildren,
       } as TreeData;
     }
-    return nc;
+    // If both is expanded, keep fresh structure here, recurse to carry deeper expansions
+    if (newHasLoaded && oldHasLoaded) {
+      return {
+        ...newRow,
+        children: mergePreservedSubtrees(newRow.children!, oldRow.children!),
+      } as TreeData;
+    }
+    return newRow;
   });
 }
 

--- a/src/pages/Ontology.tsx
+++ b/src/pages/Ontology.tsx
@@ -152,6 +152,7 @@ import {
   batchGetNodesByIds,
   buildPathTreeWithSiblings,
   collectSpecializationChildIds,
+  mergePreservedSubtrees,
   nodeHasNonEmptySpecializations,
   replaceSpineWithOneLevel,
   replaceWithOneLevel,
@@ -336,14 +337,23 @@ const Ontology = ({
         hasInstantUpdateRef.current = false;
       }, 30000);
 
-      setCurrentNodeTreeData((prevTree) => {
-        const newTree = updateFn(prevTree);
-
-        return newTree;
-      });
+      setCurrentNodeTreeData((prevTree) => updateFn(prevTree));
     },
     [currentVisibleNode?.id, currentVisibleNode, db],
   );
+
+  // Clear the instant update guard on navigation so loadPathOutline runs
+  // mergeOutlines preserves prior expansion across the reload.
+  useEffect(() => {
+    if (!hasInstantUpdateRef.current) return;
+    setHasInstantUpdate(false);
+    hasInstantUpdateRef.current = false;
+    if (instantUpdateTimeoutRef.current) {
+      clearTimeout(instantUpdateTimeoutRef.current);
+      instantUpdateTimeoutRef.current = null;
+    }
+  }, [currentVisibleNode?.id]);
+
   // Auto-focus search input on mobile search open
   useEffect(() => {
     if (mobileSearchOpen && isMobile) {
@@ -459,7 +469,7 @@ const Ontology = ({
 
       const tree = [...pathTree, ...otherRoots];
       const filtered = filterTreeForTargetNode(tree, focused.id);
-      setCurrentNodeTreeData(filtered);
+      setCurrentNodeTreeData((prev) => mergePreservedSubtrees(filtered, prev));
     } catch {
       setCurrentNodeTreeData([]);
     } finally {


### PR DESCRIPTION
Hi @samadouhra,

This PR fixes several Outline View issues related to navigation, tree expansion state, and drag/drop behavior.

1. ensuring chevrons remain visible after edits
2. preventing drag edits from breaking when the dragged node is not focused
3. preserving the outline tree’s expanded state when navigating to a different focused node after drag edits, instead of freezing the outline or resetting expanded branches

Changes include:

* making `mergePreservedSubtrees` recursive so expanded subtrees are preserved beyond one level (on usual navigation, the merge only look into one level as before)
* allowing outline refreshes on focused node changes without losing expansion state
* defaulting outline node children to an empty array so all nodes remain as drop targets
* changing drop target highlighting
* using fetched node docs for drag operations when nodes are not cached