### PR TITLE
Fix node cloning issues

### DIFF
--- a/src/components/LinkNode/LinkEditor.tsx
+++ b/src/components/LinkNode/LinkEditor.tsx
@@ -48,7 +48,9 @@ const LinkEditor: React.FC<LinkEditorProps> = ({
   const handleChanges = (e: any) => {
     setEditorContent(e.target.value);
     setClonedNodesQueue(
-      (prev: { [nodeId: string]: { title: string; id: string } }) => {
+      (prev: {
+        [nodeId: string]: { title: string; id: string; property: string };
+      }) => {
         prev[reviewId].title = e.target.value;
         return prev;
       },

--- a/src/components/LinkNode/LinkNode.tsx
+++ b/src/components/LinkNode/LinkNode.tsx
@@ -674,8 +674,9 @@ const LinkNode = ({
       .filter((n) => !!relatedNodes[n.id]?.title);
   };
 
-  const isQueuedClone = clonedNodesQueue.hasOwnProperty(link.id);
-  const queuedTitle = clonedNodesQueue[link.id]?.title;
+  const queueEntry = clonedNodesQueue[link.id];
+  const isQueuedClone = queueEntry?.property === property;
+  const queuedTitle = queueEntry?.title;
   return (
     <Box
       id={`${link.id}-${property}`}
@@ -700,7 +701,7 @@ const LinkNode = ({
           borderRadius: "25px",
 
           ":hover": {
-            backgroundColor: clonedNodesQueue.hasOwnProperty(link.id)
+            backgroundColor: isQueuedClone
               ? ""
               : (theme) =>
                   theme.palette.mode === "dark" ? "#5f5e5d" : "#d9dfe6",
@@ -834,7 +835,7 @@ const LinkNode = ({
           {property === "parts" &&
             !currentImprovement &&
             !selectedDiffNode &&
-            !clonedNodesQueue.hasOwnProperty(link.id) &&
+            !isQueuedClone &&
             !loadingIds.has(link.id) &&
             enableEdit && (
               <Tooltip title={swapIt ? "Close" : "Specialize"}>

--- a/src/components/LinkNode/LinkNode.tsx
+++ b/src/components/LinkNode/LinkNode.tsx
@@ -114,6 +114,7 @@ import {
 } from "firebase/firestore";
 
 import CloseIcon from "@mui/icons-material/Close";
+import CheckIcon from "@mui/icons-material/Check";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getTitleDeleted } from "@components/lib/utils/string.utils";
 import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
@@ -166,6 +167,7 @@ type ILinkNodeProps = {
   currentImprovement: any;
   loadingIds: any;
   saveNewSpecialization: any;
+  cancelPendingClone?: (queuedId: string) => void;
   enableEdit: boolean;
   setEditableProperty: any;
   unlinkNodeRelation: any;
@@ -200,6 +202,7 @@ const LinkNode = ({
   currentImprovement,
   loadingIds,
   saveNewSpecialization,
+  cancelPendingClone,
   enableEdit,
   setEditableProperty,
   unlinkNodeRelation,
@@ -732,6 +735,40 @@ const LinkNode = ({
               sx={{ color: getLinkColor(link.change), pl: "5px" }}
             />
           )}{" "}
+          {isQueuedClone &&
+            property !== "parts" &&
+            enableEdit &&
+            !selectedDiffNode &&
+            !currentImprovement &&
+            (loadingIds.has(link.id) ? (
+              <LoadingButton
+                loading
+                loadingIndicator={<CircularProgress size={20} />}
+                sx={{ borderRadius: "16px", p: "3px", minWidth: "40px" }}
+                disabled
+              />
+            ) : (
+              <Box sx={{ display: "flex" }}>
+                <Tooltip title="Save new specialization">
+                  <IconButton
+                    sx={{ ml: "8px", borderRadius: "18px", p: 0.2 }}
+                    onClick={() =>
+                      saveNewSpecialization(link.id, collectionName)
+                    }
+                  >
+                    <CheckIcon sx={{ color: "green" }} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Discard">
+                  <IconButton
+                    sx={{ ml: "4px", borderRadius: "18px", p: 0.2 }}
+                    onClick={() => cancelPendingClone?.(link.id)}
+                  >
+                    <CloseIcon sx={{ color: "red" }} />
+                  </IconButton>
+                </Tooltip>
+              </Box>
+            ))}
           {selectedProperty === property &&
             selectedProperty === "parts" &&
             !isQueuedClone && (

--- a/src/components/OntologyComponents/Node.tsx
+++ b/src/components/OntologyComponents/Node.tsx
@@ -736,6 +736,9 @@ const Node = ({
               });
             }
           }
+        } else if (mProperty === "parts") {
+          // Keeps parts out of the catch-all else below that
+          // would self-reference newNode.id into its own parts
         } else {
           // Handling property updates
           if (newNode.inheritance[mProperty]?.ref) {

--- a/src/components/OntologyComponents/Node.tsx
+++ b/src/components/OntologyComponents/Node.tsx
@@ -576,9 +576,11 @@ const Node = ({
     const newId = doc(collection(db, NODES)).id;
     const newTitle = title ? title : `New ${node.title}`;
     setClonedNodesQueue(
-      (prev: { [nodeId: string]: { title: string; id: string } }) => ({
+      (prev: {
+        [nodeId: string]: { title: string; id: string; property: string };
+      }) => ({
         ...prev,
-        [newId]: { title: newTitle, id: nodeId },
+        [newId]: { title: newTitle, id: nodeId, property: selectedProperty },
       }),
     );
     setNewOnes((newOnes: any) => {
@@ -954,17 +956,12 @@ const Node = ({
     searchValue = null,
     newId = null,
     collectionName: string = "main",
+    property: string = selectedProperty,
   ) => {
     // Call the asynchronous function to clone the node with the given ID.
     // Close the modal or perform any necessary cleanup.
     // handleCloseAddLinksModel();
-    await cloneNode(
-      node.id,
-      searchValue,
-      newId,
-      selectedProperty,
-      collectionName,
-    );
+    await cloneNode(node.id, searchValue, newId, property, collectionName);
   };
 
   const editStructuredProperty = async (

--- a/src/components/OntologyComponents/Node.tsx
+++ b/src/components/OntologyComponents/Node.tsx
@@ -1091,6 +1091,10 @@ const Node = ({
             );
           }
         }
+        // Initialize an empty collection structure if the property doesn't exist or has no collections yet
+        if (!previousValue || previousValue.length === 0) {
+          previousValue = [{ collectionName: "main", nodes: [] }];
+        }
         const newValue = JSON.parse(JSON.stringify(previousValue));
         for (let collection of newValue) {
           collection.nodes = collection.nodes.filter(

--- a/src/components/StructuredProperty/CollectionStructure.tsx
+++ b/src/components/StructuredProperty/CollectionStructure.tsx
@@ -210,6 +210,7 @@ const CollectionStructure = ({
   loadingIds,
   setLoadingIds,
   saveNewSpecialization,
+  cancelPendingClone,
   editableProperty,
   onGetPropertyValue,
   setRemovedElements,
@@ -279,6 +280,7 @@ const CollectionStructure = ({
   loadingIds: any;
   setLoadingIds: any;
   saveNewSpecialization: any;
+  cancelPendingClone?: (queuedId: string) => void;
   editableProperty: any;
   onGetPropertyValue: any;
   setRemovedElements: any;
@@ -2195,6 +2197,9 @@ const CollectionStructure = ({
                                                   loadingIds={loadingIds}
                                                   saveNewSpecialization={
                                                     saveNewSpecialization
+                                                  }
+                                                  cancelPendingClone={
+                                                    cancelPendingClone
                                                   }
                                                   enableEdit={enableEdit}
                                                   setClonedNodesQueue={

--- a/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
@@ -590,7 +590,6 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
     if (!inheritedPartsDetails || !mutateData) return;
     const updated = updater(JSON.parse(JSON.stringify(inheritedPartsDetails)));
     mutateData(updated);
-    debouncedRefetch?.();
   };
 
   const onAddPart = (partId: string) => {
@@ -629,6 +628,8 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
       }
       return data;
     });
+    // Show a spinner in place of the symbol until the API recompute lands
+    setCalculatingPartIds((prev) => new Set(prev).add(partId));
   };
 
   const onRemovePart = (partId: string) => {
@@ -759,6 +760,9 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
       }
       return data;
     });
+
+    // Show a spinner in place of the symbol until the API recompute lands
+    setCalculatingPartIds((prev) => new Set(prev).add(queuedId));
 
     setApprovingPendingIds((prev) => {
       const updated = new Set(prev);
@@ -896,7 +900,124 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
     const hasParts =
       currentVisibleNode.properties?.parts?.[0]?.nodes?.length > 0;
 
+    // Computed first so the nodes with no parts can render pending rows too
+    const pendingQueuedParts = Object.entries(clonedNodesQueue || {})
+      .filter(([, queuedNode]) => queuedNode?.property === "parts")
+      .map(([queuedId, queuedNode]) => ({
+        id: queuedId,
+        title: queuedNode?.title || "",
+      }));
+
+    const pendingRowsList =
+      pendingQueuedParts.length > 0 ? (
+        <List sx={{ px: 1.8, py: 1, mt: -0.5 }}>
+          {pendingQueuedParts.map((pendingPart) => {
+            const isNewlyQueued = highlightedPendingIds.has(pendingPart.id);
+
+            return (
+              <ListItem
+                key={`pending-${pendingPart.id}`}
+                sx={{
+                  display: "flex",
+                  gap: 1,
+                  px: 1,
+                  py: 0.2,
+                  borderRadius: "12px",
+                  border: "1px dashed",
+                  borderColor: (theme) =>
+                    theme.palette.mode === "dark" ? "#5a5a5a" : "#c8c8c8",
+                  mb: 0.5,
+                  "@keyframes pendingPartHighlight": {
+                    "0%": {
+                      backgroundColor: "rgba(255, 165, 0, 0.32)",
+                      boxShadow: "0 0 0 1px rgba(255, 165, 0, 0.45)",
+                    },
+                    "100%": {
+                      backgroundColor: "transparent",
+                      boxShadow: "0 0 0 0 rgba(255, 165, 0, 0)",
+                    },
+                  },
+                  animation: isNewlyQueued
+                    ? "pendingPartHighlight 1s ease-out"
+                    : "none",
+                }}
+              >
+                <ListItemText primary={null} sx={{ flex: 1, minWidth: 0.3 }} />
+                <ListItemIcon sx={{ minWidth: "auto" }}>
+                  <AddIcon sx={{ fontSize: 20, color: "orange" }} />
+                </ListItemIcon>
+                <ListItemText
+                  primary={
+                    <TextField
+                      size="small"
+                      fullWidth
+                      value={pendingPart.title}
+                      onChange={(e) =>
+                        updatePendingPartTitle?.(pendingPart.id, e.target.value)
+                      }
+                      placeholder="New part title"
+                      sx={{
+                        "& .MuiInputBase-root": {
+                          borderRadius: "12px",
+                        },
+                      }}
+                    />
+                  }
+                  sx={{ flex: 1, minWidth: 0.3 }}
+                />
+                {!!approvePendingPart && (
+                  <Tooltip title={"Approve part"} placement="top">
+                    <IconButton
+                      sx={{ p: 0.5 }}
+                      disabled={approvingPendingIds.has(pendingPart.id)}
+                      onClick={() => {
+                        onApprovePendingPart(pendingPart.id, pendingPart.title);
+                      }}
+                    >
+                      {approvingPendingIds.has(pendingPart.id) ? (
+                        <CircularProgress size={20} />
+                      ) : (
+                        <CheckIcon
+                          sx={{
+                            fontSize: 20,
+                            color: "green",
+                            border: "1px solid green",
+                            borderRadius: "50%",
+                          }}
+                        />
+                      )}
+                    </IconButton>
+                  </Tooltip>
+                )}
+                {!!cancelPendingPart && (
+                  <Tooltip title={"Cancel part"} placement="top">
+                    <IconButton
+                      sx={{ p: 0.5 }}
+                      onClick={() => {
+                        cancelPendingPart(pendingPart.id);
+                      }}
+                    >
+                      <CloseIcon
+                        sx={{
+                          fontSize: 20,
+                          color: "red",
+                          border: "1px solid red",
+                          borderRadius: "50%",
+                        }}
+                      />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </ListItem>
+            );
+          })}
+        </List>
+      ) : null;
+
     if (!hasParts) {
+      if (pendingRowsList) {
+        return <Box>{pendingRowsList}</Box>;
+      }
       return (
         <Box
           sx={{
@@ -928,27 +1049,30 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
 
     if (!inheritedPartsDetails || !cachedGeneralizationData) {
       return (
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 1,
-            py: 2,
-          }}
-        >
-          <CircularProgress size={16} />
-          <Typography
-            variant="body2"
+        <Box>
+          <Box
             sx={{
-              color: (theme) =>
-                theme.palette.mode === "light" ? "#95a5a6" : "#7f8c8d",
-              fontStyle: "italic",
-              fontSize: "0.75rem",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 1,
+              py: 2,
             }}
           >
-            Loading...
-          </Typography>
+            <CircularProgress size={16} />
+            <Typography
+              variant="body2"
+              sx={{
+                color: (theme) =>
+                  theme.palette.mode === "light" ? "#95a5a6" : "#7f8c8d",
+                fontStyle: "italic",
+                fontSize: "0.75rem",
+              }}
+            >
+              Loading...
+            </Typography>
+          </Box>
+          {pendingRowsList}
         </Box>
       );
     }
@@ -997,12 +1121,6 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
       const index = details.findIndex((d) => d.from === id);
       return index === -1;
     });
-    const pendingQueuedParts = Object.entries(clonedNodesQueue || {})
-      .filter(([, queuedNode]) => queuedNode?.property === "parts")
-      .map(([queuedId, queuedNode]) => ({
-        id: queuedId,
-        title: queuedNode?.title || "",
-      }));
 
     // Parts that exist on the node but aren't yet reflected in the inheritedPartsDetails returned from endpoint
     const currentPartIds: string[] =
@@ -1710,110 +1828,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
             ))}
           </List>
         )}
-        {pendingQueuedParts.length > 0 && (
-          <List sx={{ px: 1.8, py: 1, mt: -0.5 }}>
-            {pendingQueuedParts.map((pendingPart) => {
-              const isNewlyQueued = highlightedPendingIds.has(pendingPart.id);
-
-              return (
-                <ListItem
-                  key={`pending-${pendingPart.id}`}
-                  sx={{
-                    display: "flex",
-                    gap: 1,
-                    px: 1,
-                    py: 0.2,
-                    borderRadius: "12px",
-                    border: "1px dashed",
-                    borderColor: (theme) =>
-                      theme.palette.mode === "dark" ? "#5a5a5a" : "#c8c8c8",
-                    mb: 0.5,
-                    "@keyframes pendingPartHighlight": {
-                      "0%": {
-                        backgroundColor: "rgba(255, 165, 0, 0.32)",
-                        boxShadow: "0 0 0 1px rgba(255, 165, 0, 0.45)",
-                      },
-                      "100%": {
-                        backgroundColor: "transparent",
-                        boxShadow: "0 0 0 0 rgba(255, 165, 0, 0)",
-                      },
-                    },
-                    animation: isNewlyQueued
-                      ? "pendingPartHighlight 1s ease-out"
-                      : "none",
-                  }}
-                >
-                  <ListItemText primary={null} sx={{ flex: 1, minWidth: 0.3 }} />
-                  <ListItemIcon sx={{ minWidth: "auto" }}>
-                    <AddIcon sx={{ fontSize: 20, color: "orange" }} />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={
-                      <TextField
-                        size="small"
-                        fullWidth
-                        value={pendingPart.title}
-                        onChange={(e) =>
-                          updatePendingPartTitle?.(pendingPart.id, e.target.value)
-                        }
-                        placeholder="New part title"
-                        sx={{
-                          "& .MuiInputBase-root": {
-                            borderRadius: "12px",
-                          },
-                        }}
-                      />
-                    }
-                    sx={{ flex: 1, minWidth: 0.3 }}
-                  />
-                  {!!approvePendingPart && (
-                    <Tooltip title={"Approve part"} placement="top">
-                      <IconButton
-                        sx={{ p: 0.5 }}
-                        disabled={approvingPendingIds.has(pendingPart.id)}
-                        onClick={() => {
-                          onApprovePendingPart(pendingPart.id, pendingPart.title);
-                        }}
-                      >
-                        {approvingPendingIds.has(pendingPart.id) ? (
-                          <CircularProgress size={20} />
-                        ) : (
-                          <CheckIcon
-                            sx={{
-                              fontSize: 20,
-                              color: "green",
-                              border: "1px solid green",
-                              borderRadius: "50%",
-                            }}
-                          />
-                        )}
-                      </IconButton>
-                    </Tooltip>
-                  )}
-                  {!!cancelPendingPart && (
-                    <Tooltip title={"Cancel part"} placement="top">
-                      <IconButton
-                        sx={{ p: 0.5 }}
-                        onClick={() => {
-                          cancelPendingPart(pendingPart.id);
-                        }}
-                      >
-                        <CloseIcon
-                          sx={{
-                            fontSize: 20,
-                            color: "red",
-                            border: "1px solid red",
-                            borderRadius: "50%",
-                          }}
-                        />
-                      </IconButton>
-                    </Tooltip>
-                  )}
-                </ListItem>
-              );
-            })}
-          </List>
-        )}
+        {pendingRowsList}
       </Box>
     );
   };

--- a/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
@@ -86,7 +86,9 @@ interface InheritedPartsViewerProps {
   mutateData?: (newData: InheritedPartsDetail[] | null) => void;
   debouncedRefetch?: () => void;
   refetchNow?: () => void;
-  clonedNodesQueue?: { [nodeId: string]: { title: string; id: string } };
+  clonedNodesQueue?: {
+    [nodeId: string]: { title: string; id: string; property: string };
+  };
   approvePendingPart?: (queuedId: string) => Promise<void> | void;
   cancelPendingPart?: (queuedId: string) => void;
   updatePendingPartTitle?: (queuedId: string, title: string) => void;
@@ -995,12 +997,12 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
       const index = details.findIndex((d) => d.from === id);
       return index === -1;
     });
-    const pendingQueuedParts = Object.entries(clonedNodesQueue || {}).map(
-      ([queuedId, queuedNode]) => ({
+    const pendingQueuedParts = Object.entries(clonedNodesQueue || {})
+      .filter(([, queuedNode]) => queuedNode?.property === "parts")
+      .map(([queuedId, queuedNode]) => ({
         id: queuedId,
         title: queuedNode?.title || "",
-      }),
-    );
+      }));
 
     // Parts that exist on the node but aren't yet reflected in the inheritedPartsDetails returned from endpoint
     const currentPartIds: string[] =

--- a/src/components/StructuredProperty/PartViewer.tsx
+++ b/src/components/StructuredProperty/PartViewer.tsx
@@ -24,7 +24,9 @@ interface PartViewerProps {
   appName?: string;
   getGeneralizationParts: any;
   onDisplayDetailsChange?: (isExpanded: boolean) => void;
-  clonedNodesQueue?: { [nodeId: string]: { title: string; id: string } };
+  clonedNodesQueue?: {
+    [nodeId: string]: { title: string; id: string; property: string };
+  };
   saveNewSpecialization?: (queuedId: string, collectionName: string) => void;
   cancelPendingPart?: (queuedId: string) => void;
   updatePendingPartTitle?: (queuedId: string, title: string) => void;

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -539,12 +539,14 @@ const StructuredProperty = ({
         _prev.add(nId);
         return _prev;
       });
+      const queued = clonedNodesQueue[nId];
+      const property = queued.property;
       const addedElements: string[] = [nId];
 
       await handleSaveLinkChanges(
         [],
         addedElements,
-        selectedProperty,
+        property,
         currentVisibleNode?.id,
         collectionName,
       );
@@ -553,14 +555,14 @@ const StructuredProperty = ({
         _prev.delete(nId);
         return _prev;
       });
-      const id = clonedNodesQueue[nId].id;
-      const title = clonedNodesQueue[nId].title;
+      const id = queued.id;
+      const title = queued.title;
       setClonedNodesQueue((prev: any) => {
         const _prev = { ...prev };
         delete _prev[nId];
         return _prev;
       });
-      await handleCloning({ id }, title, nId, collectionName);
+      await handleCloning({ id }, title, nId, collectionName, property);
     } catch (error) {
       console.error(error);
     }
@@ -584,7 +586,9 @@ const StructuredProperty = ({
       return updated;
     });
     setClonedNodesQueue(
-      (prev: { [nodeId: string]: { title: string; id: string } }) => {
+      (prev: {
+        [nodeId: string]: { title: string; id: string; property: string };
+      }) => {
         const updated = { ...prev };
         delete updated[queuedId];
         return updated;
@@ -594,7 +598,9 @@ const StructuredProperty = ({
 
   const updatePendingPartTitle = (queuedId: string, title: string) => {
     setClonedNodesQueue(
-      (prev: { [nodeId: string]: { title: string; id: string } }) => ({
+      (prev: {
+        [nodeId: string]: { title: string; id: string; property: string };
+      }) => ({
         ...prev,
         [queuedId]: {
           ...prev[queuedId],

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -1521,7 +1521,11 @@ const StructuredProperty = ({
               selectedDiffNode={selectedDiffNode}
               currentImprovement={currentImprovement}
               property={property}
-              propertyValue={propertyValue ?? []}
+              propertyValue={
+                selectedProperty === property
+                  ? editableProperty ?? []
+                  : propertyValue ?? []
+              }
               setEditableProperty={setEditableProperty}
               getCategoryStyle={getCategoryStyle}
               navigateToNode={navigateToNode}
@@ -1574,6 +1578,7 @@ const StructuredProperty = ({
               setNewOnes={setNewOnes}
               loadingIds={loadingIds}
               saveNewSpecialization={saveNewSpecialization}
+              cancelPendingClone={cancelPendingPart}
               setLoadingIds={setLoadingIds}
               editableProperty={editableProperty}
               onGetPropertyValue={onGetPropertyValue}

--- a/src/components/StructuredProperty/StructuredPropertySelector.tsx
+++ b/src/components/StructuredProperty/StructuredPropertySelector.tsx
@@ -124,7 +124,9 @@ const StructuredPropertySelector = ({
     title?: string,
   ) => Promise<string | null>;
   setClonedNodesQueue: Function;
-  clonedNodesQueue: { [nodeId: string]: { title: string; id: string } };
+  clonedNodesQueue: {
+    [nodeId: string]: { title: string; id: string; property: string };
+  };
   newOnes: any;
   setNewOnes: any;
   loadingIds: any;
@@ -845,7 +847,9 @@ const StructuredPropertySelector = ({
     });
 
     setClonedNodesQueue(
-      (prev: { [nodeId: string]: { title: string; id: string } }) => {
+      (prev: {
+        [nodeId: string]: { title: string; id: string; property: string };
+      }) => {
         const updated = { ...prev };
         delete updated[queuedCloneId];
         return updated;

--- a/src/components/StructuredProperty/StructuredPropertySelector.tsx
+++ b/src/components/StructuredProperty/StructuredPropertySelector.tsx
@@ -319,7 +319,8 @@ const StructuredPropertySelector = ({
         [];
     }
 
-    setEditableProperty([...freshData]);
+    // Deep clone so edits to editableProperty don't mutate the source node.
+    setEditableProperty(JSON.parse(JSON.stringify(freshData)));
   }, [
     selectedProperty,
     currentVisibleNode,
@@ -802,10 +803,12 @@ const StructuredPropertySelector = ({
         where("nodeType", "==", nodeType),
       ),
     );
-    if (unclassifiedNodeDocs.docs.length > 0) {
-      const unclassifiedId = unclassifiedNodeDocs.docs[0].id;
-      // Reuse the same queue + UI pending flow used by search-result add.
-      await _add(unclassifiedId, searchValue);
+    // Pick the first non-deleted candidate.
+    const candidate = unclassifiedNodeDocs.docs.find(
+      (d) => (d.data() as any).deleted !== true,
+    );
+    if (candidate) {
+      await _add(candidate.id, searchValue);
     }
   };
 

--- a/src/pages/Ontology.tsx
+++ b/src/pages/Ontology.tsx
@@ -249,7 +249,7 @@ const Ontology = ({
   );
   const [searchValue, setSearchValue] = useState("");
   const [clonedNodesQueue, setClonedNodesQueue] = useState<{
-    [nodeId: string]: { title: string; id: string };
+    [nodeId: string]: { title: string; id: string; property: string };
   }>({});
   const [newOnes, setNewOnes] = useState(new Set());
   const [loadingIds, setLoadingIds] = useState(new Set());


### PR DESCRIPTION
Hi @samadouhra

This PR fixes node cloning failures and cloning issues under unclassified nodes in the Parts Editor.

Changes include:

* re-enabling per-item approve/discard for queued specialization clones
* scoping `clonedNodesQueue` entries to their corresponding property editor
* fixing cloning new parts under unclassified nodes not working
* preventing unwanted refetches for inheritance calculation when queueing new parts
* fixing blank specialization rows remaining after discarding queued changes
* fixing shared state issues across property editors
* enabling node queuing and cloning the first part on nodes that have none
* fixing new cloned parts self-referencing themselves under parts

