### PR TITLE
Migrate generic property mutations to a single API endpoint

### DIFF
--- a/src/components/AddPropertyForm/AddPropertyForm.tsx
+++ b/src/components/AddPropertyForm/AddPropertyForm.tsx
@@ -7,10 +7,15 @@ import {
   Select,
   MenuItem,
   TextField,
-  Paper,
   Typography,
+  Paper,
+  Tooltip,
+  IconButton,
+  useTheme,
+  Slide,
 } from "@mui/material";
-import { development } from "@components/lib/CONSTANTS";
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
 
 interface AddPropertyFormProps {
   addNewProperty: (title: string, type: string) => void;
@@ -29,6 +34,9 @@ const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
   exitingProperties,
   appName,
 }) => {
+  const theme = useTheme();
+  const BUTTON_COLOR = theme.palette.mode === "dark" ? "#373739" : "#dde2ea";
+
   const [propertyType, setPropertyType] = useState<string>("String");
   const [newPropertyTitle, setNewPropertyTitle] = useState<string>("");
   const [inputError, setInputError] = useState<boolean>(false);
@@ -72,114 +80,229 @@ const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
     setPropertyType("String");
   };
 
+  const handleCancel = () => {
+    setOpenAddProperty(false);
+    setNewPropertyTitle("");
+    setInputError(false);
+    setDuplicateError(false);
+  };
+
+  const disableAdd =
+    !propertyType ||
+    !newPropertyTitle ||
+    inputError ||
+    locked ||
+    duplicateError;
+
+  const modernFieldSx = {
+    "& .MuiOutlinedInput-root": {
+      borderRadius: "14px",
+      backgroundColor: (theme: any) =>
+        theme.palette.mode === "dark"
+          ? "rgba(255, 255, 255, 0.04)"
+          : "rgba(15, 23, 42, 0.03)",
+      transition:
+        "background-color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease",
+      "& .MuiOutlinedInput-notchedOutline": {
+        borderColor: (theme: any) =>
+          theme.palette.mode === "dark"
+            ? "rgba(255, 255, 255, 0.18)"
+            : "rgba(15, 23, 42, 0.14)",
+        transition: "border-color 0.2s ease",
+      },
+      "&:hover": {
+        backgroundColor: (theme: any) =>
+          theme.palette.mode === "dark"
+            ? "rgba(255, 255, 255, 0.06)"
+            : "rgba(15, 23, 42, 0.05)",
+        "& .MuiOutlinedInput-notchedOutline": {
+          borderColor: (theme: any) =>
+            theme.palette.mode === "dark"
+              ? "rgba(255, 255, 255, 0.3)"
+              : "rgba(15, 23, 42, 0.24)",
+        },
+      },
+      "&.Mui-focused": {
+        "& .MuiOutlinedInput-notchedOutline": {
+          borderColor: "orange",
+          borderWidth: "1.5px",
+        },
+        boxShadow: "0 0 0 3px rgba(255, 165, 0, 0.18)",
+      },
+    },
+  } as const;
+
   return (
-    <Paper
-      sx={{
-        mt: "20px",
-        mb: "20px",
-        borderRadius: "18px",
-        padding: "20px",
-      }}
-      elevation={3}
-    >
-      <Typography variant="h6" sx={{ mb: "16px" }}>
-        Add New Property
-      </Typography>
-      <Box
+    <Slide direction="down" in={true} timeout={500}>
+      <Paper
+        elevation={9}
         sx={{
-          display: "flex",
-          flexDirection: "column",
-          gap: 2,
+          mt: "20px",
+          mb: "20px",
+          borderRadius: "30px",
+          borderBottomRightRadius: "18px",
+          borderBottomLeftRadius: "18px",
+          width: "100%",
+          overflow: "hidden",
+          border: "2px solid orange",
         }}
       >
-        <FormControl variant="outlined" sx={{ borderRadius: "20px" }}>
-          <InputLabel id="property-type-label">Type</InputLabel>
-          <Select
-            labelId="property-type-label"
-            id="add-property-type"
-            value={propertyType}
-            onChange={(event) => setPropertyType(event.target.value)}
-            label="Property Type"
-            sx={{ borderRadius: "20px" }}
-          >
-            {(!!appName
-              ? ["String", "Activity"]
-              : [
-                  "String",
-                  "Activity",
-                  "Object",
-                  "Actor",
-                  "Evaluation Dimension",
-                  "Incentive",
-                  "Reward",
-                  "Numeric",
-                ]
-            ).map((item) => (
-              <MenuItem key={item} value={item}>
-                {item}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-
-        <TextField
-          label="Property Title"
-          value={newPropertyTitle}
-          onChange={handleTitleChange}
-          error={inputError || duplicateError}
-          helperText={
-            inputError
-              ? "Max 30 characters, no special characters allowed."
-              : duplicateError
-                ? "This property already exists."
-                : ""
-          }
-          InputLabelProps={{
-            sx: { color: "grey" },
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            background: (theme) =>
+              theme.palette.mode === "dark" ? "#242425" : "#d0d5dd",
+            p: 3,
           }}
-        />
-        <Box sx={{ display: "flex", gap: "10px" }}>
-          <Button
-            onClick={handleAddProperty}
-            color="primary"
-            disabled={
-              !propertyType ||
-              !newPropertyTitle ||
-              inputError ||
-              locked ||
-              duplicateError
-            }
-            variant="contained"
-            sx={{
-              borderRadius: "18px",
-              backgroundColor: "green",
-              mt: "10px",
-            }}
-            fullWidth
-          >
-            {"Add"}
-          </Button>
-          <Button
-            onClick={() => {
-              setOpenAddProperty(false);
-              setNewPropertyTitle("");
-              setInputError(false);
-              setDuplicateError(false);
-            }}
-            color="primary"
-            variant="contained"
-            sx={{
-              borderRadius: "18px",
-              mt: "10px",
-              backgroundColor: "red",
-            }}
-            fullWidth
-          >
-            {"Cancel"}
-          </Button>
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <AddIcon sx={{ color: "orange" }} />
+            <Typography
+              sx={{
+                fontSize: "20px",
+                fontWeight: 500,
+                fontFamily: "Roboto, sans-serif",
+                padding: "4px",
+              }}
+            >
+              Add New Property
+            </Typography>
+          </Box>
+
+          <Box sx={{ ml: "auto" }}>
+            <Tooltip title={"Close"}>
+              <IconButton
+                onClick={handleCancel}
+                sx={{ borderRadius: "25px", backgroundColor: "red" }}
+              >
+                <CloseIcon sx={{ color: "white" }} />
+              </IconButton>
+            </Tooltip>
+          </Box>
         </Box>
-      </Box>
-    </Paper>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 2.5,
+            p: 3,
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: { xs: "column", sm: "row" },
+              alignItems: "flex-start",
+              gap: 2,
+            }}
+          >
+            <FormControl
+              variant="outlined"
+              sx={{
+                ...modernFieldSx,
+                width: { xs: "100%", sm: "200px" },
+                flexShrink: 0,
+              }}
+            >
+              <InputLabel id="property-type-label">Type</InputLabel>
+              <Select
+                labelId="property-type-label"
+                id="add-property-type"
+                value={propertyType}
+                onChange={(event) => setPropertyType(event.target.value)}
+                label="Type"
+                MenuProps={{
+                  PaperProps: {
+                    sx: {
+                      borderRadius: "14px",
+                      mt: "6px",
+                      boxShadow: (theme) =>
+                        theme.palette.mode === "dark"
+                          ? "0 12px 32px rgba(0,0,0,0.5)"
+                          : "0 12px 32px rgba(15,23,42,0.16)",
+                      "& .MuiMenuItem-root": {
+                        borderRadius: "8px",
+                        mx: "6px",
+                        my: "2px",
+                      },
+                    },
+                  },
+                }}
+              >
+                {(!!appName
+                  ? ["String", "Activity"]
+                  : [
+                      "String",
+                      "Activity",
+                      "Object",
+                      "Actor",
+                      "Evaluation Dimension",
+                      "Incentive",
+                      "Reward",
+                      "Numeric",
+                    ]
+                ).map((item) => (
+                  <MenuItem key={item} value={item}>
+                    {item}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <TextField
+              label="Property Title"
+              value={newPropertyTitle}
+              onChange={handleTitleChange}
+              error={inputError || duplicateError}
+              fullWidth
+              variant="outlined"
+              helperText={
+                inputError
+                  ? "Max 30 characters, no special characters allowed."
+                  : duplicateError
+                    ? "This property already exists."
+                    : ""
+              }
+              slotProps={{
+                inputLabel: {
+                  sx: { color: "text.secondary" },
+                },
+              }}
+              sx={modernFieldSx}
+            />
+          </Box>
+
+          <Box sx={{ display: "flex", gap: "14px", mt: "4px" }}>
+            <Button
+              onClick={handleAddProperty}
+              disabled={disableAdd}
+              variant="outlined"
+              fullWidth
+              sx={{
+                borderRadius: "18px",
+                backgroundColor: BUTTON_COLOR,
+                ":hover": {
+                  backgroundColor:
+                    theme.palette.mode === "light" ? "#f0f0f0" : "",
+                },
+              }}
+            >
+              Add Property
+            </Button>
+            <Button
+              onClick={handleCancel}
+              variant="outlined"
+              color="error"
+              fullWidth
+              sx={{ borderRadius: "18px" }}
+            >
+              Cancel
+            </Button>
+          </Box>
+        </Box>
+      </Paper>
+    </Slide>
   );
 };
 

--- a/src/components/AddPropertyForm/AddPropertyForm.tsx
+++ b/src/components/AddPropertyForm/AddPropertyForm.tsx
@@ -27,6 +27,15 @@ interface AddPropertyFormProps {
 
 const SpecialCharacterRegex = /^[a-zA-Z0-9 ]*$/; // Adjust regex as necessary
 
+// Mirrors RESERVED_PROPERTIES in /api/nodes/properties/update.
+const RESERVED_PROPERTIES = new Set([
+  "title",
+  "specializations",
+  "generalizations",
+  "parts",
+  "isPartOf",
+]);
+
 const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
   addNewProperty,
   locked,
@@ -41,6 +50,7 @@ const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
   const [newPropertyTitle, setNewPropertyTitle] = useState<string>("");
   const [inputError, setInputError] = useState<boolean>(false);
   const [duplicateError, setDuplicateError] = useState<boolean>(false);
+  const [reservedError, setReservedError] = useState<boolean>(false);
 
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
@@ -49,6 +59,7 @@ const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
     setNewPropertyTitle(value);
     setInputError(!isValid);
     setDuplicateError(false);
+    setReservedError(RESERVED_PROPERTIES.has(value.trim()));
   };
 
   const handleAddProperty = () => {
@@ -57,7 +68,8 @@ const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
       !propertyType ||
       inputError ||
       locked ||
-      duplicateError
+      duplicateError ||
+      reservedError
     ) {
       return;
     }
@@ -85,6 +97,7 @@ const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
     setNewPropertyTitle("");
     setInputError(false);
     setDuplicateError(false);
+    setReservedError(false);
   };
 
   const disableAdd =
@@ -92,7 +105,8 @@ const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
     !newPropertyTitle ||
     inputError ||
     locked ||
-    duplicateError;
+    duplicateError ||
+    reservedError;
 
   const modernFieldSx = {
     "& .MuiOutlinedInput-root": {
@@ -254,7 +268,7 @@ const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
               label="Property Title"
               value={newPropertyTitle}
               onChange={handleTitleChange}
-              error={inputError || duplicateError}
+              error={inputError || duplicateError || reservedError}
               fullWidth
               variant="outlined"
               helperText={
@@ -262,7 +276,9 @@ const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
                   ? "Max 30 characters, no special characters allowed."
                   : duplicateError
                     ? "This property already exists."
-                    : ""
+                    : reservedError
+                      ? `"${newPropertyTitle.trim()}" is a reserved property name.`
+                      : ""
               }
               slotProps={{
                 inputLabel: {

--- a/src/components/NodBody/NodeBody.tsx
+++ b/src/components/NodBody/NodeBody.tsx
@@ -2,17 +2,10 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Box, Button, Paper, Typography, useTheme } from "@mui/material";
 import { ICollection, INode } from "@components/types/INode";
 import Text from "../OntologyComponents/Text";
-import {
-  collection,
-  deleteField,
-  doc,
-  getFirestore,
-  updateDoc,
-  writeBatch,
-} from "firebase/firestore";
-import { NODES } from "@components/lib/firestoreClient/collections";
+import { getFirestore } from "firebase/firestore";
+import { Post } from "@components/lib/utils/Post";
 import StructuredProperty from "../StructuredProperty/StructuredProperty";
-import { DISPLAY, PROPERTIES_ORDER } from "@components/lib/CONSTANTS";
+import { PROPERTIES_ORDER } from "@components/lib/CONSTANTS";
 import {
   recordLogs,
   saveNewChangeLog,
@@ -154,90 +147,14 @@ const NodeBody: React.FC<NodeBodyProps> = ({
     }
   }, [currentVisibleNode, selectedDiffNode]);
 
-  const removeProperty = async (property: string) => {
-    if (
-      await confirmIt(
-        <Typography>
-          Are sure you want delete the property{" "}
-          <strong>{DISPLAY[property] || property}</strong>?
-        </Typography>,
-        "Delete",
-        "Keep",
-      )
-    ) {
-      const nodeRef = doc(collection(db, NODES), currentVisibleNode?.id);
-      const properties = currentVisibleNode.properties;
-      const propertyType = currentVisibleNode.propertyType;
-      delete properties[property];
-      await updateDoc(nodeRef, { propertyType, properties });
-      recordLogs({
-        action: "removeProperty",
-        node: currentVisibleNode?.id,
-        property,
-      });
-    }
-  };
-
-  const updateSpecializationsInheritance = async (
-    specializations: ICollection[],
-    batch: any,
-    property: string,
-    propertyValue: any,
-    ref: string,
-    propertyType: string,
-  ) => {
-    try {
-      let newBatch = batch;
-      for (let { nodes: links } of specializations) {
-        for (let link of links) {
-          const nodeRef = doc(collection(db, NODES), link.id);
-          let objectUpdate = {
-            [`inheritance.${property}.inheritanceType`]:
-              "inheritUnlessAlreadyOverRidden",
-            [`properties.${property}`]: propertyValue,
-            [`inheritance.${property}.ref`]: ref,
-            [`inheritance.${property}.title`]: currentVisibleNode?.title ?? "",
-            [`propertyType.${property}`]: propertyType,
-          };
-
-          if (newBatch._committed) {
-            newBatch = writeBatch(db);
-          }
-          updateDoc(nodeRef, objectUpdate);
-
-          if (newBatch._mutations.length > 498) {
-            await newBatch.commit();
-            newBatch = writeBatch(db);
-          }
-
-          let linkNodeData: INode | null = relatedNodes[link.id] || null;
-          if (!linkNodeData) {
-            linkNodeData = await fetchNode(link.id);
-          }
-
-          if (linkNodeData) {
-            newBatch = await updateSpecializationsInheritance(
-              linkNodeData.specializations,
-              newBatch,
-              property,
-              propertyValue,
-              ref,
-              propertyType,
-            );
-          }
-        }
-      }
-
-      return newBatch;
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   const addNewProperty = async (
     newProperty: string,
     newPropertyType: string,
   ) => {
+    // Captured outside `try` so the catch can roll back / report against the
+    // node the property was added to, even if the user has since navigated.
+    const targetNodeId = currentVisibleNode?.id;
+    const targetNodeTitle = currentVisibleNode?.title ?? "";
     try {
       if (!user) return;
       if (newProperty in currentVisibleNode.properties) {
@@ -250,33 +167,33 @@ const NodeBody: React.FC<NodeBodyProps> = ({
       }
       if (!newProperty.trim() || !newPropertyType.trim()) return;
 
-      const nodeRef = doc(collection(db, NODES), currentVisibleNode?.id);
-      const properties = currentVisibleNode.properties;
-      const previousValue = JSON.parse(
-        JSON.stringify(currentVisibleNode.properties),
-      );
-      const propertyType = currentVisibleNode.propertyType;
-      const inheritance = currentVisibleNode.inheritance;
+      const normalizedType = newPropertyType.toLowerCase();
+      const propertyValue =
+        normalizedType === "string"
+          ? ""
+          : normalizedType === "numeric"
+            ? 0
+            : [{ collectionName: "main", nodes: [] }];
 
-      propertyType[newProperty] = newPropertyType.toLowerCase();
-
-      if (newPropertyType.toLowerCase() === "string") {
-        properties[newProperty] = "";
-      } else if (newPropertyType.toLowerCase() === "numeric") {
-        properties[newProperty] = 0;
-      } else {
-        properties[newProperty] = [{ collectionName: "main", nodes: [] }];
-      }
-      inheritance[newProperty] = {
-        ref: null,
-        title: "",
-        inheritanceType: "inheritUnlessAlreadyOverRidden",
-      };
+      // Show the new (empty) property instantly.
       setCurrentVisibleNode((prev: any) => {
         const _prev = { ...prev };
-        _prev.properties = properties;
-        _prev.propertyType = propertyType;
-        _prev.inheritance = inheritance;
+        _prev.properties = {
+          ...(_prev.properties || {}),
+          [newProperty]: propertyValue,
+        };
+        _prev.propertyType = {
+          ...(_prev.propertyType || {}),
+          [newProperty]: normalizedType,
+        };
+        _prev.inheritance = {
+          ...(_prev.inheritance || {}),
+          [newProperty]: {
+            ref: null,
+            title: "",
+            inheritanceType: "inheritUnlessAlreadyOverRidden",
+          },
+        };
         return _prev;
       });
       setTimeout(() => {
@@ -292,35 +209,16 @@ const NodeBody: React.FC<NodeBodyProps> = ({
           }, 2000);
         }
       }, 500);
-      await updateDoc(nodeRef, {
-        properties,
-        propertyType,
-        inheritance,
-      });
-      saveNewChangeLog(db, {
-        nodeId: currentVisibleNode?.id,
-        modifiedBy: user?.uname,
-        modifiedProperty: null,
-        previousValue,
-        newValue: properties,
-        modifiedAt: new Date(),
-        changeType: "add property",
-        fullNode: currentVisibleNode,
-        changeDetails: { addedProperty: newProperty },
-      });
 
       setOpenAddProperty(false);
 
-      const batch = writeBatch(db);
-      await updateSpecializationsInheritance(
-        currentVisibleNode.specializations,
-        batch,
-        newProperty,
-        properties[newProperty],
-        currentVisibleNode?.id,
-        newPropertyType.toLowerCase(),
-      );
-      await batch.commit();
+      await Post("/nodes/properties/update", {
+        action: "add",
+        nodeId: targetNodeId,
+        propertyName: newProperty,
+        propertyType: newPropertyType,
+        ...(appName ? { appName } : {}),
+      });
 
       recordLogs({
         action: "add new property",
@@ -330,13 +228,30 @@ const NodeBody: React.FC<NodeBodyProps> = ({
       });
     } catch (error: any) {
       setOpenAddProperty(false);
+
+      // The write failed, so no snapshot will arrive to undo the instant
+      // update — reset from the source of truth (only if still on that node).
+      const fresh = await fetchNode(targetNodeId);
+      setCurrentVisibleNode((prev: any) =>
+        prev?.id === targetNodeId && fresh ? fresh : prev,
+      );
+
+      const reason =
+        (typeof error === "string" ? error : error?.message) ||
+        "Please try again.";
+      setSnackbarMessage(
+        `Failed to add property "${newProperty}" to "${targetNodeTitle}": ${reason}`,
+      );
+
       recordLogs({
         type: "error",
         error: JSON.stringify({
-          name: error.name,
-          message: error.message,
-          stack: error.stack,
+          name: error?.name,
+          message: typeof error === "string" ? error : error?.message,
+          stack: error?.stack,
         }),
+        action: "add new property (failed)",
+        node: targetNodeId,
       });
     }
   };
@@ -398,8 +313,7 @@ const NodeBody: React.FC<NodeBodyProps> = ({
       try {
         if (!user?.uname) return;
 
-        const currentNode = JSON.parse(JSON.stringify(currentVisibleNode));
-        const properties = currentNode.properties;
+        const properties = currentVisibleNode.properties || {};
 
         if (
           properties.hasOwnProperty(newValue) ||
@@ -411,61 +325,74 @@ const NodeBody: React.FC<NodeBodyProps> = ({
           return;
         }
 
-        const nodeRef = doc(collection(db, NODES), currentVisibleNode.id);
+        // Captured before the await so the failure path can revert / report
+        // against the right node even if the user navigates away mid-flight.
+        const targetNodeId = currentVisibleNode?.id;
+        const targetNodeTitle = currentVisibleNode?.title ?? "";
 
-        const propertyValue = currentNode.properties[previousValue];
-        const propertyType = currentNode.propertyType[previousValue];
-        const inheritanceValue = currentNode.inheritance[previousValue];
-
-        let ObjectUpdates = {
-          [`propertyType.${previousValue}`]: deleteField(),
-          [`properties.${previousValue}`]: deleteField(),
-          [`inheritance.${previousValue}`]: deleteField(),
-          /* new values */
-          [`propertyType.${newValue}`]: propertyType,
-          [`properties.${newValue}`]: propertyValue,
-          [`inheritance.${newValue}`]: inheritanceValue,
+        // Move a property key from `from` -> `to` across all of a node's maps.
+        const renameKeyInNode = (node: any, from: string, to: string) => {
+          const _node = { ...node };
+          for (const mapName of [
+            "properties",
+            "propertyType",
+            "inheritance",
+            "textValue",
+            "propertyOf",
+          ]) {
+            const map = _node[mapName];
+            if (map && Object.prototype.hasOwnProperty.call(map, from)) {
+              const { [from]: val, ...rest } = map;
+              _node[mapName] = { ...rest, [to]: val };
+            }
+          }
+          return _node;
         };
-        if (currentNode.textValue && currentNode.textValue[previousValue]) {
-          const comments = currentNode.textValue[previousValue];
-          ObjectUpdates = {
-            ...ObjectUpdates,
-            [`textValue.${previousValue}`]: deleteField(),
-            [`textValue.${newValue}`]: comments,
-          };
+
+        // Rename instantly on the current node.
+        setCurrentVisibleNode((prev: any) =>
+          !prev || prev.id !== targetNodeId
+            ? prev
+            : renameKeyInNode(prev, previousValue, newValue),
+        );
+
+        try {
+          await Post("/nodes/properties/update", {
+            action: "rename",
+            nodeId: targetNodeId,
+            previousValue,
+            newValue,
+            ...(appName ? { appName } : {}),
+          });
+        } catch (error: any) {
+          // The write failed, so no snapshot will arrive to undo the instant
+          // update — reset from truth (only if still on that node).
+          const fresh = await fetchNode(targetNodeId);
+          setCurrentVisibleNode((prev: any) =>
+            prev?.id === targetNodeId && fresh ? fresh : prev,
+          );
+          const reason =
+            (typeof error === "string" ? error : error?.message) ||
+            "Please try again.";
+          setSnackbarMessage(
+            `Failed to rename property "${previousValue}" on "${targetNodeTitle}": ${reason}`,
+          );
+          recordLogs({
+            type: "error",
+            error: JSON.stringify({
+              name: error?.name,
+              message: typeof error === "string" ? error : error?.message,
+              stack: error?.stack,
+            }),
+            action: "rename property (failed)",
+            node: targetNodeId,
+          });
         }
-        if (currentNode.propertyOf && currentNode.propertyOf[previousValue]) {
-          const propertyOfValue = currentNode.propertyOf[previousValue];
-          ObjectUpdates = {
-            ...ObjectUpdates,
-            [`propertyOf.${previousValue}`]: deleteField(),
-            [`propertyOf.${newValue}`]: propertyOfValue,
-          };
-        }
-        updateDoc(nodeRef, ObjectUpdates);
-        await updateInheritance({
-          nodeId: currentVisibleNode.id,
-          updatedProperties: [],
-          deletedProperties: [],
-          editedProperties: [{ previousValue, newValue }],
-          db,
-        });
-        saveNewChangeLog(db, {
-          nodeId: currentNode.id,
-          modifiedBy: user?.uname,
-          modifiedProperty: newValue,
-          previousValue,
-          newValue,
-          modifiedAt: new Date(),
-          changeType: "edit property",
-          fullNode: currentNode,
-          ...(appName ? { appName } : {}),
-        });
       } catch (error) {
         console.error(error);
       }
     },
-    [user?.uname, currentVisibleNode],
+    [user?.uname, currentVisibleNode, appName, fetchNode],
   );
 
   return (

--- a/src/components/OntologyComponents/Node.tsx
+++ b/src/components/OntologyComponents/Node.tsx
@@ -1070,6 +1070,132 @@ const Node = ({
           id: l,
         }));
 
+        // Generic link-typed properties (actor, …) are saved through the API.
+        // The structural edges below keep their existing flow.
+        if (
+          !["specializations", "generalizations", "parts", "isPartOf"].includes(
+            selectedProperty,
+          )
+        ) {
+          const targetNodeTitle = relatedNodes[nodeId]?.title ?? "";
+
+          // Show the edited links right away, starting from the collections
+          // the user actually saw: while inheriting, those live on the
+          // referenced node, not in this node's own (stale) copy.
+          setCurrentVisibleNode((prev: any) => {
+            if (!prev || prev.id !== nodeId) return prev;
+            const ref = prev.inheritance?.[selectedProperty]?.ref;
+            const base =
+              ref && relatedNodes[ref]
+                ? relatedNodes[ref].properties[selectedProperty]
+                : prev.properties[selectedProperty];
+            const next: ICollection[] = JSON.parse(
+              JSON.stringify(
+                Array.isArray(base) && base.length
+                  ? base
+                  : [{ collectionName: "main", nodes: [] }],
+              ),
+            );
+            for (const c of next) {
+              c.nodes = (c.nodes || []).filter(
+                (n: { id: string }) => !removedElements.includes(n.id),
+              );
+            }
+            let i = next.findIndex(
+              (c) => c.collectionName === selectedCollection,
+            );
+            if (i === -1) i = 0;
+            const existing = new Set(
+              next.flatMap((c) => c.nodes.map((n: { id: string }) => n.id)),
+            );
+            next[i].nodes.push(
+              ...addedLinks.filter((l) => !existing.has(l.id)),
+            );
+            return {
+              ...prev,
+              properties: { ...prev.properties, [selectedProperty]: next },
+              inheritance: {
+                ...prev.inheritance,
+                [selectedProperty]: {
+                  ...prev.inheritance?.[selectedProperty],
+                  ref: null,
+                  title: "",
+                },
+              },
+            };
+          });
+
+          try {
+            await Post("/nodes/properties/update", {
+              action: "change-links",
+              nodeId,
+              propertyName: selectedProperty,
+              added: addedElements,
+              removed: removedElements,
+              collectionName: selectedCollection || "main",
+              ...(appName ? { appName } : {}),
+            });
+
+            if (onInstantTreeUpdate) {
+              const cols =
+                (relatedNodes[nodeId]?.properties?.[
+                  selectedProperty
+                ] as ICollection[]) || [];
+              let collectionIdx = cols.findIndex(
+                (c) => c.collectionName === selectedCollection,
+              );
+              if (collectionIdx === -1) collectionIdx = 0;
+              onInstantTreeUpdate((tree) => {
+                let updatedTree = tree;
+                for (const removedId of removedElements) {
+                  updatedTree = removeLinkFromNode(
+                    updatedTree,
+                    nodeId,
+                    removedId,
+                    selectedProperty,
+                    collectionIdx,
+                  );
+                }
+                for (const addedId of addedElements) {
+                  updatedTree = addLinkToNode(
+                    updatedTree,
+                    nodeId,
+                    addedId,
+                    selectedProperty,
+                    selectedCollection || "main",
+                    relatedNodes,
+                    relatedNodes[addedId]?.title,
+                  );
+                }
+                return updatedTree;
+              });
+            }
+          } catch (error: any) {
+            // Nothing was saved, so the screen won't correct itself —
+            // re-fetch the node and reset (only if the user is still on it).
+            const fresh = await fetchNode(nodeId);
+            setCurrentVisibleNode((prev: any) =>
+              prev?.id === nodeId && fresh ? fresh : prev,
+            );
+            const reason =
+              (typeof error === "string" ? error : error?.message) ||
+              "Please try again.";
+            setSnackbarMessage(
+              `Failed to update "${selectedProperty}" on "${targetNodeTitle}": ${reason}`,
+            );
+            recordLogs({
+              type: "error",
+              error: JSON.stringify({
+                name: error?.name,
+                message: typeof error === "string" ? error : error?.message,
+                stack: error?.stack,
+              }),
+              at: "handleSaveLinkChanges",
+            });
+          }
+          return;
+        }
+
         // Close the modal or perform any other necessary actions
         // Get the node document from the database
         const nodeDoc = await getDoc(doc(collection(db, NODES), nodeId));
@@ -1410,7 +1536,17 @@ const Node = ({
         });
       }
     },
-    [checkedItems, db, relatedNodes, appName, onInstantTreeUpdate, user?.uname],
+    [
+      checkedItems,
+      db,
+      relatedNodes,
+      appName,
+      onInstantTreeUpdate,
+      user?.uname,
+      setCurrentVisibleNode,
+      setSnackbarMessage,
+      fetchNode,
+    ],
   );
 
   //  function to handle the deletion of a Node
@@ -1623,8 +1759,8 @@ const Node = ({
     if (!confirm) return;
     if (!currentVisibleNode.properties?.hasOwnProperty(property)) return;
 
-    // Captured before the await so the failure path can restore / report
-    // against the right node even if the user navigates away mid-flight.
+    // Remember which node this was, in case the user navigates away while
+    // the request is in flight.
     const targetNodeId = currentVisibleNode?.id;
     const targetNodeTitle = currentVisibleNode?.title ?? "";
 
@@ -1657,8 +1793,8 @@ const Node = ({
         ...(appName ? { appName } : {}),
       });
     } catch (error: any) {
-      // The write failed, so no snapshot will arrive to undo the instant
-      // update — reset from the source of truth (only if still on that node).
+      // Nothing was saved, so the screen won't correct itself —
+      // re-fetch the node and reset (only if the user is still on it).
       const fresh = await fetchNode(targetNodeId);
       setCurrentVisibleNode((prev: any) =>
         prev?.id === targetNodeId && fresh ? fresh : prev,

--- a/src/components/OntologyComponents/Node.tsx
+++ b/src/components/OntologyComponents/Node.tsx
@@ -144,7 +144,9 @@ import { triggerUpdateDerivedPaths } from "@components/lib/utils/triggerUpdateDe
 
 type INodeProps = {
   currentVisibleNode: INode;
-  setCurrentVisibleNode: (node: INode) => void;
+  setCurrentVisibleNode: (
+    node: INode | ((prev: INode | null) => INode | null),
+  ) => void;
   setSnackbarMessage: (message: string) => void;
   user: User;
   mainSpecializations: MainSpecializations;
@@ -1607,77 +1609,78 @@ const Node = ({
     [eachOntologyPath],
   );
   const deleteProperty = async (property: string) => {
+    const confirm = await confirmIt(
+      <Box>
+        <Typography>
+          Are you sure you want to delete the property{" "}
+          <strong style={{ color: "orange" }}>{property}</strong> from this
+          node:
+        </Typography>
+      </Box>,
+      "Yes",
+      "Cancel",
+    );
+    if (!confirm) return;
+    if (!currentVisibleNode.properties?.hasOwnProperty(property)) return;
+
+    // Captured before the await so the failure path can restore / report
+    // against the right node even if the user navigates away mid-flight.
+    const targetNodeId = currentVisibleNode?.id;
+    const targetNodeTitle = currentVisibleNode?.title ?? "";
+
+    // Remove instantly from the current node's view.
+    setCurrentVisibleNode((prev: any) => {
+      if (!prev || prev.id !== targetNodeId) return prev;
+      const _prev = { ...prev };
+      const { [property]: _p, ...restProps } = _prev.properties || {};
+      const { [property]: _t, ...restTypes } = _prev.propertyType || {};
+      const { [property]: _i, ...restInh } = _prev.inheritance || {};
+      _prev.properties = restProps;
+      _prev.propertyType = restTypes;
+      _prev.inheritance = restInh;
+      if (_prev.textValue) {
+        const { [property]: _tv, ...restTv } = _prev.textValue;
+        _prev.textValue = restTv;
+      }
+      if (_prev.propertyOf) {
+        const { [property]: _po, ...restPo } = _prev.propertyOf;
+        _prev.propertyOf = restPo;
+      }
+      return _prev;
+    });
+
     try {
-      const confirm = await confirmIt(
-        <Box>
-          <Typography>
-            Are you sure you want to delete the property{" "}
-            <strong style={{ color: "orange" }}>{property}</strong> from this
-            node:
-          </Typography>
-        </Box>,
-        "Yes",
-        "Cancel",
+      await Post("/nodes/properties/update", {
+        action: "delete",
+        nodeId: targetNodeId,
+        propertyName: property,
+        ...(appName ? { appName } : {}),
+      });
+    } catch (error: any) {
+      // The write failed, so no snapshot will arrive to undo the instant
+      // update — reset from the source of truth (only if still on that node).
+      const fresh = await fetchNode(targetNodeId);
+      setCurrentVisibleNode((prev: any) =>
+        prev?.id === targetNodeId && fresh ? fresh : prev,
       );
 
-      if (confirm) {
-        const currentNode = { ...currentVisibleNode };
-        const properties = currentNode.properties;
+      const reason =
+        (typeof error === "string" ? error : error?.message) ||
+        "Please try again.";
+      setSnackbarMessage(
+        `Failed to delete property "${property}" from "${targetNodeTitle}": ${reason}`,
+      );
 
-        /*     
-        const propertyType = currentNode.propertyType;
-        const inheritance = currentNode.inheritance; */
-        if (properties.hasOwnProperty(property)) {
-          const element = document.getElementById(`property-${property}`);
-          if (element) {
-            element.scrollIntoView({ behavior: "smooth", block: "center" });
-
-            element.style.transition =
-              "box-shadow 0.3s ease, opacity 0.5s ease, transform 0.5s ease";
-            element.style.boxShadow = "0 0 0 3px red";
-            element.style.opacity = "0";
-            element.style.transform = "translateX(-20px)";
-          }
-
-          updateInheritance({
-            nodeId: currentNode.id,
-            updatedProperties: [],
-            deletedProperties: [property],
-            db,
-          });
-        }
-        const inheritedRef = currentNode.inheritance[property].ref;
-
-        // Fetch inheritedRef if missing
-        let previousValue = currentNode.properties[property];
-        if (inheritedRef) {
-          let inheritedRefNode: INode | null =
-            relatedNodes[inheritedRef] || null;
-          if (!inheritedRefNode) {
-            const fetchedNode = await fetchNode(inheritedRef);
-            if (fetchedNode) {
-              inheritedRefNode = fetchedNode;
-            }
-          }
-          previousValue = inheritedRefNode
-            ? inheritedRefNode.properties[property]
-            : currentNode.properties[property];
-        }
-
-        saveNewChangeLog(db, {
-          nodeId: currentNode.id,
-          modifiedBy: user?.uname,
-          modifiedProperty: property,
-          previousValue,
-          newValue: null,
-          modifiedAt: new Date(),
-          changeType: "remove property",
-          fullNode: currentNode,
-          ...(appName ? { appName } : {}),
-        });
-      }
-    } catch (error) {
-      console.error(error);
+      recordLogs({
+        type: "error",
+        error: JSON.stringify({
+          name: error?.name,
+          message: typeof error === "string" ? error : error?.message,
+          stack: error?.stack,
+        }),
+        action: "delete property (failed)",
+        node: targetNodeId,
+      });
     }
   };
 

--- a/src/components/StructuredProperty/ChipsProperty.tsx
+++ b/src/components/StructuredProperty/ChipsProperty.tsx
@@ -9,14 +9,9 @@ import {
 import { Box, Paper, Tooltip, Typography } from "@mui/material";
 import { DISPLAY } from "@components/lib/CONSTANTS";
 import SelectInheritance from "../SelectInheritance/SelectInheritance";
-import {
-  saveNewChangeLog,
-  updateInheritance,
-} from "@components/lib/utils/helpers";
-import { collection, doc, getFirestore, updateDoc } from "firebase/firestore";
-import { NODES } from "@components/lib/firestoreClient/collections";
 import PropertyContributors from "./PropertyContributors";
 import InheritanceDetailsPanel from "./InheritanceDetailsPanel";
+import { Post } from "@components/lib/utils/Post";
 
 const ChipsProperty = ({
   currentVisibleNode,
@@ -41,7 +36,6 @@ const ChipsProperty = ({
   enableEdit: boolean;
   appName?: string;
 }) => {
-  const db = getFirestore();
   const [value, setValue] = useState<
     { title: string; added?: boolean; removed?: boolean }[]
   >([]);
@@ -114,56 +108,19 @@ const ChipsProperty = ({
       )
         return;
 
-      setValue(newValue);
+      setValue(newValue); // shown instantly; the server write confirms via snapshot
 
-      const previousValue: string[] = currentVisibleNode.properties[
-        property
-      ] as string[];
-
-      const nodeRef = doc(collection(db, NODES), currentVisibleNode?.id);
-
-      await updateDoc(nodeRef, {
-        [`properties.${property}`]: newValue.map((c) => c.title),
-        [`inheritance.${property}.ref`]: null,
-        [`inheritance.${property}.title`]: "",
-      });
-      if (!!currentVisibleNode.inheritance[property]?.ref) {
-        await updateInheritance({
-          nodeId: currentVisibleNode?.id,
-          updatedProperties: [property],
-          db,
-        });
-      }
-      let changeMessage: "add element" | "remove element" | "modify elements" =
-        "add element";
-
-      if (added.length === 1) {
-        changeMessage = "add element";
-      }
-      if (removed.length === 1) {
-        changeMessage = "remove element";
-      }
-      if (added.length > 1 || removed.length > 1) {
-        changeMessage = "modify elements";
-      }
-
-      saveNewChangeLog(db, {
+      await Post("/nodes/properties/update", {
+        action: "change",
         nodeId: currentVisibleNode?.id,
-        modifiedBy: user?.uname,
-        modifiedProperty: property,
-        previousValue,
-        newValue: newValue.map((c) => c.title),
-        modifiedAt: new Date(),
-        changeType: changeMessage,
-        fullNode: currentVisibleNode,
-        changeDetails: {
-          addedElements: added.map((c) => c.title),
-          removedElements: removed.map((c) => c.title),
-        },
+        propertyName: property,
+        value: newValue.map((c) => c.title),
         ...(appName ? { appName } : {}),
       });
     } catch (error) {
       console.error(error);
+      // The write failed — revert the chips to the node's stored value.
+      setValue(propertyValue);
     }
   };
 

--- a/src/components/StructuredProperty/NumericProperty.tsx
+++ b/src/components/StructuredProperty/NumericProperty.tsx
@@ -15,14 +15,8 @@ import {
   Typography,
 } from "@mui/material";
 
-import { collection, doc, updateDoc, getFirestore } from "firebase/firestore";
 import { useTheme } from "@emotion/react";
 import { INode } from "@components/types/INode";
-import { NODES } from "@components/lib/firestoreClient/collections";
-import {
-  saveNewChangeLog,
-  updateInheritance,
-} from "@components/lib/utils/helpers";
 import {
   capitalizeFirstLetter,
   getTooltipHelper,
@@ -35,6 +29,7 @@ import EditIcon from "@mui/icons-material/Edit";
 import EditProperty from "../AddPropertyForm/EditProperty";
 import InheritanceDetailsPanel from "./InheritanceDetailsPanel";
 import SelectInheritance from "../SelectInheritance/SelectInheritance";
+import { Post } from "@components/lib/utils/Post";
 
 interface NumericPropertyValue {
   value: number | string;
@@ -72,7 +67,6 @@ const NumericProperty = ({
   modifyProperty,
   deleteProperty,
 }: INumericPropertyProps) => {
-  const db = getFirestore();
   const theme: any = useTheme();
   const [numericValue, setNumericValue] = useState<number | string>("");
   const [unit, setUnit] = useState<string>("");
@@ -80,7 +74,6 @@ const NumericProperty = ({
   const [isEditingValue, setIsEditingValue] = useState(false);
   const [isEditingUnit, setIsEditingUnit] = useState(false);
   const [{ user }] = useAuth();
-  const [reference, setReference] = useState<string | null>(null);
   const [editProperty, setEditProperty] = useState("");
   const [newPropertyValue, setNewPropertyValue] = useState("");
   const valueInputRef = useRef<HTMLInputElement>(null);
@@ -111,42 +104,11 @@ const NumericProperty = ({
   }, [currentImprovement, property]);
 
   useEffect(() => {
-    setReference(currentVisibleNode.inheritance[property]?.ref || null);
-  }, [currentVisibleNode, property]);
-
-  useEffect(() => {
     if (!isEditingValue && !isEditingUnit) {
       setNumericValue(displayValue);
       setUnit(displayUnit);
     }
   }, [displayValue, displayUnit, isEditingValue, isEditingUnit]);
-
-  const saveChangeHistory = useCallback(
-    async (
-      previousValue: NumericPropertyValue,
-      newValue: NumericPropertyValue,
-      nodeId: string,
-    ) => {
-      if (
-        !user?.uname ||
-        JSON.stringify(previousValue) === JSON.stringify(newValue)
-      )
-        return;
-
-      saveNewChangeLog(db, {
-        nodeId,
-        modifiedBy: user.uname,
-        modifiedProperty: property,
-        previousValue: JSON.stringify(previousValue),
-        newValue: JSON.stringify(newValue),
-        modifiedAt: new Date(),
-        changeType: "change text",
-        fullNode: currentVisibleNode,
-        ...(appName ? { appName } : {}),
-      });
-    },
-    [db, property, user, currentVisibleNode, appName],
-  );
 
   const onSaveNumericChange = useCallback(
     async (newValue: number | string, newUnit: string) => {
@@ -167,50 +129,30 @@ const NumericProperty = ({
           unit: newUnit.trim(),
         };
 
-        const nodeRef = doc(collection(db, NODES), currentVisibleNode?.id);
-
-        const updateData = {
-          [`properties.${property}`]: newPropertyValue,
-          ...(reference
-            ? {
-                [`inheritance.${property}.ref`]: null,
-                [`inheritance.${property}.title`]: "",
-              }
-            : {}),
-        };
-
-        await updateDoc(nodeRef, updateData);
-
-        if (reference) {
-          updateInheritance({
-            nodeId: currentVisibleNode?.id,
-            updatedProperties: [property],
-            db,
-          });
-        }
-
-        await saveChangeHistory(
-          previousValue,
-          newPropertyValue,
-          currentVisibleNode?.id,
-        );
+        await Post("/nodes/properties/update", {
+          action: "change",
+          nodeId: currentVisibleNode?.id,
+          propertyName: property,
+          value: newPropertyValue,
+          ...(appName ? { appName } : {}),
+        });
 
         setIsEditingValue(false);
         setIsEditingUnit(false);
-      } catch (error) {
+      } catch (error: any) {
         console.error("Error saving numeric value:", error);
-        setError("Failed to save value");
+        // The write didn't land — revert the local edit and surface why.
+        setNumericValue(previousValue.value);
+        setUnit(previousValue.unit);
+        setIsEditingValue(false);
+        setIsEditingUnit(false);
+        setError(
+          (typeof error === "string" ? error : error?.message) ||
+            "Failed to save value",
+        );
       }
     },
-    [
-      user?.uname,
-      currentVisibleNode?.id,
-      reference,
-      property,
-      db,
-      saveChangeHistory,
-      normalizedValue,
-    ],
+    [user?.uname, currentVisibleNode?.id, property, normalizedValue, appName],
   );
 
   const handleDeleteProperty = useCallback(() => {

--- a/src/pages/api/nodes/properties/update.ts
+++ b/src/pages/api/nodes/properties/update.ts
@@ -11,15 +11,16 @@ import {
   USERS,
 } from "@components/lib/firestoreClient/collections";
 import { getDoerCreate } from "@components/lib/utils/helpers";
+import { computeDiffValue } from "@components/lib/utils/diffValue";
 import { FieldValue } from "firebase-admin/firestore";
-import { INode, NodeChange } from "@components/types/INode";
+import { ICollection, INode, NodeChange } from "@components/types/INode";
 
 /**
  * Single endpoint for generic node-property operations — add / delete /
- * rename / change — selected by `action` in the request body.
+ * rename / change / change-links — selected by `action` in the request body.
  */
 
-type PropertyAction = "add" | "delete" | "rename" | "change";
+type PropertyAction = "add" | "delete" | "rename" | "change" | "change-links";
 
 type OperationContext = {
   nodeId: string;
@@ -179,6 +180,36 @@ async function walkSpecializations(
   return { written, skipped };
 }
 
+/**
+ * Make descendants that inherit this property point at `nodeId`. Only the
+ * inheritance ref is written — values are read through it, never copied. A
+ * descendant with its own value keeps it, and its subtree is left alone too.
+ */
+async function rewireInheritingDescendants(
+  nodeId: string,
+  nodeTitle: string,
+  propertyName: string,
+): Promise<void> {
+  await walkSpecializations(
+    nodeId,
+    (node) => {
+      const inh = node.inheritance?.[propertyName];
+      if (!inh || inh.inheritanceType === "neverInherit") return null;
+      const stillInherits = inh.ref !== null; // null === overridden, leave it
+      const rewire =
+        inh.inheritanceType === "alwaysInherit" ||
+        (inh.inheritanceType === "inheritUnlessAlreadyOverRidden" &&
+          stillInherits);
+      if (!rewire) return null;
+      return {
+        [`inheritance.${propertyName}.ref`]: nodeId,
+        [`inheritance.${propertyName}.title`]: nodeTitle,
+      };
+    },
+    { descendPastSkipped: false },
+  );
+}
+
 /** Write an info/error log to LOGS, attributed to `uname`. */
 const recordLogs = async (logs: { [key: string]: any }, uname: string) => {
   try {
@@ -200,6 +231,8 @@ const recordLogs = async (logs: { [key: string]: any }, uname: string) => {
 /** Write a NodeChange to NODES_LOGS and bump the user's last-activity timestamp. */
 async function writeChangeLog(change: NodeChange): Promise<void> {
   if (!change.modifiedBy) return;
+  const diffValue = computeDiffValue(change);
+  if (diffValue) change.diffValue = diffValue;
   await db
     .collection(NODES_LOGS)
     .doc()
@@ -525,28 +558,9 @@ async function changeProperty(
   }
   await db.collection(NODES).doc(nodeId).update(nodeUpdates);
 
-  // When newly overriding, re-point inheriting descendants at this node —
-  // ref only, values resolve through it. A descendant that doesn't rewire
-  // prunes its subtree: nodes below it inherit from it, not from us.
+  // When newly overriding, re-point inheriting descendants at this node.
   if (wasInheriting) {
-    await walkSpecializations(
-      nodeId,
-      (node) => {
-        const inh = node.inheritance?.[cleanName];
-        if (!inh || inh.inheritanceType === "neverInherit") return null;
-        const stillInherits = inh.ref !== null; // null === overridden, leave it
-        const rewire =
-          inh.inheritanceType === "alwaysInherit" ||
-          (inh.inheritanceType === "inheritUnlessAlreadyOverRidden" &&
-            stillInherits);
-        if (!rewire) return null;
-        return {
-          [`inheritance.${cleanName}.ref`]: nodeId,
-          [`inheritance.${cleanName}.title`]: nodeData.title ?? "",
-        };
-      },
-      { descendPastSkipped: false },
-    );
+    await rewireInheritingDescendants(nodeId, nodeData.title ?? "", cleanName);
   }
 
   // No-op edits still persist the value (an override can pin the inherited
@@ -566,7 +580,169 @@ async function changeProperty(
   return { ok: true, changedProperty: cleanName };
 }
 
-const ACTIONS: PropertyAction[] = ["add", "delete", "rename", "change"];
+/**
+ * Add/remove link elements on a link-typed property.
+ * Maintains propertyOf back-links on the linked nodes.
+ */
+async function changeLinks(
+  ctx: OperationContext,
+): Promise<{ ok: true; changedProperty: string }> {
+  const { nodeId, nodeData, data, uname, appName } = ctx;
+
+  const nameError = validatePropertyName(data?.propertyName);
+  if (nameError) throw new HttpError(400, nameError);
+  const cleanName = (data.propertyName as string).trim();
+
+  if (!hasOwn(nodeData.properties, cleanName)) {
+    throw new HttpError(404, `Property "${cleanName}" not found on this node`);
+  }
+  const propertyType = (nodeData.propertyType as any)?.[cleanName];
+  if (propertyType === "string" || CHANGE_TYPES.has(propertyType)) {
+    throw new HttpError(
+      400,
+      `Property "${cleanName}" (type "${propertyType ?? "unknown"}") is not link-typed`,
+    );
+  }
+
+  const isIdArray = (v: any): v is string[] =>
+    Array.isArray(v) && v.every((x) => typeof x === "string");
+  const added: string[] = isIdArray(data.added)
+    ? [...new Set<string>(data.added)]
+    : [];
+  const removed: string[] = isIdArray(data.removed)
+    ? [...new Set<string>(data.removed)]
+    : [];
+  if (added.length === 0 && removed.length === 0) {
+    throw new HttpError(400, "added and/or removed link ids are required");
+  }
+  const collectionName =
+    typeof data.collectionName === "string" ? data.collectionName : "main";
+
+  // Apply the edit to the collections the user actually saw: while inheriting,
+  // those live on the referenced node, not in this node's own (stale) copy.
+  const inheritedRef = nodeData.inheritance?.[cleanName]?.ref;
+  let refData: INode | undefined;
+  if (inheritedRef) {
+    refData = (await db.collection(NODES).doc(inheritedRef).get()).data() as
+      | INode
+      | undefined;
+  }
+  let base: any =
+    refData && hasOwn(refData.properties, cleanName)
+      ? refData.properties[cleanName]
+      : nodeData.properties[cleanName];
+  if (!Array.isArray(base) || base.length === 0) {
+    base = [{ collectionName: "main", nodes: [] }];
+  }
+  const previousValue: ICollection[] = JSON.parse(JSON.stringify(base));
+  const newValue: ICollection[] = JSON.parse(JSON.stringify(base));
+
+  for (const c of newValue) {
+    c.nodes = (c.nodes || []).filter((n) => !removed.includes(n.id));
+  }
+  let collectionIdx = newValue.findIndex(
+    (c) => c.collectionName === collectionName,
+  );
+  if (collectionIdx === -1) collectionIdx = 0;
+  const existingIds = new Set(
+    newValue.flatMap((c) => c.nodes.map((n) => n.id)),
+  );
+
+  // Fetch each added node for its title and back-links. Ids that don't exist,
+  // are deleted, or point at this node itself are skipped, not errors.
+  const addedNodes: { id: string; data: INode }[] = [];
+  for (const id of added) {
+    if (existingIds.has(id) || id === nodeId) continue;
+    const d = (await db.collection(NODES).doc(id).get()).data() as
+      | INode
+      | undefined;
+    if (d && !d.deleted) addedNodes.push({ id, data: d });
+  }
+  newValue[collectionIdx].nodes.push(
+    ...addedNodes.map((n) => ({ id: n.id, title: n.data.title ?? "" })),
+  );
+
+  // Write the new collections. Editing an inherited property makes it an
+  // override: break the ref and copy the referenced node's comments down.
+  const wasInheriting = !!inheritedRef;
+  const nodeUpdates: Record<string, any> = {
+    [`properties.${cleanName}`]: newValue,
+  };
+  if (wasInheriting) {
+    nodeUpdates[`inheritance.${cleanName}.ref`] = null;
+    nodeUpdates[`inheritance.${cleanName}.title`] = "";
+    if (refData?.textValue && hasOwn(refData.textValue, cleanName)) {
+      nodeUpdates[`textValue.${cleanName}`] = refData.textValue[cleanName];
+    }
+  }
+  if (uname && uname !== "ouhrac") {
+    nodeUpdates.contributors = FieldValue.arrayUnion(uname);
+    nodeUpdates[`contributorsByProperty.${cleanName}`] =
+      FieldValue.arrayUnion(uname);
+  }
+  await db.collection(NODES).doc(nodeId).update(nodeUpdates);
+
+  // Update the back-links: each linked node records in propertyOf which
+  // nodes use it as a value of this property.
+  const batch = db.batch();
+  for (const id of removed) {
+    const snap = await db.collection(NODES).doc(id).get();
+    const backLinks = (snap.data() as INode | undefined)?.propertyOf?.[
+      cleanName
+    ];
+    if (!Array.isArray(backLinks)) continue;
+    for (const c of backLinks) {
+      c.nodes = (c.nodes || []).filter((n) => n.id !== nodeId);
+    }
+    batch.update(snap.ref, { [`propertyOf.${cleanName}`]: backLinks });
+  }
+  for (const { id, data: d } of addedNodes) {
+    const backLinks: ICollection[] = Array.isArray(d.propertyOf?.[cleanName])
+      ? (d.propertyOf as any)[cleanName]
+      : [{ collectionName: "main", nodes: [] }];
+    let main = backLinks.find((c) => c.collectionName === "main");
+    if (!main) {
+      main = { collectionName: "main", nodes: [] };
+      backLinks.push(main);
+    }
+    if (!main.nodes.some((n) => n.id === nodeId)) {
+      main.nodes.push({ id: nodeId });
+      batch.update(db.collection(NODES).doc(id), {
+        [`propertyOf.${cleanName}`]: backLinks,
+      });
+    }
+  }
+  await batch.commit();
+
+  // When newly overriding, re-point inheriting descendants at this node.
+  if (wasInheriting) {
+    await rewireInheritingDescendants(nodeId, nodeData.title ?? "", cleanName);
+  }
+
+  if (uname) {
+    await writeChangeLog({
+      nodeId,
+      modifiedBy: uname,
+      modifiedProperty: cleanName,
+      previousValue,
+      newValue,
+      modifiedAt: new Date(),
+      changeType: "modify elements",
+      fullNode: nodeData,
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+
+  return { ok: true, changedProperty: cleanName };
+}
+
+const ACTIONS: PropertyAction[] = [
+  "add",
+  "delete",
+  "rename",
+  "change",
+  "change-links",
+];
 
 function fail(res: NextApiResponse, status: number, msg: string) {
   return res.status(status).json({ error: msg, message: msg });
@@ -615,6 +791,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         break;
       case "change":
         result = await changeProperty(ctx);
+        break;
+      case "change-links":
+        result = await changeLinks(ctx);
         break;
     }
 

--- a/src/pages/api/nodes/properties/update.ts
+++ b/src/pages/api/nodes/properties/update.ts
@@ -1,0 +1,644 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import fbAuth from "@components/middlewares/fbAuth";
+import {
+  db,
+  MAX_TRANSACTION_WRITES,
+} from "@components/lib/firestoreServer/admin";
+import {
+  LOGS,
+  NODES,
+  NODES_LOGS,
+  USERS,
+} from "@components/lib/firestoreClient/collections";
+import { getDoerCreate } from "@components/lib/utils/helpers";
+import { FieldValue } from "firebase-admin/firestore";
+import { INode, NodeChange } from "@components/types/INode";
+
+/**
+ * Single endpoint for generic node-property operations — add / delete /
+ * rename / change — selected by `action` in the request body.
+ */
+
+type PropertyAction = "add" | "delete" | "rename" | "change";
+
+type OperationContext = {
+  nodeId: string;
+  nodeData: INode;
+  data: any;
+  uname?: string;
+  appName?: string;
+};
+
+/** Thrown by ops to signal a specific HTTP status. */
+class HttpError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+const hasOwn = (obj: any, key: string) =>
+  !!obj && Object.prototype.hasOwnProperty.call(obj, key);
+
+const RESERVED_PROPERTIES = new Set([
+  "title",
+  "specializations",
+  "generalizations",
+  "parts",
+  "isPartOf",
+]);
+
+const PROPERTY_NAME_REGEX = /^[a-zA-Z0-9 ]+$/;
+
+/** Returns an error message, or `null` if the name is valid. */
+function validatePropertyName(name: unknown): string | null {
+  if (typeof name !== "string") return "property name must be a string";
+  const trimmed = name.trim();
+  if (!trimmed) return "property name is required";
+  if (trimmed.length > 30) return "property name must be at most 30 characters";
+  if (!PROPERTY_NAME_REGEX.test(name)) {
+    return "property name may only contain letters, numbers and spaces";
+  }
+  if (RESERVED_PROPERTIES.has(trimmed)) {
+    return `"${trimmed}" is a reserved property and cannot be modified here`;
+  }
+  return null;
+}
+
+/** Initial value by type; link-typed properties start as an empty `main` collection. */
+function defaultValueForType(normalizedType: string): any {
+  if (normalizedType === "string") return "";
+  if (normalizedType === "numeric") return 0;
+  return [{ collectionName: "main", nodes: [] }];
+}
+
+function specializationIds(node: Pick<INode, "specializations">): string[] {
+  return (node.specializations || []).flatMap((collection) =>
+    (collection.nodes || []).map((n) => n.id),
+  );
+}
+
+/** Field paths removed from a node when a property is deleted. */
+function deletionUpdates(propertyName: string): Record<string, any> {
+  const del = FieldValue.delete();
+  return {
+    [`properties.${propertyName}`]: del,
+    [`propertyType.${propertyName}`]: del,
+    [`inheritance.${propertyName}`]: del,
+    [`textValue.${propertyName}`]: del,
+    [`propertyOf.${propertyName}`]: del,
+  };
+}
+
+/**
+ * Field paths that move a property `oldName` -> `newName` on a single node.
+ * Only call for nodes that actually have `oldName`.
+ */
+function renameUpdatesFor(
+  node: INode,
+  oldName: string,
+  newName: string,
+): Record<string, any> {
+  const del = FieldValue.delete();
+  // Old data can lack the inheritance title; normalize to "".
+  const inh = node.inheritance?.[oldName];
+  const updates: Record<string, any> = {
+    [`properties.${oldName}`]: del,
+    [`properties.${newName}`]: node.properties?.[oldName],
+    [`propertyType.${oldName}`]: del,
+    [`propertyType.${newName}`]: (node.propertyType as any)?.[oldName],
+    [`inheritance.${oldName}`]: del,
+    [`inheritance.${newName}`]: { ...inh, title: inh?.title ?? "" },
+  };
+  if (node.textValue && hasOwn(node.textValue, oldName)) {
+    updates[`textValue.${oldName}`] = del;
+    updates[`textValue.${newName}`] = node.textValue[oldName];
+  }
+  const propertyOf = (node as any).propertyOf;
+  if (propertyOf && hasOwn(propertyOf, oldName)) {
+    updates[`propertyOf.${oldName}`] = del;
+    updates[`propertyOf.${newName}`] = propertyOf[oldName];
+  }
+  return updates;
+}
+
+/**
+ * BFS over the specialization subtree below `rootId`. `apply` returns a
+ * Firestore update (batched) or `null` to skip. `descendPastSkipped` controls
+ * whether a skipped node's subtree is still visited (add) or pruned (rewiring).
+ */
+async function walkSpecializations(
+  rootId: string,
+  apply: (node: INode, nodeId: string) => Record<string, any> | null,
+  { descendPastSkipped = true }: { descendPastSkipped?: boolean } = {},
+): Promise<{ written: number; skipped: number }> {
+  const visited = new Set<string>([rootId]);
+  const rootSnap = await db.collection(NODES).doc(rootId).get();
+  const rootData = rootSnap.data() as INode | undefined;
+  if (!rootData) return { written: 0, skipped: 0 };
+
+  const queue = specializationIds(rootData).filter((id) => !visited.has(id));
+  queue.forEach((id) => visited.add(id));
+
+  let batch = db.batch();
+  let pending = 0;
+  let written = 0;
+  let skipped = 0;
+
+  while (queue.length > 0) {
+    const currentId = queue.shift() as string;
+    const snap = await db.collection(NODES).doc(currentId).get();
+    const data = snap.data() as INode | undefined;
+    if (!data) continue;
+
+    const update = apply(data, currentId);
+    if (update) {
+      batch.update(snap.ref, update);
+      pending += 1;
+      written += 1;
+      if (pending >= MAX_TRANSACTION_WRITES) {
+        await batch.commit();
+        batch = db.batch();
+        pending = 0;
+      }
+    } else {
+      skipped += 1;
+      if (!descendPastSkipped) continue;
+    }
+
+    for (const childId of specializationIds(data)) {
+      if (!visited.has(childId)) {
+        visited.add(childId);
+        queue.push(childId);
+      }
+    }
+  }
+
+  if (pending > 0) await batch.commit();
+  return { written, skipped };
+}
+
+/** Write an info/error log to LOGS, attributed to `uname`. */
+const recordLogs = async (logs: { [key: string]: any }, uname: string) => {
+  try {
+    if (uname === "ouhrac") return;
+    const logRef = db.collection(LOGS).doc();
+    const doerCreate = getDoerCreate(uname || "");
+    await logRef.set({
+      type: "info",
+      ...logs,
+      createdAt: new Date(),
+      doer: uname,
+      doerCreate,
+    });
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+/** Write a NodeChange to NODES_LOGS and bump the user's last-activity timestamp. */
+async function writeChangeLog(change: NodeChange): Promise<void> {
+  if (!change.modifiedBy) return;
+  await db
+    .collection(NODES_LOGS)
+    .doc()
+    .set(change as any);
+  if (change.modifiedBy !== "ouhrac") {
+    await db.collection(USERS).doc(change.modifiedBy).update({
+      lasChangeMadeAt: new Date(),
+    });
+  }
+}
+
+async function addProperty(
+  ctx: OperationContext,
+): Promise<{ ok: true; addedProperty: string }> {
+  const { nodeId, nodeData, data, uname, appName } = ctx;
+
+  const { propertyName, propertyType } = data as {
+    propertyName?: string;
+    propertyType?: string;
+  };
+  if (!propertyType || typeof propertyType !== "string") {
+    throw new HttpError(400, "propertyType is required");
+  }
+  const nameError = validatePropertyName(propertyName);
+  if (nameError) throw new HttpError(400, nameError);
+  const cleanName = (propertyName as string).trim();
+
+  if (hasOwn(nodeData.properties, cleanName)) {
+    throw new HttpError(
+      409,
+      `Property "${cleanName}" already exists on this node`,
+    );
+  }
+
+  const normalizedType = propertyType.toLowerCase();
+  const propertyValue = defaultValueForType(normalizedType);
+  const previousProperties = nodeData.properties || {};
+
+  // Create the property on the node itself (own value, not inherited).
+  const nodeUpdates: Record<string, any> = {
+    [`properties.${cleanName}`]: propertyValue,
+    [`propertyType.${cleanName}`]: normalizedType,
+    [`inheritance.${cleanName}`]: {
+      ref: null,
+      title: "",
+      inheritanceType: "inheritUnlessAlreadyOverRidden",
+    },
+  };
+  if (uname && uname !== "ouhrac") {
+    nodeUpdates.contributors = FieldValue.arrayUnion(uname);
+  }
+  await db.collection(NODES).doc(nodeId).update(nodeUpdates);
+
+  // Propagate down the subtree, skipping descendants that already define
+  // the property (their own value is preserved).
+  await walkSpecializations(nodeId, (node) => {
+    if (hasOwn(node.properties, cleanName)) return null;
+    return {
+      [`properties.${cleanName}`]: propertyValue,
+      [`propertyType.${cleanName}`]: normalizedType,
+      [`inheritance.${cleanName}`]: {
+        ref: nodeId,
+        title: nodeData.title ?? "",
+        inheritanceType: "inheritUnlessAlreadyOverRidden",
+      },
+    };
+  });
+
+  if (uname) {
+    const newProperties = { ...previousProperties, [cleanName]: propertyValue };
+    await writeChangeLog({
+      nodeId,
+      modifiedBy: uname,
+      modifiedProperty: null,
+      previousValue: previousProperties,
+      newValue: newProperties,
+      modifiedAt: new Date(),
+      changeType: "add property",
+      changeDetails: { addedProperty: cleanName },
+      fullNode: { ...nodeData, properties: newProperties },
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+
+  return { ok: true, addedProperty: cleanName };
+}
+
+async function deleteProperty(
+  ctx: OperationContext,
+): Promise<{ ok: true; removedProperty: string }> {
+  const { nodeId, nodeData, data, uname, appName } = ctx;
+
+  const nameError = validatePropertyName(data?.propertyName);
+  if (nameError) throw new HttpError(400, nameError);
+  const cleanName = (data.propertyName as string).trim();
+
+  if (!hasOwn(nodeData.properties, cleanName)) {
+    throw new HttpError(404, `Property "${cleanName}" not found on this node`);
+  }
+
+  // Resolve previous value for the log (follows inheritance ref if any).
+  let previousValue: any = nodeData.properties[cleanName];
+  const inheritedRef = nodeData.inheritance?.[cleanName]?.ref;
+  if (inheritedRef) {
+    const refData = (
+      await db.collection(NODES).doc(inheritedRef).get()
+    ).data() as INode | undefined;
+    if (refData) previousValue = refData.properties?.[cleanName];
+  }
+
+  // Remove from the node, then unconditionally across the subtree.
+  const nodeUpdates: Record<string, any> = deletionUpdates(cleanName);
+  if (uname && uname !== "ouhrac") {
+    nodeUpdates.contributors = FieldValue.arrayUnion(uname);
+  }
+  await db.collection(NODES).doc(nodeId).update(nodeUpdates);
+  const updates = deletionUpdates(cleanName);
+  await walkSpecializations(nodeId, () => updates);
+
+  if (uname) {
+    await writeChangeLog({
+      nodeId,
+      modifiedBy: uname,
+      modifiedProperty: cleanName,
+      previousValue: previousValue ?? null,
+      newValue: null,
+      modifiedAt: new Date(),
+      changeType: "remove property",
+      fullNode: nodeData,
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+
+  return { ok: true, removedProperty: cleanName };
+}
+
+async function renameProperty(
+  ctx: OperationContext,
+): Promise<{ ok: true; renamedTo: string }> {
+  const { nodeId, nodeData, data, uname, appName } = ctx;
+
+  const { previousValue, newValue } = data as {
+    previousValue?: string;
+    newValue?: string;
+  };
+  const oldNameError = validatePropertyName(previousValue);
+  if (oldNameError) throw new HttpError(400, `Old ${oldNameError}`);
+  const newNameError = validatePropertyName(newValue);
+  if (newNameError) throw new HttpError(400, `New ${newNameError}`);
+  const oldName = (previousValue as string).trim();
+  const newName = (newValue as string).trim();
+  if (oldName === newName) {
+    throw new HttpError(400, "New name must differ from the current name");
+  }
+
+  if (!hasOwn(nodeData.properties, oldName)) {
+    throw new HttpError(404, `Property "${oldName}" not found on this node`);
+  }
+  if (hasOwn(nodeData.properties, newName)) {
+    throw new HttpError(
+      409,
+      `Property "${newName}" already exists on this node`,
+    );
+  }
+
+  const nodeUpdates = renameUpdatesFor(nodeData, oldName, newName);
+  if (uname && uname !== "ouhrac") {
+    nodeUpdates.contributors = FieldValue.arrayUnion(uname);
+    nodeUpdates[`contributorsByProperty.${newName}`] =
+      FieldValue.arrayUnion(uname);
+  }
+  await db.collection(NODES).doc(nodeId).update(nodeUpdates);
+
+  // Rename across the subtree — only nodes that define the old key; a
+  // collision on the new name overwrites it.
+  await walkSpecializations(nodeId, (node) =>
+    hasOwn(node.properties, oldName)
+      ? renameUpdatesFor(node, oldName, newName)
+      : null,
+  );
+
+  if (uname) {
+    await writeChangeLog({
+      nodeId,
+      modifiedBy: uname,
+      modifiedProperty: newName,
+      previousValue: oldName,
+      newValue: newName,
+      modifiedAt: new Date(),
+      changeType: "edit property",
+      fullNode: nodeData,
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+
+  return { ok: true, renamedTo: newName };
+}
+
+/**
+ * Types `change` accepts. `string` (text) is synced by the realtime YJS
+ * editor; link/collection types go through the link-element flow.
+ */
+const CHANGE_TYPES = new Set(["numeric", "string-select", "string-array"]);
+
+/** Light, type-aware validation of an incoming value. */
+function validateValue(propertyType: string, value: any): string | null {
+  if (value === undefined || value === null) return "value is required";
+  if (propertyType === "string-array") {
+    if (!Array.isArray(value) || !value.every((v) => typeof v === "string")) {
+      return "value must be an array of strings";
+    }
+  }
+  if (propertyType === "numeric") {
+    const ok =
+      typeof value === "number" ||
+      (typeof value === "object" && value !== null && "value" in value);
+    if (!ok) return "numeric value must be a number or { value, unit }";
+  }
+  // string-select stores an object ({ performer, reason, … }) — accept as-is.
+  return null;
+}
+
+/** Change-log fields for a value change; the shape depends on the type. */
+function buildValueChangeLog(
+  propertyType: string,
+  previousValue: any,
+  newValue: any,
+): Pick<
+  NodeChange,
+  "previousValue" | "newValue" | "changeType" | "changeDetails"
+> {
+  if (propertyType === "numeric") {
+    return {
+      previousValue: JSON.stringify(previousValue ?? null),
+      newValue: JSON.stringify(newValue ?? null),
+      changeType: "change text",
+    };
+  }
+  if (propertyType === "string-select") {
+    return {
+      previousValue: previousValue ?? null,
+      newValue,
+      changeType: "change select-string",
+    };
+  }
+  // string-array
+  const oldArr: string[] = Array.isArray(previousValue) ? previousValue : [];
+  const newArr: string[] = Array.isArray(newValue) ? newValue : [];
+  const added = newArr.filter((x) => !oldArr.includes(x));
+  const removed = oldArr.filter((x) => !newArr.includes(x));
+  let changeType: NodeChange["changeType"] = "modify elements";
+  if (added.length === 1 && removed.length === 0) changeType = "add element";
+  else if (removed.length === 1 && added.length === 0)
+    changeType = "remove element";
+  return {
+    previousValue: oldArr,
+    newValue: newArr,
+    changeType,
+    changeDetails: { addedElements: added, removedElements: removed },
+  };
+}
+
+async function changeProperty(
+  ctx: OperationContext,
+): Promise<{ ok: true; changedProperty: string }> {
+  const { nodeId, nodeData, data, uname, appName } = ctx;
+
+  const nameError = validatePropertyName(data?.propertyName);
+  if (nameError) throw new HttpError(400, nameError);
+  const cleanName = (data.propertyName as string).trim();
+
+  if (!hasOwn(nodeData.properties, cleanName)) {
+    throw new HttpError(404, `Property "${cleanName}" not found on this node`);
+  }
+  if (!data || !("value" in data)) {
+    throw new HttpError(400, "value is required");
+  }
+  const value = data.value;
+
+  // The node is authoritative for the property's type.
+  const propertyType = (nodeData.propertyType as any)?.[cleanName];
+  if (propertyType === "string") {
+    throw new HttpError(
+      400,
+      "Text properties are edited via the realtime editor, not this endpoint",
+    );
+  }
+  if (!CHANGE_TYPES.has(propertyType)) {
+    throw new HttpError(
+      400,
+      `Property "${cleanName}" (type "${propertyType ?? "unknown"}") cannot be changed here; only numeric, string-select and string-array are supported`,
+    );
+  }
+  const valueError = validateValue(propertyType, value);
+  if (valueError) throw new HttpError(400, valueError);
+
+  // Resolve the previous value for the log through the inheritance ref —
+  // while inheriting, the node's own stored copy can be stale.
+  let previousValue: any = nodeData.properties[cleanName];
+  const inheritedRef = nodeData.inheritance?.[cleanName]?.ref;
+  if (inheritedRef) {
+    const refData = (
+      await db.collection(NODES).doc(inheritedRef).get()
+    ).data() as INode | undefined;
+    if (refData && hasOwn(refData.properties, cleanName)) {
+      previousValue = refData.properties[cleanName];
+    }
+  }
+  const wasInheriting = !!inheritedRef;
+
+  // Write the value; if the node was inheriting, this overrides — break its ref.
+  const nodeUpdates: Record<string, any> = {
+    [`properties.${cleanName}`]: value,
+  };
+  if (wasInheriting) {
+    nodeUpdates[`inheritance.${cleanName}.ref`] = null;
+    nodeUpdates[`inheritance.${cleanName}.title`] = "";
+  }
+  if (uname && uname !== "ouhrac") {
+    nodeUpdates.contributors = FieldValue.arrayUnion(uname);
+    nodeUpdates[`contributorsByProperty.${cleanName}`] =
+      FieldValue.arrayUnion(uname);
+  }
+  await db.collection(NODES).doc(nodeId).update(nodeUpdates);
+
+  // When newly overriding, re-point inheriting descendants at this node —
+  // ref only, values resolve through it. A descendant that doesn't rewire
+  // prunes its subtree: nodes below it inherit from it, not from us.
+  if (wasInheriting) {
+    await walkSpecializations(
+      nodeId,
+      (node) => {
+        const inh = node.inheritance?.[cleanName];
+        if (!inh || inh.inheritanceType === "neverInherit") return null;
+        const stillInherits = inh.ref !== null; // null === overridden, leave it
+        const rewire =
+          inh.inheritanceType === "alwaysInherit" ||
+          (inh.inheritanceType === "inheritUnlessAlreadyOverRidden" &&
+            stillInherits);
+        if (!rewire) return null;
+        return {
+          [`inheritance.${cleanName}.ref`]: nodeId,
+          [`inheritance.${cleanName}.title`]: nodeData.title ?? "",
+        };
+      },
+      { descendPastSkipped: false },
+    );
+  }
+
+  // No-op edits still persist the value (an override can pin the inherited
+  // value) but are not logged.
+  if (uname && JSON.stringify(previousValue) !== JSON.stringify(value)) {
+    await writeChangeLog({
+      nodeId,
+      modifiedBy: uname,
+      modifiedProperty: cleanName,
+      modifiedAt: new Date(),
+      fullNode: nodeData,
+      ...buildValueChangeLog(propertyType, previousValue, value),
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+
+  return { ok: true, changedProperty: cleanName };
+}
+
+const ACTIONS: PropertyAction[] = ["add", "delete", "rename", "change"];
+
+function fail(res: NextApiResponse, status: number, msg: string) {
+  return res.status(status).json({ error: msg, message: msg });
+}
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return fail(res, 405, "Method not allowed");
+
+  const data = req.body.data;
+  const { action, nodeId, appName, user } = data as {
+    action?: PropertyAction;
+    nodeId?: string;
+    appName?: string;
+    user?: any;
+  };
+  const { uname } = user?.userData || {};
+
+  if (!action || !ACTIONS.includes(action)) {
+    return fail(res, 400, `Unknown or missing action "${action}"`);
+  }
+  if (!nodeId || typeof nodeId !== "string") {
+    return fail(res, 400, "nodeId is required");
+  }
+
+  try {
+    const nodeData = (await db.collection(NODES).doc(nodeId).get()).data() as
+      | INode
+      | undefined;
+    if (!nodeData || nodeData.deleted) return fail(res, 404, "Node not found");
+    if (appName && nodeData.appName && nodeData.appName !== appName) {
+      return fail(res, 403, "Node does not belong to this app");
+    }
+
+    const ctx: OperationContext = { nodeId, nodeData, data, uname, appName };
+
+    let result: { ok: true } & Record<string, any>;
+    switch (action) {
+      case "add":
+        result = await addProperty(ctx);
+        break;
+      case "delete":
+        result = await deleteProperty(ctx);
+        break;
+      case "rename":
+        result = await renameProperty(ctx);
+        break;
+      case "change":
+        result = await changeProperty(ctx);
+        break;
+    }
+
+    return res.status(200).json(result);
+  } catch (error: any) {
+    if (error instanceof HttpError) {
+      return fail(res, error.status, error.message);
+    }
+    console.error("nodes/properties error", error);
+    recordLogs(
+      {
+        type: "error",
+        error: JSON.stringify({
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        }),
+        at: "nodes/properties/update",
+      },
+      uname,
+    );
+    const message = error?.message || "Internal error";
+    return res.status(500).json({ error: message, message });
+  }
+}
+
+export default fbAuth(handler);


### PR DESCRIPTION
Hi @samadouhra

This PR moves generic property operations (add, delete, rename, and value changes) off the client and onto a single backend API endpoint.

Changes include:

- adding a single `/nodes/properties/update` endpoint that handles add, delete, rename, and change actions via an `action` field in the request body
- routing property add and rename (NodeBody) and delete (Node) through the endpoint instead of direct Firestore writes
- routing numeric and list/chips value changes through the endpoint
- handling inheritance propagation to specializations on the server
- keeping the local update UI, with the change reverting and showing an error if the save fails
- preventing a newly added property from overwriting a child that already defines one with the same name
- adding/removing links on properties like actor now goes through the endpoint, and the linked nodes are kept in sync automatically
- specializations, generalizations, parts, and isPartOf are untouched and still work as before