### PR TITLE
Move parts editing to a single backend endpoint

### DIFF
--- a/src/components/OntologyComponents/Node.tsx
+++ b/src/components/OntologyComponents/Node.tsx
@@ -91,7 +91,13 @@ import {
   setDoc,
   updateDoc,
 } from "firebase/firestore";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import Text from "./Text";
 import useConfirmDialog from "@components/lib/hooks/useConfirmDialog";
 import {
@@ -135,6 +141,7 @@ import { getStorage } from "firebase/storage";
 import NodeActivityFlow from "../NodBody/NodeActivityFlow";
 import { development } from "@components/lib/CONSTANTS";
 import { Post } from "@components/lib/utils/Post";
+import { pendingWrites } from "@components/lib/utils/pendingWrites";
 import ChipsProperty from "../StructuredProperty/ChipsProperty";
 import {
   addLinkToNode,
@@ -1037,6 +1044,21 @@ const Node = ({
     }
   };
 
+  // Latest parts value are used as the write base so the writes build on each other
+  // and not on the snapshot. This prevents viewer edits to undo each other.
+  const latestPartsRef = useRef<{ id: string; parts: ICollection[] } | null>(
+    null,
+  );
+  useEffect(() => {
+    if (!currentVisibleNode?.id) return;
+    latestPartsRef.current = {
+      id: currentVisibleNode.id,
+      parts: JSON.parse(
+        JSON.stringify(currentVisibleNode.properties?.parts ?? []),
+      ),
+    };
+  }, [currentVisibleNode?.id, currentVisibleNode?.properties?.parts]);
+
   const handleSaveLinkChanges = useCallback(
     async (
       removedElements: string[],
@@ -1070,9 +1092,12 @@ const Node = ({
           id: l,
         }));
 
-        // Parts are saved through the dedicated parts endpoint
+        // Save parts through the parts endpoint.
         if (selectedProperty === "parts") {
-          const source = relatedNodes[nodeId]?.properties?.parts;
+          const source =
+            latestPartsRef.current?.id === nodeId
+              ? latestPartsRef.current.parts
+              : relatedNodes[nodeId]?.properties?.parts;
           const next: ICollection[] =
             Array.isArray(source) && source.length
               ? JSON.parse(JSON.stringify(source))
@@ -1089,17 +1114,25 @@ const Node = ({
           );
           next[i].nodes.push(...addedLinks.filter((l) => !existing.has(l.id)));
 
+          // Advance the ref now so adds in the same tick build on this result.
+          latestPartsRef.current = { id: nodeId, parts: next };
+
           setCurrentVisibleNode((prev: any) =>
             prev && prev.id === nodeId
               ? { ...prev, properties: { ...prev.properties, parts: next } }
               : prev,
           );
 
-          await Post("/nodes/parts/update", {
-            nodeId,
-            parts: next,
-            ...(appName ? { appName } : {}),
-          });
+          pendingWrites.start(nodeId, "properties.parts");
+          try {
+            await Post("/nodes/parts/update", {
+              nodeId,
+              parts: next,
+              ...(appName ? { appName } : {}),
+            });
+          } finally {
+            pendingWrites.end(nodeId, "properties.parts");
+          }
           return;
         }
 

--- a/src/components/OntologyComponents/Node.tsx
+++ b/src/components/OntologyComponents/Node.tsx
@@ -1070,6 +1070,39 @@ const Node = ({
           id: l,
         }));
 
+        // Parts are saved through the dedicated parts endpoint
+        if (selectedProperty === "parts") {
+          const source = relatedNodes[nodeId]?.properties?.parts;
+          const next: ICollection[] =
+            Array.isArray(source) && source.length
+              ? JSON.parse(JSON.stringify(source))
+              : [{ collectionName: "main", nodes: [] }];
+          for (const c of next) {
+            c.nodes = (c.nodes || []).filter(
+              (n: { id: string }) => !removedElements.includes(n.id),
+            );
+          }
+          let i = next.findIndex((c) => c.collectionName === selectedCollection);
+          if (i === -1) i = 0;
+          const existing = new Set(
+            next.flatMap((c) => c.nodes.map((n: { id: string }) => n.id)),
+          );
+          next[i].nodes.push(...addedLinks.filter((l) => !existing.has(l.id)));
+
+          setCurrentVisibleNode((prev: any) =>
+            prev && prev.id === nodeId
+              ? { ...prev, properties: { ...prev.properties, parts: next } }
+              : prev,
+          );
+
+          await Post("/nodes/parts/update", {
+            nodeId,
+            parts: next,
+            ...(appName ? { appName } : {}),
+          });
+          return;
+        }
+
         // Generic link-typed properties (actor, …) are saved through the API.
         // The structural edges below keep their existing flow.
         if (

--- a/src/components/StructuredProperty/InheritedPartsViewer.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewer.tsx
@@ -327,7 +327,21 @@ const InheritedPartsViewer: React.FC<InheritedPartsViewerProps> = ({
             borderRadius: "20px",
           }}
         >
-          {details.map((entry, index) => (
+          {details.map((entry, index) => {
+            // Read the part's optional state live from parts (details is just
+            // the reference), so the badge updates on toggle without a recompute.
+            const liveToOptional = entry.to
+              ? getCurrentPartOptionalStatus(entry.to)
+              : !!entry.toOptional;
+            const liveOptionalChange: "added" | "removed" | "none" =
+              entry.from && entry.to
+                ? entry.fromOptional === liveToOptional
+                  ? "none"
+                  : liveToOptional
+                    ? "added"
+                    : "removed"
+                : "none";
+            return (
             <ListItem
               key={`${entry.from}-${entry.to}`}
               sx={{
@@ -481,8 +495,8 @@ const InheritedPartsViewer: React.FC<InheritedPartsViewerProps> = ({
                     >
                       {formatPartTitle(
                         entry.toTitle,
-                        entry.toOptional || false,
-                        entry.optionalChange,
+                        liveToOptional,
+                        liveOptionalChange,
                       )}
                     </Link>
                   ) : null
@@ -490,7 +504,8 @@ const InheritedPartsViewer: React.FC<InheritedPartsViewerProps> = ({
                 sx={{ flex: 1, minWidth: 0.3 }}
               />
             </ListItem>
-          ))}
+            );
+          })}
         </List>
         <Popover
           id={id}

--- a/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
@@ -148,6 +148,11 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
   const [approvingPendingIds, setApprovingPendingIds] = useState<Set<string>>(
     new Set(),
   );
+  // Titles of just-approved parts, used as a fallback while the cloned node
+  // hasn't loaded into relatedNodes yet (otherwise the new row shows blank).
+  const [approvedTitles, setApprovedTitles] = useState<{ [id: string]: string }>(
+    {},
+  );
   const [loadingSpecializations, setLoadingSpecializations] = useState<
     Set<string>
   >(new Set());
@@ -512,6 +517,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
       updated.add(queuedId);
       return updated;
     });
+    setApprovedTitles((prev) => ({ ...prev, [queuedId]: title }));
     try {
       await Promise.resolve(approvePendingPart?.(queuedId));
     } finally {
@@ -579,7 +585,13 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
 
     // Computed first so the nodes with no parts can render pending rows too
     const pendingQueuedParts = Object.entries(clonedNodesQueue || {})
-      .filter(([, queuedNode]) => queuedNode?.property === "parts")
+      // Hide a row the moment its checkmark is clicked: the approved part shows
+      // up as its own row, so keeping this one would briefly double it.
+      .filter(
+        ([queuedId, queuedNode]) =>
+          queuedNode?.property === "parts" &&
+          !approvingPendingIds.has(queuedId),
+      )
       .map(([queuedId, queuedNode]) => ({
         id: queuedId,
         title: queuedNode?.title || "",
@@ -596,6 +608,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                 key={`pending-${pendingPart.id}`}
                 sx={{
                   display: "flex",
+                  alignItems: "center",
                   gap: 1,
                   px: 1,
                   py: 0.2,
@@ -625,66 +638,74 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                 </ListItemIcon>
                 <ListItemText
                   primary={
-                    <TextField
-                      size="small"
-                      fullWidth
-                      value={pendingPart.title}
-                      onChange={(e) =>
-                        updatePendingPartTitle?.(pendingPart.id, e.target.value)
-                      }
-                      placeholder="New part title"
-                      sx={{
-                        "& .MuiInputBase-root": {
-                          borderRadius: "12px",
-                        },
-                      }}
-                    />
-                  }
-                  sx={{ flex: 1, minWidth: 0.3 }}
-                />
-                {!!approvePendingPart && (
-                  <Tooltip title={"Approve part"} placement="top">
-                    <IconButton
-                      sx={{ p: 0.5 }}
-                      disabled={approvingPendingIds.has(pendingPart.id)}
-                      onClick={() => {
-                        onApprovePendingPart(pendingPart.id, pendingPart.title);
-                      }}
+                    <Box
+                      sx={{ display: "flex", alignItems: "center", gap: 1 }}
                     >
-                      {approvingPendingIds.has(pendingPart.id) ? (
-                        <CircularProgress size={20} />
-                      ) : (
-                        <CheckIcon
-                          sx={{
-                            fontSize: 20,
-                            color: "green",
-                            border: "1px solid green",
-                            borderRadius: "50%",
-                          }}
-                        />
-                      )}
-                    </IconButton>
-                  </Tooltip>
-                )}
-                {!!cancelPendingPart && (
-                  <Tooltip title={"Cancel part"} placement="top">
-                    <IconButton
-                      sx={{ p: 0.5 }}
-                      onClick={() => {
-                        cancelPendingPart(pendingPart.id);
-                      }}
-                    >
-                      <CloseIcon
+                      <TextField
+                        size="small"
+                        value={pendingPart.title}
+                        onChange={(e) =>
+                          updatePendingPartTitle?.(
+                            pendingPart.id,
+                            e.target.value,
+                          )
+                        }
+                        placeholder="New part title"
                         sx={{
-                          fontSize: 20,
-                          color: "red",
-                          border: "1px solid red",
-                          borderRadius: "50%",
+                          flex: 1,
+                          "& .MuiInputBase-root": {
+                            borderRadius: "12px",
+                          },
                         }}
                       />
-                    </IconButton>
-                  </Tooltip>
-                )}
+                      {!!approvePendingPart && (
+                        <Tooltip title={"Approve part"} placement="top">
+                          <IconButton
+                            sx={{ p: 0.5 }}
+                            onClick={() => {
+                              onApprovePendingPart(
+                                pendingPart.id,
+                                pendingPart.title,
+                              );
+                            }}
+                          >
+                            <CheckIcon
+                              sx={{
+                                fontSize: 20,
+                                color: "green",
+                                border: "1px solid green",
+                                borderRadius: "50%",
+                              }}
+                            />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                      {!!cancelPendingPart && (
+                        <Tooltip title={"Cancel part"} placement="top">
+                          <IconButton
+                            sx={{ p: 0.5 }}
+                            onClick={() => {
+                              cancelPendingPart(pendingPart.id);
+                            }}
+                          >
+                            <CloseIcon
+                              sx={{
+                                fontSize: 20,
+                                color: "red",
+                                border: "1px solid red",
+                                borderRadius: "50%",
+                              }}
+                            />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                    </Box>
+                  }
+                  // flex-basis reserves the width of the action-button column
+                  // the rows above have, so the + stays aligned while the field
+                  // (not an invisible icon) fills that space.
+                  sx={{ flex: "1 1 36px", minWidth: 0.3 }}
+                />
               </ListItem>
             );
           })}
@@ -791,7 +812,11 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
         to: partNode.id,
         symbol: "",
         fromTitle: "",
-        toTitle: allNodes[partNode.id]?.title || partNode.title || "",
+        toTitle:
+          allNodes[partNode.id]?.title ||
+          partNode.title ||
+          approvedTitles[partNode.id] ||
+          "",
         fromOptional: false,
         toOptional: liveOptional,
         optionalChange: "none",
@@ -1450,6 +1475,12 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
   const activeGeneralization = generalizations.find((g) => g.id === activeTab);
   const activeGenId = activeGeneralization?.id;
   const activeGenTitle = activeGeneralization?.title;
+  // Only turn the arrow into a spinner when rows are actually showing. If the
+  // active gen has no details yet, the tab body shows its own "Loading…", so a
+  // second spinner here would be redundant.
+  const showRecomputeSpinner =
+    !!inheritedPartsLoading &&
+    !!inheritedPartsDetails?.some((c) => c.generalizationId === activeGenId);
   const handleSorting = (e: any) => {
     try {
       // draggableId === the part id (see the Draggable above).
@@ -1605,12 +1636,12 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                 justifyContent: "center",
                 gap: 1,
                 height: "50px",
-                width: inheritedPartsLoading ? "auto" : "50px",
+                width: showRecomputeSpinner ? "auto" : "50px",
                 whiteSpace: "nowrap",
               }}
             >
               {/* Spinner + label while the gen→node mapping recomputes. */}
-              {inheritedPartsLoading ? (
+              {showRecomputeSpinner ? (
                 <>
                   <CircularProgress size={20} sx={{ color: "orange" }} />
                   <Typography

--- a/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
@@ -36,15 +36,9 @@ import CloseIcon from "@mui/icons-material/Close";
 import InheritedPartsLegend from "../Common/InheritedPartsLegend";
 import GeneralizationTabs from "./GeneralizationTabs";
 
-import {
-  collection,
-  getFirestore,
-  doc,
-  updateDoc,
-  Timestamp,
-} from "firebase/firestore";
-import { NODES } from "@components/lib/firestoreClient/collections";
-import { recordLogs, saveNewChangeLog } from "@components/lib/utils/helpers";
+import { Timestamp } from "firebase/firestore";
+import { recordLogs } from "@components/lib/utils/helpers";
+import { Post } from "@components/lib/utils/Post";
 
 interface GeneralizationNode {
   id: string;
@@ -122,7 +116,6 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
   cancelPendingPart,
   updatePendingPartTitle,
 }) => {
-  const db = getFirestore();
   const [activeTab, setActiveTab] = React.useState<string | null>(null);
   const generalizationsFromParent: GeneralizationNode[] =
     getAllGeneralizations();
@@ -534,31 +527,12 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
         mutateData?.(updatedDetails);
       }
 
-      // Firestore write for both fields
-      const nodeRef = doc(collection(db, NODES), currentVisibleNode?.id);
-      const updates: any = {
-        "properties.parts": updatedParts,
-      };
-      if (updatedDetails) {
-        updates.inheritedPartsDetails = updatedDetails;
-      }
-      await updateDoc(nodeRef, updates);
-
-      saveNewChangeLog(db, {
+      // Persist through the endpoint (stores parts + inheritedPartsDetails,
+      // maintains isPartOf, writes the change log).
+      await Post("/nodes/parts/update", {
         nodeId: currentVisibleNode?.id,
-        modifiedBy: user.uname,
-        modifiedProperty: "parts",
-        previousValue: previousParts,
-        newValue: updatedParts,
-        modifiedAt: new Date(),
-        changeType: "modify elements",
-        changeDetails: {
-          action: "switch to",
-          from: fromId,
-          oldTo,
-          newTo,
-        },
-        fullNode: currentVisibleNode,
+        parts: updatedParts,
+        ...(updatedDetails ? { inheritedPartsDetails: updatedDetails } : {}),
         ...(appName ? { appName } : {}),
       });
 
@@ -848,30 +822,12 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
         mutateData?.(updatedDetails);
       }
 
-      // Persist both fields in a single write so the node doc stays consistent and the cached inheritedPartsDetails isn't stale
-      const nodeRef = doc(collection(db, NODES), currentVisibleNode?.id);
-      const updates: any = {
-        "properties.parts": updatedParts,
-      };
-      if (updatedDetails) {
-        updates.inheritedPartsDetails = updatedDetails;
-      }
-      await updateDoc(nodeRef, updates);
-
-      saveNewChangeLog(db, {
+      // Persist through the endpoint (stores parts + inheritedPartsDetails,
+      // maintains isPartOf, writes the change log).
+      await Post("/nodes/parts/update", {
         nodeId: currentVisibleNode?.id,
-        modifiedBy: user.uname,
-        modifiedProperty: "parts",
-        previousValue: previousParts,
-        newValue: updatedParts,
-        modifiedAt: new Date(),
-        changeType: "modify elements",
-        changeDetails: {
-          action: "toggle optional",
-          partId,
-          optional: newOptional,
-        },
-        fullNode: currentVisibleNode,
+        parts: updatedParts,
+        ...(updatedDetails ? { inheritedPartsDetails: updatedDetails } : {}),
         ...(appName ? { appName } : {}),
       });
 
@@ -1884,34 +1840,17 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
             moveValue,
           );
         }
-        // Update the nodeData with the new property values
-        const nodeRef = doc(collection(db, NODES), currentVisibleNode?.id);
-        const property = "parts";
-        updateDoc(nodeRef, {
-          [`properties.${property}`]: propertyValue,
-        });
-
-        saveNewChangeLog(db, {
+        // Persist the reordered parts through the endpoint.
+        Post("/nodes/parts/update", {
           nodeId: currentVisibleNode?.id,
-          modifiedBy: user?.uname,
-          modifiedProperty: property,
-          previousValue,
-          newValue: propertyValue,
-          modifiedAt: new Date(),
-          changeType: "sort elements",
-          changeDetails: {
-            draggableNodeId: draggableId,
-            source,
-            destination,
-          },
-          fullNode: currentVisibleNode,
+          parts: propertyValue,
           ...(appName ? { appName } : {}),
         });
 
         // Record a log of the sorting action
         recordLogs({
           action: "sort elements",
-          field: property,
+          field: "parts",
           sourceCategory: "main",
           destinationCategory: "main",
           nodeId: currentVisibleNode?.id,

--- a/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
@@ -21,7 +21,6 @@ import {
   InheritedPartsDetail,
   ILinkNode,
   INode,
-  TransferInheritance,
 } from "@components/types/INode";
 import ArrowRightAltIcon from "@mui/icons-material/ArrowRightAlt";
 import RemoveIcon from "@mui/icons-material/Remove";
@@ -71,7 +70,7 @@ interface InheritedPartsViewerProps {
   saveParts: (
     newParts: ICollection[],
     inheritedPartsDetails?: InheritedPartsDetail[] | null,
-  ) => void;
+  ) => Promise<void>;
   user: any;
   appName?: string;
   navigateToNode?: any;
@@ -79,9 +78,6 @@ interface InheritedPartsViewerProps {
   addPart?: any;
   removePart?: any;
   inheritedPartsDetails?: InheritedPartsDetail[] | null;
-  loadingInheritedPartsDetails?: boolean;
-  mutateData?: (newData: InheritedPartsDetail[] | null) => void;
-  debouncedRefetch?: () => void;
   refetchNow?: () => void;
   clonedNodesQueue?: {
     [nodeId: string]: { title: string; id: string; property: string };
@@ -111,9 +107,6 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
   setDisplayDetails,
   appName,
   inheritedPartsDetails,
-  loadingInheritedPartsDetails,
-  mutateData,
-  debouncedRefetch,
   refetchNow,
   clonedNodesQueue,
   approvePendingPart,
@@ -157,48 +150,6 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
   const [highlightedPendingIds, setHighlightedPendingIds] = useState<Set<string>>(
     new Set(),
   );
-  // Parts whose inheritance symbol is being recomputed by the API after a
-  // local replace. While present, the row's symbol is replaced with a spinner.
-  const [calculatingPartIds, setCalculatingPartIds] = useState<Set<string>>(
-    new Set(),
-  );
-  // Parts the user just removed or replaced. Suppresses a false
-  // pending-recompute spinner until properties.parts catches up.
-  const [optimisticallyRemovedIds, setOptimisticallyRemovedIds] = useState<
-    Set<string>
-  >(new Set());
-  const prevLoadingInheritedRef = useRef<boolean | undefined>(
-    loadingInheritedPartsDetails,
-  );
-
-  // When loading transitions from true → false, the API response just landed,
-  // so the freshly recomputed symbols are now in inheritedPartsDetails: drop
-  // every spinner.
-  useEffect(() => {
-    if (prevLoadingInheritedRef.current && !loadingInheritedPartsDetails) {
-      setCalculatingPartIds((prev) => (prev.size > 0 ? new Set() : prev));
-    }
-    prevLoadingInheritedRef.current = loadingInheritedPartsDetails;
-  }, [loadingInheritedPartsDetails]);
-
-  // Drop ids once they're gone from properties.parts (snapshot landed).
-  useEffect(() => {
-    setOptimisticallyRemovedIds((prev) => {
-      if (prev.size === 0) return prev;
-      const stillInParts = new Set<string>(
-        currentVisibleNode.properties?.parts?.[0]?.nodes?.map(
-          (n: { id: string }) => n.id,
-        ) ?? [],
-      );
-      let changed = false;
-      const next = new Set<string>();
-      for (const id of prev) {
-        if (stillInParts.has(id)) next.add(id);
-        else changed = true;
-      }
-      return changed ? next : prev;
-    });
-  }, [currentVisibleNode.properties?.parts]);
 
   // Merge nodes from props with locally fetched nodes
   const allNodes = { ...nodes, ...fetchedNodes };
@@ -271,30 +222,6 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
     return null;
   }
 
-  const getPartOptionalStatus = (partId: string, nodeId: string): boolean => {
-    const node = allNodes[nodeId];
-    if (!node?.properties?.parts) return false;
-
-    for (const collection of node.properties.parts) {
-      const part = collection.nodes.find((n: any) => n.id === partId);
-      if (part) return !!part.optional;
-    }
-    return false;
-  };
-
-  const getCurrentPartOptionalStatus = (partId: string): boolean => {
-    const currentNodeInCache =
-      allNodes[currentVisibleNode.id] || currentVisibleNode;
-    const currentNodeParts = currentNodeInCache.properties?.["parts"];
-
-    if (!currentNodeParts) return false;
-
-    for (const collection of currentNodeParts) {
-      const part = collection.nodes.find((n: any) => n.id === partId);
-      if (part) return !!part.optional;
-    }
-    return false;
-  };
   const handleClick = (event: any, from: string) => {
     setAnchorEl(event.currentTarget);
     setPickingFor(from);
@@ -452,9 +379,6 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
       const updatedParts: ICollection[] = JSON.parse(
         JSON.stringify(sourceParts),
       );
-      const previousParts = JSON.parse(
-        JSON.stringify(currentVisibleNode.properties?.["parts"] || []),
-      );
       const partsCol = updatedParts[0];
       if (!partsCol) return;
       const oldIdx = partsCol.nodes.findIndex((n: any) => n.id === oldTo);
@@ -527,13 +451,12 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
             title: oldToTitle,
           });
         });
+       }
 
-        mutateData?.(updatedDetails);
-      }
-
-      // Persist through the shared saveParts (stores parts + inheritedPartsDetails,
-      // maintains isPartOf, writes the change log, handles failure).
-      saveParts(updatedParts, updatedDetails);
+      // Save parts + the userOverride (so the recompute keeps the pick), then
+      // refetch so the switched symbols render.
+      await saveParts(updatedParts, updatedDetails);
+      refetchNow?.();
 
       recordLogs({
         action: "switch to",
@@ -556,187 +479,26 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
     }
   };
 
-  // Helper to clone and optimistically update inheritedPartsDetails
-  const optimisticUpdate = (
-    updater: (details: InheritedPartsDetail[]) => InheritedPartsDetail[],
-  ) => {
-    if (!inheritedPartsDetails || !mutateData) return;
-    const updated = updater(JSON.parse(JSON.stringify(inheritedPartsDetails)));
-    mutateData(updated);
-  };
-
+  // onAddPart/onRemovePart/onReplacePart route through saveParts. Rows derive
+  // from properties.parts, so they update at once; a new part shows a pending
+  // spinner until the recompute fills its annotation.
   const onAddPart = (partId: string) => {
     addPart(partId);
-    optimisticUpdate((data) => {
-      for (const gen of data) {
-        let updatedExistingEntry = false;
-        const entry = gen.details.find(
-          (d) => d.from === partId && d.symbol === "x",
-        );
-        if (entry) {
-          entry.symbol = "=";
-          entry.to = partId;
-          entry.toTitle = entry.fromTitle;
-          entry.toOptional = entry.fromOptional;
-          entry.optionalChange = "none";
-          updatedExistingEntry = true;
-        }
-
-        // If this part doesn't exist in inherited comparison rows,
-        // optimistically render it as a newly added part.
-        const alreadyPresent = gen.details.some((d) => d.to === partId);
-        if (!updatedExistingEntry && !alreadyPresent) {
-          gen.details.push({
-            from: "",
-            to: partId,
-            symbol: "+",
-            fromTitle: "",
-            toTitle: allNodes[partId]?.title || "",
-            fromOptional: false,
-            toOptional: getCurrentPartOptionalStatus(partId),
-            optionalChange: "none",
-            hops: 0,
-          });
-        }
-      }
-      return data;
-    });
-    // Show a spinner in place of the symbol until the API recompute lands
-    setCalculatingPartIds((prev) => new Set(prev).add(partId));
   };
 
   const onRemovePart = (partId: string) => {
-    setOptimisticallyRemovedIds((prev) => new Set(prev).add(partId));
     removePart(partId);
-
-    // For parts with (= or > symbol), keep the row visible with a
-    // spinner in place of the symbol until the API recompute lands.
-    // For "+"" parts, filter the row out instantly.
-    let hasInheritanceSource = false;
-    if (inheritedPartsDetails) {
-      for (const gen of inheritedPartsDetails) {
-        const entry = gen.details.find((d) => d.to === partId);
-        if (entry?.from) {
-          hasInheritanceSource = true;
-          break;
-        }
-      }
-    }
-
-    if (hasInheritanceSource) {
-      setCalculatingPartIds((prev) => new Set(prev).add(partId));
-      debouncedRefetch?.();
-      return;
-    }
-
-    optimisticUpdate((data) => {
-      for (const gen of data) {
-        gen.details = gen.details.filter((d) => d.to !== partId);
-      }
-      return data;
-    });
   };
 
   const onReplacePart = async (oldPartId: string, newPartId: string) => {
     if (!oldPartId || !newPartId || oldPartId === newPartId) return;
-
-    setOptimisticallyRemovedIds((prev) => new Set(prev).add(oldPartId));
-
-    // Build updated inheritedPartsDetails locally for instant UI feedback on
-    // to/toTitle and to fold into replaceWith's single updateDoc. The symbol
-    // is intentionally left stale — the API recompute below will replace it
-    // with the correct value, and the row shows a spinner in the meantime.
-    let updatedDetails: InheritedPartsDetail[] | null = null;
-    if (inheritedPartsDetails) {
-      updatedDetails = JSON.parse(JSON.stringify(inheritedPartsDetails));
-      const newTitle = allNodes[newPartId]?.title || "";
-
-      updatedDetails!.forEach((gen, idx) => {
-        // Re-hydrate createdAt so the hook's freshness check survives.
-        const original: any = inheritedPartsDetails[idx]?.createdAt;
-        if (original && typeof original.toMillis === "function") {
-          gen.createdAt = original;
-        } else {
-          const seconds = original?._seconds ?? original?.seconds;
-          const nanos =
-            original?._nanoseconds ?? original?.nanoseconds ?? 0;
-          gen.createdAt =
-            typeof seconds === "number"
-              ? new Timestamp(seconds, nanos)
-              : Timestamp.now();
-        }
-
-        // Every row whose to === oldPartId now points at newPartId.
-        for (const entry of gen.details) {
-          if (entry.to === oldPartId) {
-            entry.to = newPartId;
-            entry.toTitle = newTitle;
-          }
-        }
-
-        // Rename oldPartId → newPartId wherever it appears in nonPickedOnes.
-        for (const fromKey of Object.keys(gen.nonPickedOnes)) {
-          gen.nonPickedOnes[fromKey] = gen.nonPickedOnes[fromKey].map(
-            (item) =>
-              item.id === oldPartId
-                ? { id: newPartId, title: newTitle }
-                : item,
-          );
-        }
-      });
-
-      mutateData?.(updatedDetails);
-    }
-
-    // Show spinner in place of the symbol for this part until the API returns.
-    setCalculatingPartIds((prev) => {
-      const next = new Set(prev);
-      next.add(newPartId);
-      return next;
-    });
-
-    try {
-      await replaceWith(oldPartId, newPartId, updatedDetails);
-      // Trigger an immediate API recompute so the symbol updates as soon as
-      // the parts changes are persisted. The loading→idle transition above
-      // clears the spinner.
-      refetchNow?.();
-    } catch (error) {
-      console.error(error);
-      setCalculatingPartIds((prev) => {
-        if (!prev.has(newPartId)) return prev;
-        const next = new Set(prev);
-        next.delete(newPartId);
-        return next;
-      });
-    }
+    // The new id shows a pending row until the recompute fills its symbol;
+    // refetch so it resolves promptly.
+    await replaceWith(oldPartId, newPartId);
+    refetchNow?.();
   };
 
   const onApprovePendingPart = async (queuedId: string, title: string) => {
-    // Optimistically show the approved part immediately in the list.
-    optimisticUpdate((data) => {
-      for (const gen of data) {
-        const alreadyExists = gen.details.some((entry) => entry.to === queuedId);
-        if (!alreadyExists) {
-          gen.details.push({
-            from: "",
-            to: queuedId,
-            symbol: "+",
-            fromTitle: "",
-            toTitle: title,
-            fromOptional: false,
-            toOptional: false,
-            optionalChange: "none",
-            hops: 0,
-          });
-        }
-      }
-      return data;
-    });
-
-    // Show a spinner in place of the symbol until the API recompute lands
-    setCalculatingPartIds((prev) => new Set(prev).add(queuedId));
-
     setApprovingPendingIds((prev) => {
       const updated = new Set(prev);
       updated.add(queuedId);
@@ -760,12 +522,10 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
         currentVisibleNode.properties?.["parts"];
       if (!sourceParts) return;
 
-      // Build the new properties.parts with optional flipped on the matching node
+      // Flip optional on the part. Rows read optional live from properties.parts,
+      // so the (o) badge updates as soon as saveParts runs.
       const updatedParts: ICollection[] = JSON.parse(
         JSON.stringify(sourceParts),
-      );
-      const previousParts = JSON.parse(
-        JSON.stringify(currentVisibleNode.properties?.["parts"] || []),
       );
 
       let newOptional = false;
@@ -781,49 +541,8 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
       }
       if (!found) return;
 
-      // Build the new inheritedPartsDetails with toOptional/optionalChange
-      //    updated for every entry that points at this part
-      const updatedDetails: InheritedPartsDetail[] | null = inheritedPartsDetails
-        ? JSON.parse(JSON.stringify(inheritedPartsDetails))
-        : null;
-      if (updatedDetails) {
-        updatedDetails.forEach((gen, idx) => {
-          // JSON.stringify strips the Timestamp class off createdAt. The hook's
-          // freshness check calls .toMillis(), so re-hydrate it: prefer the
-          // original instance (already a Timestamp), otherwise rebuild from
-          // {seconds,nanoseconds} (snapshot) or {_seconds,_nanoseconds} (API).
-          const original: any = inheritedPartsDetails![idx]?.createdAt;
-          if (original && typeof original.toMillis === "function") {
-            gen.createdAt = original;
-          } else {
-            const seconds = original?._seconds ?? original?.seconds;
-            const nanos =
-              original?._nanoseconds ?? original?.nanoseconds ?? 0;
-            gen.createdAt =
-              typeof seconds === "number"
-                ? new Timestamp(seconds, nanos)
-                : Timestamp.now();
-          }
-
-          for (const entry of gen.details) {
-            if (entry.to !== partId) continue;
-            entry.toOptional = newOptional;
-            entry.optionalChange = entry.from
-              ? entry.fromOptional === newOptional
-                ? "none"
-                : newOptional
-                  ? "added"
-                  : "removed"
-              : "none";
-          }
-        });
-        // Reflect the change in the React tree immediately.
-        mutateData?.(updatedDetails);
-      }
-
-      // Persist through the shared saveParts (stores parts + inheritedPartsDetails,
-      // maintains isPartOf, writes the change log, handles failure).
-      saveParts(updatedParts, updatedDetails);
+      // Save through saveParts (maintains isPartOf, logs, handles failure).
+      saveParts(updatedParts);
 
       recordLogs({
         action: "toggle optional",
@@ -1037,7 +756,41 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
       },
       {} as { [key: string]: string[] },
     );
-    const draggableItems = details.filter((entry: any) => entry.to);
+    // Rows come from the node's own parts, so edits show at once. details is
+    // just an annotation lookup (from/symbol/switch options); a part with no
+    // entry yet renders `pending`. optional/optionalChange are read live.
+    const detailByTo = new Map<string, any>();
+    for (const d of details) {
+      if (d.to) detailByTo.set(d.to, d);
+    }
+    const draggableItems = (
+      currentVisibleNode.properties?.parts?.[0]?.nodes ?? []
+    ).map((partNode: any) => {
+      const liveOptional = !!partNode.optional;
+      const entry = detailByTo.get(partNode.id);
+      if (entry) {
+        const optionalChange = entry.from
+          ? entry.fromOptional === liveOptional
+            ? "none"
+            : liveOptional
+              ? "added"
+              : "removed"
+          : "none";
+        return { ...entry, toOptional: liveOptional, optionalChange, pending: false };
+      }
+      return {
+        from: "",
+        to: partNode.id,
+        symbol: "",
+        fromTitle: "",
+        toTitle: allNodes[partNode.id]?.title || partNode.title || "",
+        fromOptional: false,
+        toOptional: liveOptional,
+        optionalChange: "none",
+        hops: 0,
+        pending: true,
+      };
+    });
 
     const partAlternativesLookup: {
       [partId: string]: {
@@ -1045,7 +798,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
         gens: { id: string; title: string }[];
       };
     } = {};
-    
+
     // Calculate available dropdown options per part
     for (const entry of draggableItems) {
       if (partAlternativesLookup[entry.to]) continue;
@@ -1066,26 +819,11 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
         }));
       partAlternativesLookup[entry.to] = { specs, gens };
     }
-    
+
     const nonDraggableItems = Object.keys(nonPickedOnes).filter((id) => {
       const index = details.findIndex((d) => d.from === id);
       return index === -1;
     });
-
-    // Parts that exist on the node but aren't yet reflected in the inheritedPartsDetails returned from endpoint
-    const currentPartIds: string[] =
-      currentVisibleNode.properties?.parts?.[0]?.nodes?.map(
-        (n: { id: string }) => n.id,
-      ) ?? [];
-    const idsAlreadyInDetails = new Set<string>();
-    for (const d of details) {
-      if (d.to) idsAlreadyInDetails.add(d.to);
-      if (d.from) idsAlreadyInDetails.add(d.from);
-    }
-    const pendingRecomputeIds = currentPartIds.filter(
-      (id) =>
-        !idsAlreadyInDetails.has(id) && !optimisticallyRemovedIds.has(id),
-    );
 
     return (
       <Box
@@ -1105,8 +843,8 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
             >
               {draggableItems.map((entry: any, index: number) => (
                 <Draggable
-                  key={`${entry.from}::${entry.to}`}
-                  draggableId={`${entry.from}::${entry.to}`}
+                  key={entry.to}
+                  draggableId={entry.to}
                   index={index}
                 >
                   {(providedDraggable) => (
@@ -1169,7 +907,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                       />
 
                       <ListItemIcon sx={{ minWidth: "auto" }}>
-                        {calculatingPartIds.has(entry.to) ? (
+                        {entry.pending ? (
                           <Tooltip
                             title="Calculating inheritance for this part"
                             placement="top"
@@ -1241,7 +979,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                         <Tooltip title={"Remove part"} placement="top">
                           <span
                             style={{
-                              cursor: calculatingPartIds.has(entry.to)
+                              cursor: entry.pending
                                 ? "not-allowed"
                                 : undefined,
                               display: "inline-flex",
@@ -1249,7 +987,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                           >
                             <IconButton
                               sx={{ p: 0.5 }}
-                              disabled={calculatingPartIds.has(entry.to)}
+                              disabled={entry.pending}
                               onClick={() => {
                                 onRemovePart(entry.to);
                               }}
@@ -1257,14 +995,14 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                               <RemoveIcon
                                 sx={{
                                   fontSize: 20,
-                                  color: calculatingPartIds.has(entry.to)
+                                  color: entry.pending
                                     ? "gray"
                                     : "red",
-                                  border: calculatingPartIds.has(entry.to)
+                                  border: entry.pending
                                     ? "1px solid gray"
                                     : "1px solid red",
                                   borderRadius: "50%",
-                                  opacity: calculatingPartIds.has(entry.to)
+                                  opacity: entry.pending
                                     ? 0.5
                                     : 1,
                                 }}
@@ -1315,7 +1053,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                                 <Box
                                   component="button"
                                   type="button"
-                                  disabled={calculatingPartIds.has(entry.to)}
+                                  disabled={entry.pending}
                                   onMouseDown={(e: React.MouseEvent) => {
                                     e.stopPropagation();
                                   }}
@@ -1325,7 +1063,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                                     toggleOptional(entry.to);
                                   }}
                                   sx={{
-                                    cursor: calculatingPartIds.has(entry.to)
+                                    cursor: entry.pending
                                       ? "not-allowed"
                                       : "pointer",
                                     "&:disabled": { opacity: 0.5 },
@@ -1389,7 +1127,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                               >
                                 <Select
                                   value={entry.to}
-                                  disabled={calculatingPartIds.has(entry.to)}
+                                  disabled={entry.pending}
                                   onChange={(e) => {
                                     const newPartId = e.target.value;
                                     onReplacePart(entry.to, newPartId);
@@ -1589,89 +1327,6 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
             </List>
           )}
         </Droppable>
-        {pendingRecomputeIds.length > 0 && (
-          <List sx={{ px: 1.8, py: 0, mt: -0.5 }}>
-            {pendingRecomputeIds.map((partId: string) => (
-              <ListItem
-                key={`pending-recompute-${partId}`}
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 1,
-                  px: 1,
-                  py: 0,
-                  backgroundImage:
-                    "repeating-linear-gradient(to right, gray 0, gray 1px, transparent 1px, transparent 6px)",
-                  backgroundPosition: "top",
-                  backgroundRepeat: "repeat-x",
-                  backgroundSize: "100% 1px",
-                }}
-              >
-                <ListItemText
-                  primary={null}
-                  sx={{ flex: 1, minWidth: 0.3 }}
-                />
-                {/* Hidden spaces to align buttons with above rows */}
-                <Box aria-hidden sx={{ width: 20, flexShrink: 0 }} />
-                <Box aria-hidden sx={{ width: 30, flexShrink: 0 }} />
-                <ListItemText
-                  primary={
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        minHeight: 40,
-                      }}
-                    >
-                      <Tooltip
-                        title="Calculating inheritance for this part"
-                        placement="top"
-                      >
-                        <Box
-                          sx={{
-                            width: 28,
-                            height: 28,
-                            flexShrink: 0,
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                          }}
-                        >
-                          <CircularProgress
-                            size={18}
-                            sx={{ color: "orange" }}
-                          />
-                        </Box>
-                      </Tooltip>
-                      <Box
-                        sx={{
-                          flex: 1,
-                          minWidth: 0,
-                          display: "flex",
-                          alignItems: "center",
-                          pl: "22px",
-                          pr: "14px",
-                        }}
-                      >
-                        <Typography
-                          sx={{
-                            fontSize: "0.9rem",
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          {allNodes[partId]?.title ?? ""}
-                        </Typography>
-                      </Box>
-                    </Box>
-                  }
-                  sx={{ flex: 1, minWidth: 0.3 }}
-                />
-              </ListItem>
-            ))}
-          </List>
-        )}
         <Popover
           id={id}
           open={open}
@@ -1788,15 +1443,14 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
   const activeGenTitle = activeGeneralization?.title;
   const handleSorting = (e: any) => {
     try {
-      // Destructure properties from the result object
-      let { source, destination, draggableId, type } = e;
-      const separatorIdx = draggableId.indexOf("::");
-      draggableId = separatorIdx !== -1
-        ? draggableId.substring(separatorIdx + 2)
-        : draggableId;
-      // If there is no destination, no sorting needed
-
-      if (!destination || !user?.uname) {
+      // draggableId === the part id (see the Draggable above).
+      const { source, destination, draggableId } = e;
+      // No destination, or dropped back in the same spot: nothing to persist.
+      if (
+        !destination ||
+        !user?.uname ||
+        destination.index === source?.index
+      ) {
         return;
       }
 
@@ -1804,65 +1458,36 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
       const sourceCollectionIndex = 0;
       const destinationCollectionIndex = 0;
 
-      const propertyValue: ICollection[] =
-        currentVisibleNode.properties?.["parts"];
+      const source_ = currentVisibleNode.properties?.["parts"];
+      if (!source_) return;
 
-      // Ensure defined source and destination categories
-      if (propertyValue) {
-        // Ensure nodeData exists
+      // Work on a clone so we never mutate the live node state in place.
+      const newParts: ICollection[] = JSON.parse(JSON.stringify(source_));
 
-        const previousValue = JSON.parse(JSON.stringify(propertyValue));
+      const nodeIdx = newParts[sourceCollectionIndex].nodes.findIndex(
+        (link: ILinkNode) => link.id === draggableId,
+      );
 
-        if (!propertyValue) return;
-        // Find the index of the draggable item in the source category
-
-        const nodeIdx = propertyValue[sourceCollectionIndex].nodes.findIndex(
-          (link: ILinkNode) => link.id === draggableId,
+      if (nodeIdx !== -1) {
+        const moveValue = newParts[sourceCollectionIndex].nodes[nodeIdx];
+        newParts[sourceCollectionIndex].nodes.splice(nodeIdx, 1);
+        newParts[destinationCollectionIndex].nodes.splice(
+          destination.index,
+          0,
+          moveValue,
         );
-
-        // If the draggable item is found in the source category
-        if (nodeIdx !== -1) {
-          const moveValue = propertyValue[sourceCollectionIndex].nodes[nodeIdx];
-
-          // Remove the item from the source category
-          propertyValue[sourceCollectionIndex].nodes.splice(nodeIdx, 1);
-
-          // Move the item to the destination category
-          propertyValue[destinationCollectionIndex].nodes.splice(
-            destination.index,
-            0,
-            moveValue,
-          );
-        }
-        // Persist the reordered parts through the shared saveParts.
-        saveParts(propertyValue);
-
-        // Record a log of the sorting action
-        recordLogs({
-          action: "sort elements",
-          field: "parts",
-          sourceCategory: "main",
-          destinationCategory: "main",
-          nodeId: currentVisibleNode?.id,
-        });
-
-        // Optimistic update: reorder details to match new parts order
-        optimisticUpdate((data) => {
-          const newPartsOrder =
-            propertyValue[0]?.nodes?.map((n: any) => n.id) || [];
-          for (const gen of data) {
-            gen.details.sort((a, b) => {
-              const aIdx = newPartsOrder.indexOf(a.to);
-              const bIdx = newPartsOrder.indexOf(b.to);
-              return (
-                (aIdx === -1 ? Infinity : aIdx) -
-                (bIdx === -1 ? Infinity : bIdx)
-              );
-            });
-          }
-          return data;
-        });
       }
+
+      // Persist the reordered parts through the shared saveParts.
+      saveParts(newParts);
+
+      recordLogs({
+        action: "sort elements",
+        field: "parts",
+        sourceCategory: "main",
+        destinationCategory: "main",
+        nodeId: currentVisibleNode?.id,
+      });
     } catch (error: any) {
       // Log any errors that occur during the sorting process
       console.error(error);

--- a/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
@@ -38,7 +38,6 @@ import GeneralizationTabs from "./GeneralizationTabs";
 
 import { Timestamp } from "firebase/firestore";
 import { recordLogs } from "@components/lib/utils/helpers";
-import { Post } from "@components/lib/utils/Post";
 
 interface GeneralizationNode {
   id: string;
@@ -69,6 +68,10 @@ interface InheritedPartsViewerProps {
   setDisplayDetails: any;
   enableEdit: boolean;
   replaceWith: any;
+  saveParts: (
+    newParts: ICollection[],
+    inheritedPartsDetails?: InheritedPartsDetail[] | null,
+  ) => void;
   user: any;
   appName?: string;
   navigateToNode?: any;
@@ -98,6 +101,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
   readOnly = false,
   enableEdit,
   replaceWith,
+  saveParts,
   currentVisibleNode,
   triggerSearch,
   addPart,
@@ -527,14 +531,9 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
         mutateData?.(updatedDetails);
       }
 
-      // Persist through the endpoint (stores parts + inheritedPartsDetails,
-      // maintains isPartOf, writes the change log).
-      await Post("/nodes/parts/update", {
-        nodeId: currentVisibleNode?.id,
-        parts: updatedParts,
-        ...(updatedDetails ? { inheritedPartsDetails: updatedDetails } : {}),
-        ...(appName ? { appName } : {}),
-      });
+      // Persist through the shared saveParts (stores parts + inheritedPartsDetails,
+      // maintains isPartOf, writes the change log, handles failure).
+      saveParts(updatedParts, updatedDetails);
 
       recordLogs({
         action: "switch to",
@@ -822,14 +821,9 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
         mutateData?.(updatedDetails);
       }
 
-      // Persist through the endpoint (stores parts + inheritedPartsDetails,
-      // maintains isPartOf, writes the change log).
-      await Post("/nodes/parts/update", {
-        nodeId: currentVisibleNode?.id,
-        parts: updatedParts,
-        ...(updatedDetails ? { inheritedPartsDetails: updatedDetails } : {}),
-        ...(appName ? { appName } : {}),
-      });
+      // Persist through the shared saveParts (stores parts + inheritedPartsDetails,
+      // maintains isPartOf, writes the change log, handles failure).
+      saveParts(updatedParts, updatedDetails);
 
       recordLogs({
         action: "toggle optional",
@@ -1840,12 +1834,8 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
             moveValue,
           );
         }
-        // Persist the reordered parts through the endpoint.
-        Post("/nodes/parts/update", {
-          nodeId: currentVisibleNode?.id,
-          parts: propertyValue,
-          ...(appName ? { appName } : {}),
-        });
+        // Persist the reordered parts through the shared saveParts.
+        saveParts(propertyValue);
 
         // Record a log of the sorting action
         recordLogs({

--- a/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
@@ -78,6 +78,10 @@ interface InheritedPartsViewerProps {
   addPart?: any;
   removePart?: any;
   inheritedPartsDetails?: InheritedPartsDetail[] | null;
+  inheritedPartsLoading?: boolean;
+  mutateInheritedPartsDetails?: (
+    newData: InheritedPartsDetail[] | null,
+  ) => void;
   refetchNow?: () => void;
   clonedNodesQueue?: {
     [nodeId: string]: { title: string; id: string; property: string };
@@ -107,6 +111,8 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
   setDisplayDetails,
   appName,
   inheritedPartsDetails,
+  inheritedPartsLoading,
+  mutateInheritedPartsDetails,
   refetchNow,
   clonedNodesQueue,
   approvePendingPart,
@@ -357,44 +363,45 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
     try {
       if (!user?.uname || !fromId || !option || !activeGenId) return;
 
-      // Identify the old pick (oldTo) by finding the row in the active gen
+      // The current pick (oldTo) for this generalization part.
       const activeGen = inheritedPartsDetails?.find(
         (g) => g.generalizationId === activeGenId,
       );
-      const xRow = activeGen?.details.find(
-        (d) => d.from === fromId && d.to,
-      );
+      const xRow = activeGen?.details.find((d) => d.from === fromId && d.to);
       if (!xRow) return;
 
       const oldTo = xRow.to;
       const newTo = option;
       if (!oldTo || oldTo === newTo) return;
-      const oldToTitle = xRow.toTitle || allNodes[oldTo]?.title || "";
       const newToTitle = allNodes[newTo]?.title || xRow.toTitle || "";
+      const oldToTitle = xRow.toTitle || allNodes[oldTo]?.title || "";
 
       const sourceParts: ICollection[] | undefined =
         currentVisibleNode.properties?.["parts"];
-      if (!sourceParts) return;
+      if (!sourceParts?.[0]) return;
 
+      // Swap the parts' positions so the picked part takes the old one's slot:
+      // the generalization row stays put and only its right column flips.
       const updatedParts: ICollection[] = JSON.parse(
         JSON.stringify(sourceParts),
       );
-      const partsCol = updatedParts[0];
-      if (!partsCol) return;
-      const oldIdx = partsCol.nodes.findIndex((n: any) => n.id === oldTo);
-      const newIdx = partsCol.nodes.findIndex((n: any) => n.id === newTo);
+      const partsNodes = updatedParts[0].nodes;
+      const oldIdx = partsNodes.findIndex((n: any) => n.id === oldTo);
+      const newIdx = partsNodes.findIndex((n: any) => n.id === newTo);
       if (oldIdx === -1 || newIdx === -1) return;
-      const tmp = partsCol.nodes[oldIdx];
-      partsCol.nodes[oldIdx] = partsCol.nodes[newIdx];
-      partsCol.nodes[newIdx] = tmp;
+      const tmp = partsNodes[oldIdx];
+      partsNodes[oldIdx] = partsNodes[newIdx];
+      partsNodes[newIdx] = tmp;
+      const newOrder: string[] = partsNodes.map((n: any) => n.id);
 
-      // Build updated inheritedPartsDetails. Only the active generalization's row + nonPickedOnes change
+      // Update details locally for an instant switch; refetchNow reconciles.
       const updatedDetails: InheritedPartsDetail[] | null =
         inheritedPartsDetails
           ? JSON.parse(JSON.stringify(inheritedPartsDetails))
           : null;
       if (updatedDetails) {
         updatedDetails.forEach((gen, idx) => {
+          // Keep createdAt a real Timestamp.
           const original: any = inheritedPartsDetails![idx]?.createdAt;
           if (original && typeof original.toMillis === "function") {
             gen.createdAt = original;
@@ -410,51 +417,52 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
 
           if (gen.generalizationId !== activeGenId) return;
 
-          // Resolve both rows before updating either, so we don't grab the
-          // wrong row after the generalization row's `to` flips to newTo.
-          const xRow = gen.details.find(
+          const row = gen.details.find(
             (d) => d.from === fromId && d.to === oldTo,
           );
-          const otherRow = gen.details.find(
-            (d) => d !== xRow && d.to === newTo,
-          );
-
-          // Swap the optional values
-          const xRowToOptionalBefore = xRow?.toOptional ?? false;
-          const otherRowToOptionalBefore = otherRow?.toOptional ?? false;
-
-          // change symbol of the two rows
-          if (xRow) {
-            xRow.to = newTo;
-            xRow.toTitle = newToTitle;
-            xRow.userOverride = true;
-            xRow.symbol = xRow.from === xRow.to ? "=" : ">";
-            if (otherRow) xRow.toOptional = otherRowToOptionalBefore;
+          if (row) {
+            row.to = newTo;
+            row.toTitle = newToTitle;
+            row.userOverride = true;
+            row.symbol = row.from === row.to ? "=" : ">";
           }
 
-          // Change new row and old row's "to" so that it does not appear in multiple places
-          if (otherRow) {
-            otherRow.to = oldTo;
-            otherRow.toTitle = oldToTitle;
-            if (xRow) otherRow.toOptional = xRowToOptionalBefore;
+          // Drop the row newTo already had, so it isn't listed twice.
+          gen.details = gen.details.filter((d) => d === row || d.to !== newTo);
+
+          // Give the displaced oldTo a "+" row so it keeps a row.
+          if (!gen.details.some((d) => d.to === oldTo)) {
+            gen.details.push({
+              from: "",
+              to: oldTo,
+              symbol: "+",
+              fromTitle: "",
+              toTitle: oldToTitle,
+              fromOptional: false,
+              toOptional: false,
+              optionalChange: "none",
+              hops: 0,
+            });
           }
 
-          // nonPickedOnes: drop newTo, push oldTo back as an alternative
-          if (!gen.nonPickedOnes[fromId]) {
-            gen.nonPickedOnes[fromId] = [];
-          }
+          // Order rows by the new parts order, like the server does.
+          gen.details.sort((a, b) => {
+            const ia = newOrder.indexOf(a.to);
+            const ib = newOrder.indexOf(b.to);
+            return (ia === -1 ? Infinity : ia) - (ib === -1 ? Infinity : ib);
+          });
+
+          // Switch alternatives: drop newTo, offer oldTo as the way back.
+          if (!gen.nonPickedOnes[fromId]) gen.nonPickedOnes[fromId] = [];
           gen.nonPickedOnes[fromId] = gen.nonPickedOnes[fromId].filter(
             (item) => item.id !== newTo,
           );
-          gen.nonPickedOnes[fromId].push({
-            id: oldTo,
-            title: oldToTitle,
-          });
+          gen.nonPickedOnes[fromId].push({ id: oldTo, title: oldToTitle });
         });
-       }
+      }
 
-      // Save parts + the userOverride (so the recompute keeps the pick), then
-      // refetch so the switched symbols render.
+      // Show it now, then persist and let the server decide.
+      mutateInheritedPartsDetails?.(updatedDetails);
       await saveParts(updatedParts, updatedDetails);
       refetchNow?.();
 
@@ -1332,6 +1340,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
           open={open}
           anchorEl={anchorEl}
           onClose={handleClose}
+          disableRestoreFocus
           anchorOrigin={{
             vertical: "center",
             horizontal: "right",
@@ -1591,9 +1600,33 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                 position: "absolute",
                 left: "50%",
                 transform: "translateX(-50%)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 1,
+                height: "50px",
+                width: inheritedPartsLoading ? "auto" : "50px",
+                whiteSpace: "nowrap",
               }}
             >
-              <ArrowRightAltIcon sx={{ color: "orange", fontSize: "50px" }} />
+              {/* Spinner + label while the gen→node mapping recomputes. */}
+              {inheritedPartsLoading ? (
+                <>
+                  <CircularProgress size={20} sx={{ color: "orange" }} />
+                  <Typography
+                    sx={{
+                      fontSize: "0.8rem",
+                      fontWeight: "bold",
+                      fontStyle: "italic",
+                      color: "orange",
+                    }}
+                  >
+                    Generating inheritance…
+                  </Typography>
+                </>
+              ) : (
+                <ArrowRightAltIcon sx={{ color: "orange", fontSize: "50px" }} />
+              )}
             </Box>
 
             <Box

--- a/src/components/StructuredProperty/PartViewer.tsx
+++ b/src/components/StructuredProperty/PartViewer.tsx
@@ -21,7 +21,7 @@ interface PartViewerProps {
   saveParts: (
     newParts: any[],
     inheritedPartsDetails?: InheritedPartsDetail[] | null,
-  ) => void;
+  ) => Promise<void>;
   user: any;
   navigateToNode: any;
   replaceWith: any;
@@ -62,9 +62,6 @@ const PartViewer: React.FC<PartViewerProps> = ({
 
   const {
     data: inheritedPartsDetails,
-    loading: loadingInheritedPartsDetails,
-    mutateData,
-    debouncedRefetch,
     refetchNow,
   } = useInheritedPartsDetails(currentVisibleNode);
 
@@ -117,9 +114,6 @@ const PartViewer: React.FC<PartViewerProps> = ({
           saveParts={saveParts}
           appName={appName}
           inheritedPartsDetails={inheritedPartsDetails}
-          loadingInheritedPartsDetails={loadingInheritedPartsDetails}
-          mutateData={mutateData}
-          debouncedRefetch={debouncedRefetch}
           refetchNow={refetchNow}
           clonedNodesQueue={clonedNodesQueue}
           approvePendingPart={(queuedId: string) =>

--- a/src/components/StructuredProperty/PartViewer.tsx
+++ b/src/components/StructuredProperty/PartViewer.tsx
@@ -62,6 +62,8 @@ const PartViewer: React.FC<PartViewerProps> = ({
 
   const {
     data: inheritedPartsDetails,
+    loading: inheritedPartsLoading,
+    mutateData: mutateInheritedPartsDetails,
     refetchNow,
   } = useInheritedPartsDetails(currentVisibleNode);
 
@@ -114,6 +116,8 @@ const PartViewer: React.FC<PartViewerProps> = ({
           saveParts={saveParts}
           appName={appName}
           inheritedPartsDetails={inheritedPartsDetails}
+          inheritedPartsLoading={inheritedPartsLoading}
+          mutateInheritedPartsDetails={mutateInheritedPartsDetails}
           refetchNow={refetchNow}
           clonedNodesQueue={clonedNodesQueue}
           approvePendingPart={(queuedId: string) =>

--- a/src/components/StructuredProperty/PartViewer.tsx
+++ b/src/components/StructuredProperty/PartViewer.tsx
@@ -18,6 +18,10 @@ interface PartViewerProps {
   ) => void;
   linkNodeRelation: any;
   unlinkNodeRelation: any;
+  saveParts: (
+    newParts: any[],
+    inheritedPartsDetails?: InheritedPartsDetail[] | null,
+  ) => void;
   user: any;
   navigateToNode: any;
   replaceWith: any;
@@ -42,6 +46,7 @@ const PartViewer: React.FC<PartViewerProps> = ({
   addNodesToCache,
   linkNodeRelation,
   unlinkNodeRelation,
+  saveParts,
   user,
   navigateToNode,
   replaceWith,
@@ -109,6 +114,7 @@ const PartViewer: React.FC<PartViewerProps> = ({
           user={user}
           navigateToNode={navigateToNode}
           replaceWith={replaceWith}
+          saveParts={saveParts}
           appName={appName}
           inheritedPartsDetails={inheritedPartsDetails}
           loadingInheritedPartsDetails={loadingInheritedPartsDetails}

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -52,6 +52,7 @@ import VisualizeTheProperty from "./VisualizeTheProperty";
 import CollectionStructure from "./CollectionStructure";
 import PropertyContributors from "./PropertyContributors";
 import { NODES } from "@components/lib/firestoreClient/collections";
+import { Post } from "@components/lib/utils/Post";
 import InheritedPartsLegend from "../Common/InheritedPartsLegend";
 import EditProperty from "../AddPropertyForm/EditProperty";
 import StructuredPropertySelector from "./StructuredPropertySelector";
@@ -718,6 +719,27 @@ const StructuredProperty = ({
     fromModel: boolean = false,
   ) => {
     try {
+      // Parts: drop the id from the node's own parts and persist via endpoint.
+      if (property === "parts") {
+        const source = currentVisibleNode?.properties?.parts;
+        const newParts: ICollection[] = Array.isArray(source)
+          ? JSON.parse(JSON.stringify(source))
+          : [{ collectionName: "main", nodes: [] }];
+        for (const c of newParts) {
+          c.nodes = (c.nodes || []).filter((n: ILinkNode) => n.id !== linkId);
+        }
+        setCurrentVisibleNode((prev: any) =>
+          prev && prev.id === currentNodeId
+            ? { ...prev, properties: { ...prev.properties, parts: newParts } }
+            : prev,
+        );
+        await Post("/nodes/parts/update", {
+          nodeId: currentNodeId,
+          parts: newParts,
+          ...(appName ? { appName } : {}),
+        });
+        return;
+      }
       if (
         fromModel ||
         (await confirmIt(
@@ -931,97 +953,27 @@ const StructuredProperty = ({
     partId: string;
   }) => {
     try {
-      const nodeData = relatedNodes[currentNodeId];
-      if (!nodeData) {
-        console.error(
-          "linkNodeRelation: node not found in cache",
-          currentNodeId,
-        );
-        return;
-      }
-
-      let parts = nodeData.properties?.["parts"];
-
-      if (!parts || !Array.isArray(parts) || !parts[0]?.nodes) {
-        console.error("linkNodeRelation: parts structure is invalid");
-        return;
-      }
-
-      const previousPartsValue = JSON.parse(JSON.stringify(parts));
-      parts[0].nodes.push({
+      const source = currentVisibleNode?.properties?.parts;
+      const newParts: ICollection[] =
+        Array.isArray(source) && source.length
+          ? JSON.parse(JSON.stringify(source))
+          : [{ collectionName: "main", nodes: [] }];
+      if (newParts[0].nodes.some((n: ILinkNode) => n.id === partId)) return;
+      newParts[0].nodes.push({
         id: partId,
         title: relatedNodes[partId]?.title ?? "",
       });
-
-      const nodeRef = doc(collection(db, NODES), currentNodeId);
-      const linkRef = doc(collection(db, NODES), partId);
-      const linkData = relatedNodes[partId];
-
-      const previousIsPartOfValue = linkData?.properties?.["isPartOf"]
-        ? JSON.parse(JSON.stringify(linkData.properties["isPartOf"]))
-        : [{ collectionName: "main", nodes: [] }];
-
-      if (
-        linkData?.properties?.["isPartOf"] &&
-        Array.isArray(linkData.properties["isPartOf"]) &&
-        linkData.properties["isPartOf"][0]?.nodes
-      ) {
-        linkData.properties["isPartOf"][0].nodes.push({
-          id: currentNodeId,
-          title: nodeData.title ?? "",
-        });
-        await updateDoc(linkRef, {
-          "properties.isPartOf": linkData.properties["isPartOf"],
-        });
-      } else if (linkData) {
-        const newIsPartOf = [
-          {
-            collectionName: "main",
-            nodes: [{ id: currentNodeId, title: nodeData.title ?? "" }],
-          },
-        ];
-        await updateDoc(linkRef, {
-          "properties.isPartOf": newIsPartOf,
-        });
-      }
-
-      await updateDoc(nodeRef, {
-        "properties.parts": parts,
-      });
-
-      saveNewChangeLog(db, {
+      // Instant UI, then persist through the endpoint (handles isPartOf + log).
+      setCurrentVisibleNode((prev: any) =>
+        prev && prev.id === currentNodeId
+          ? { ...prev, properties: { ...prev.properties, parts: newParts } }
+          : prev,
+      );
+      await Post("/nodes/parts/update", {
         nodeId: currentNodeId,
-        modifiedBy: user?.uname || "",
-        modifiedProperty: property,
-        previousValue: previousPartsValue,
-        newValue: parts,
-        modifiedAt: new Date(),
-        changeType: "add element",
-        fullNode: currentVisibleNode,
+        parts: newParts,
         ...(appName ? { appName } : {}),
       });
-
-      saveNewChangeLog(db, {
-        nodeId: partId,
-        modifiedBy: user?.uname || "",
-        modifiedProperty: property,
-        previousValue: previousIsPartOfValue,
-        newValue: linkData?.properties?.["isPartOf"] || [],
-        modifiedAt: new Date(),
-        changeType: "add element",
-        fullNode: currentVisibleNode,
-        ...(appName ? { appName } : {}),
-      });
-
-      await updateInheritance({
-        nodeId: currentNodeId,
-        updatedProperties: ["parts"],
-        db,
-      });
-
-      if (onInstantTreeUpdate) {
-        onInstantTreeUpdate((tree) => [...tree]);
-      }
     } catch (error) {
       console.error(error);
     }
@@ -1043,136 +995,35 @@ const StructuredProperty = ({
 
         const sourceParts: ICollection[] | undefined =
           currentVisibleNode.properties?.parts;
-
-        if (
-          !sourceParts ||
-          !Array.isArray(sourceParts) ||
-          !sourceParts[0]?.nodes
-        ) {
-          return;
-        }
+        if (!Array.isArray(sourceParts) || !sourceParts[0]?.nodes) return;
 
         const updatedParts: ICollection[] = JSON.parse(
           JSON.stringify(sourceParts),
         );
-        const previousParts = JSON.parse(
-          JSON.stringify(currentVisibleNode.properties?.parts || []),
-        );
-
         const elementIdx = updatedParts[0].nodes.findIndex(
           (n: ILinkNode) => n.id === oldPartId,
         );
-        const existIdx = updatedParts[0].nodes.findIndex(
-          (n: ILinkNode) => n.id === newPartId,
-        );
-
         if (elementIdx === -1) return;
-        if (existIdx !== -1) return; // newPartId already in parts
+        if (updatedParts[0].nodes.some((n: ILinkNode) => n.id === newPartId)) {
+          return; // newPartId already in parts
+        }
 
-        // Replace .id and title at the same slot. preserves position and the slot's optional flag
+        // Replace id + title at the same slot (keeps position and optional flag).
         updatedParts[0].nodes[elementIdx].id = newPartId;
         updatedParts[0].nodes[elementIdx].title =
           relatedNodes[newPartId]?.title || "";
 
-        // Build isPartOf updates for old and new parts.
-        const nodeRef = doc(collection(db, NODES), currentVisibleNode.id);
-        const oldPartRef = doc(collection(db, NODES), oldPartId);
-        const newPartRef = doc(collection(db, NODES), newPartId);
-
-        let oldPartData: INode | null = relatedNodes[oldPartId] || null;
-        if (!oldPartData) oldPartData = await fetchNode(oldPartId);
-        let updatedOldIsPartOf: ICollection[] | null = null;
-        const oldIsPartOfRaw = oldPartData?.properties?.isPartOf;
-        if (Array.isArray(oldIsPartOfRaw)) {
-          updatedOldIsPartOf = JSON.parse(JSON.stringify(oldIsPartOfRaw));
-          for (const col of updatedOldIsPartOf!) {
-            col.nodes = col.nodes.filter(
-              (n: ILinkNode) => n.id !== currentVisibleNode.id,
-            );
-          }
-        }
-
-        let newPartData: INode | null = relatedNodes[newPartId] || null;
-        if (!newPartData) newPartData = await fetchNode(newPartId);
-        let updatedNewIsPartOf: ICollection[] | null = null;
-        const newIsPartOfRaw = newPartData?.properties?.isPartOf;
-        if (Array.isArray(newIsPartOfRaw)) {
-          updatedNewIsPartOf = JSON.parse(JSON.stringify(newIsPartOfRaw));
-          const alreadyHas = (updatedNewIsPartOf || []).some((col) =>
-            col.nodes.some((n: ILinkNode) => n.id === currentVisibleNode.id),
-          );
-          if (!alreadyHas) {
-            if (!updatedNewIsPartOf || updatedNewIsPartOf.length === 0) {
-              updatedNewIsPartOf = [{ collectionName: "main", nodes: [] }];
-            }
-            updatedNewIsPartOf[0].nodes.push({
-              id: currentVisibleNode.id,
-              title: currentVisibleNode.title ?? "",
-            });
-          }
-        } else if (newPartData) {
-          updatedNewIsPartOf = [
-            {
-              collectionName: "main",
-              nodes: [
-                {
-                  id: currentVisibleNode.id,
-                  title: currentVisibleNode.title ?? "",
-                },
-              ],
-            },
-          ];
-        }
-
-        // Write to db for current node first  then the two cross-node isPartOf writes in parallel.
-        const currentNodeUpdates: any = {
-          "properties.parts": updatedParts,
-        };
-        if (updatedInheritedPartsDetails) {
-          currentNodeUpdates.inheritedPartsDetails =
-            updatedInheritedPartsDetails;
-        }
-        await updateDoc(nodeRef, currentNodeUpdates);
-
-        const isPartOfWrites: Promise<any>[] = [];
-        if (updatedOldIsPartOf) {
-          isPartOfWrites.push(
-            updateDoc(oldPartRef, {
-              "properties.isPartOf": updatedOldIsPartOf,
-            }),
-          );
-        }
-        if (updatedNewIsPartOf) {
-          isPartOfWrites.push(
-            updateDoc(newPartRef, {
-              "properties.isPartOf": updatedNewIsPartOf,
-            }),
-          );
-        }
-        if (isPartOfWrites.length > 0) {
-          await Promise.all(isPartOfWrites);
-        }
-
-        await updateInheritance({
+        setCurrentVisibleNode((prev: any) =>
+          prev && prev.id === currentVisibleNode.id
+            ? { ...prev, properties: { ...prev.properties, parts: updatedParts } }
+            : prev,
+        );
+        await Post("/nodes/parts/update", {
           nodeId: currentVisibleNode.id,
-          updatedProperties: ["parts"],
-          db,
-        });
-
-        saveNewChangeLog(db, {
-          nodeId: currentVisibleNode.id,
-          modifiedBy: user.uname,
-          modifiedProperty: "parts",
-          previousValue: previousParts,
-          newValue: updatedParts,
-          modifiedAt: new Date(),
-          changeType: "modify elements",
-          changeDetails: {
-            action: "replace part",
-            oldPartId,
-            newPartId,
-          },
-          fullNode: currentVisibleNode,
+          parts: updatedParts,
+          ...(updatedInheritedPartsDetails
+            ? { inheritedPartsDetails: updatedInheritedPartsDetails }
+            : {}),
           ...(appName ? { appName } : {}),
         });
 
@@ -1183,10 +1034,6 @@ const StructuredProperty = ({
           newPartId,
           nodeId: currentVisibleNode.id,
         });
-
-        if (onInstantTreeUpdate) {
-          onInstantTreeUpdate((tree) => [...tree]);
-        }
       } catch (error: any) {
         console.error(error);
         recordLogs({

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -711,6 +711,47 @@ const StructuredProperty = ({
 
     return inheritedParts;
   };
+  // Single entry point for persisting the focused node's parts.
+  //  On failure it re-fetches and resets so the UI never keeps an unsaved change.
+  const saveParts = useCallback(
+    async (
+      newParts: ICollection[],
+      inheritedPartsDetails?: InheritedPartsDetail[] | null,
+    ) => {
+      const nodeId = currentVisibleNode?.id;
+      if (!nodeId) return;
+      setCurrentVisibleNode((prev: any) =>
+        prev && prev.id === nodeId
+          ? { ...prev, properties: { ...prev.properties, parts: newParts } }
+          : prev,
+      );
+      try {
+        await Post("/nodes/parts/update", {
+          nodeId,
+          parts: newParts,
+          ...(inheritedPartsDetails ? { inheritedPartsDetails } : {}),
+          ...(appName ? { appName } : {}),
+        });
+      } catch (error: any) {
+        const fresh = await fetchNode(nodeId);
+        setCurrentVisibleNode((prev: any) =>
+          prev?.id === nodeId && fresh ? fresh : prev,
+        );
+        const reason =
+          (typeof error === "string" ? error : error?.message) ||
+          "Please try again.";
+        setSnackbarMessage(`Failed to update parts: ${reason}`);
+      }
+    },
+    [
+      currentVisibleNode,
+      appName,
+      setCurrentVisibleNode,
+      fetchNode,
+      setSnackbarMessage,
+    ],
+  );
+
   const unlinkNodeRelation = async (
     currentNodeId: string,
     linkId: string,
@@ -728,16 +769,7 @@ const StructuredProperty = ({
         for (const c of newParts) {
           c.nodes = (c.nodes || []).filter((n: ILinkNode) => n.id !== linkId);
         }
-        setCurrentVisibleNode((prev: any) =>
-          prev && prev.id === currentNodeId
-            ? { ...prev, properties: { ...prev.properties, parts: newParts } }
-            : prev,
-        );
-        await Post("/nodes/parts/update", {
-          nodeId: currentNodeId,
-          parts: newParts,
-          ...(appName ? { appName } : {}),
-        });
+        await saveParts(newParts);
         return;
       }
       if (
@@ -963,17 +995,7 @@ const StructuredProperty = ({
         id: partId,
         title: relatedNodes[partId]?.title ?? "",
       });
-      // Instant UI, then persist through the endpoint (handles isPartOf + log).
-      setCurrentVisibleNode((prev: any) =>
-        prev && prev.id === currentNodeId
-          ? { ...prev, properties: { ...prev.properties, parts: newParts } }
-          : prev,
-      );
-      await Post("/nodes/parts/update", {
-        nodeId: currentNodeId,
-        parts: newParts,
-        ...(appName ? { appName } : {}),
-      });
+      await saveParts(newParts);
     } catch (error) {
       console.error(error);
     }
@@ -1013,19 +1035,7 @@ const StructuredProperty = ({
         updatedParts[0].nodes[elementIdx].title =
           relatedNodes[newPartId]?.title || "";
 
-        setCurrentVisibleNode((prev: any) =>
-          prev && prev.id === currentVisibleNode.id
-            ? { ...prev, properties: { ...prev.properties, parts: updatedParts } }
-            : prev,
-        );
-        await Post("/nodes/parts/update", {
-          nodeId: currentVisibleNode.id,
-          parts: updatedParts,
-          ...(updatedInheritedPartsDetails
-            ? { inheritedPartsDetails: updatedInheritedPartsDetails }
-            : {}),
-          ...(appName ? { appName } : {}),
-        });
+        await saveParts(updatedParts, updatedInheritedPartsDetails);
 
         recordLogs({
           action: "replace part",
@@ -1046,16 +1056,7 @@ const StructuredProperty = ({
         });
       }
     },
-    [
-      currentVisibleNode,
-      relatedNodes,
-      fetchNode,
-      db,
-      property,
-      user,
-      appName,
-      onInstantTreeUpdate,
-    ],
+    [currentVisibleNode, relatedNodes, property, user, saveParts],
   );
 
   if (
@@ -1467,6 +1468,7 @@ const StructuredProperty = ({
             addNodesToCache={addNodesToCache}
             linkNodeRelation={linkNodeRelation}
             unlinkNodeRelation={unlinkNodeRelation}
+            saveParts={saveParts}
             user={user}
             navigateToNode={navigateToNode}
             replaceWith={replaceWith}

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -53,6 +53,7 @@ import CollectionStructure from "./CollectionStructure";
 import PropertyContributors from "./PropertyContributors";
 import { NODES } from "@components/lib/firestoreClient/collections";
 import { Post } from "@components/lib/utils/Post";
+import { pendingWrites } from "@components/lib/utils/pendingWrites";
 import InheritedPartsLegend from "../Common/InheritedPartsLegend";
 import EditProperty from "../AddPropertyForm/EditProperty";
 import StructuredPropertySelector from "./StructuredPropertySelector";
@@ -711,8 +712,8 @@ const StructuredProperty = ({
 
     return inheritedParts;
   };
-  // Single entry point for persisting the focused node's parts.
-  //  On failure it re-fetches and resets so the UI never keeps an unsaved change.
+  // Single write point for the focused node's parts. 
+  // On failure it re-fetches so the UI never keeps an unsaved change.
   const saveParts = useCallback(
     async (
       newParts: ICollection[],
@@ -725,6 +726,7 @@ const StructuredProperty = ({
           ? { ...prev, properties: { ...prev.properties, parts: newParts } }
           : prev,
       );
+      pendingWrites.start(nodeId, "properties.parts");
       try {
         await Post("/nodes/parts/update", {
           nodeId,
@@ -741,6 +743,8 @@ const StructuredProperty = ({
           (typeof error === "string" ? error : error?.message) ||
           "Please try again.";
         setSnackbarMessage(`Failed to update parts: ${reason}`);
+      } finally {
+        pendingWrites.end(nodeId, "properties.parts");
       }
     },
     [
@@ -784,8 +788,7 @@ const StructuredProperty = ({
         if (nodeDoc.exists()) {
           const nodeData = nodeDoc.data() as any;
 
-          const inheritedRef =
-            property !== "parts" ? nodeData.inheritance?.[property]?.ref : null;
+          const inheritedRef = nodeData.inheritance?.[property]?.ref;
           if (inheritedRef) {
             let inheritedNode: INode | null =
               relatedNodes[inheritedRef] ?? null;
@@ -802,44 +805,12 @@ const StructuredProperty = ({
             JSON.stringify(nodeData.properties[property]),
           );
 
-          let removedFromInheritanceParts = false;
-
-          if (property === "parts") {
-            if (
-              linkIndex === -1 &&
-              Array.isArray(nodeData.properties?.[property]) &&
-              nodeData.properties[property][collectionIndex]?.nodes
-            ) {
-              linkIndex = nodeData.properties[property][
-                collectionIndex
-              ].nodes.findIndex((c: { id: string }) => c.id === linkId);
-            }
-            if (
-              nodeData.inheritanceParts &&
-              nodeData.inheritanceParts[linkId]
-            ) {
-              // Remove from inheritanceParts (broken inheritance scenario)
-              delete nodeData.inheritanceParts[linkId];
-              removedFromInheritanceParts = true;
-            } else if (
-              linkIndex !== -1 &&
-              Array.isArray(nodeData.properties[property]) &&
-              nodeData.propertyType[property] !== "string" &&
-              nodeData.propertyType[property] !== "string-array"
-            ) {
-              // Remove from direct parts (intact inheritance scenario)
-              nodeData.properties[property][collectionIndex].nodes.splice(
-                linkIndex,
-                1,
-              );
-            }
-          } else if (
+          if (
             linkIndex !== -1 &&
             Array.isArray(nodeData.properties[property]) &&
             nodeData.propertyType[property] !== "string" &&
             nodeData.propertyType[property] !== "string-array"
           ) {
-            // Remove from other properties (generalizations, specializations, etc.)
             nodeData.properties[property][collectionIndex].nodes.splice(
               linkIndex,
               1,
@@ -848,9 +819,7 @@ const StructuredProperty = ({
 
           let shouldBeRemovedFromParent = false;
 
-          if (property === "parts" && removedFromInheritanceParts) {
-            shouldBeRemovedFromParent = true;
-          } else if (Array.isArray(nodeData.properties[property])) {
+          if (Array.isArray(nodeData.properties[property])) {
             const stillExists = nodeData.properties[property].some(
               (col: any) =>
                 Array.isArray(col.nodes) &&
@@ -861,23 +830,13 @@ const StructuredProperty = ({
             shouldBeRemovedFromParent = true;
           }
 
-          // const childDoc = await getDoc(doc(collection(db, NODES), child.id));
-          // const childData = childDoc.data() as INode;
           if (shouldBeRemovedFromParent) {
             unlinkPropertyOf(db, property, currentVisibleNode?.id, linkId);
           }
 
-          let propertyUpdateObject: any = {};
-
-          // Update based on where the item was removed from
-          if (property === "parts" && removedFromInheritanceParts) {
-            // Update inheritanceParts for broken inheritance
-            propertyUpdateObject.inheritanceParts = nodeData.inheritanceParts;
-          } else {
-            // Update direct properties for intact inheritance or other properties
-            propertyUpdateObject[`properties.${property}`] =
-              nodeData.properties[property];
-          }
+          const propertyUpdateObject: any = {
+            [`properties.${property}`]: nodeData.properties[property],
+          };
 
           await updateDoc(nodeDoc.ref, propertyUpdateObject);
 

--- a/src/lib/hooks/useInheritedPartsDetails.ts
+++ b/src/lib/hooks/useInheritedPartsDetails.ts
@@ -120,8 +120,27 @@ export const useInheritedPartsDetails = (
       currentGenIds.length === cachedGenIds.length &&
       currentGenIds.every((id) => cachedGenIds.includes(id));
 
+    // If a current part has no annotation in the cached details, its row would
+    // stay stuck on the pending spinner, treat the cache as stale and recompute.
+    const currentPartIds: string[] =
+      currentVisibleNode.properties?.parts?.[0]?.nodes?.map(
+        (n: { id: string }) => n.id,
+      ) ?? [];
+    const annotatedToIds = new Set<string>();
+    if (Array.isArray(cachedData)) {
+      for (const calc of cachedData) {
+        for (const d of calc.details ?? []) {
+          if (d.to) annotatedToIds.add(d.to);
+        }
+      }
+    }
+    const cacheCoversAllParts = currentPartIds.every((id) =>
+      annotatedToIds.has(id),
+    );
+
     const isCacheFresh =
       generalizationsMatch &&
+      cacheCoversAllParts &&
       cachedData.every(
         (calc: any) =>
           calc.createdAt &&

--- a/src/lib/hooks/useInheritedPartsDetails.ts
+++ b/src/lib/hooks/useInheritedPartsDetails.ts
@@ -179,11 +179,17 @@ export const useInheritedPartsDetails = (
     };
   }, [currentVisibleNode?.id, currentVisibleNode?.generalizations?.length]);
 
-  // Detect parts changes on the current node (e.g, adding new part)
-  // and trigger a debounced refetch without wiping the current data
-  const partsSignature = currentVisibleNode?.properties?.parts?.[0]?.nodes
-    ?.map((n: any) => n.id)
-    .join(",") ?? "";
+  // Refetch only when the set of parts changes (add/remove/replace), not on
+  // reorder or optional toggles. Sorted so order changes don't count.
+  const partsSignature = [
+    ...new Set(
+      currentVisibleNode?.properties?.parts?.[0]?.nodes?.map(
+        (n: any) => n.id,
+      ) ?? [],
+    ),
+  ]
+    .sort()
+    .join(",");
   const prevPartsSignatureRef = useRef(partsSignature);
 
   useEffect(() => {

--- a/src/lib/utils/pendingWrites.ts
+++ b/src/lib/utils/pendingWrites.ts
@@ -1,0 +1,33 @@
+// Counts unsaved writes per node and field. Ontology checks this so a stale
+// snapshot can't overwrite a field that was just edited but isn't saved yet.
+// A count, not a flag, so two overlapping edits both finish before it clears.
+//
+// `field` is the path that changed, e.g. "properties.parts" or "specializations".
+const counts = new Map<string, number>();
+
+const keyOf = (nodeId: string, field: string) => `${nodeId}::${field}`;
+
+export const pendingWrites = {
+  start(nodeId: string, field: string) {
+    if (!nodeId || !field) return;
+    const k = keyOf(nodeId, field);
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  },
+  end(nodeId: string, field: string) {
+    if (!nodeId || !field) return;
+    const k = keyOf(nodeId, field);
+    const next = (counts.get(k) ?? 0) - 1;
+    if (next <= 0) counts.delete(k);
+    else counts.set(k, next);
+  },
+  // Fields with a write still in flight for this node.
+  fields(nodeId: string): string[] {
+    if (!nodeId) return [];
+    const prefix = `${nodeId}::`;
+    const result: string[] = [];
+    for (const k of counts.keys()) {
+      if (k.startsWith(prefix)) result.push(k.slice(prefix.length));
+    }
+    return result;
+  },
+};

--- a/src/pages/Ontology.tsx
+++ b/src/pages/Ontology.tsx
@@ -131,6 +131,7 @@ import {
 import { getDatabase, onValue, ref } from "firebase/database";
 
 import { recordLogs } from "@components/lib/utils/helpers";
+import { pendingWrites } from "@components/lib/utils/pendingWrites";
 import { useHover } from "@components/lib/hooks/useHover";
 import { useInheritedPartsDetails } from "@components/lib/hooks/useInheritedPartsDetails";
 import { MemoizedToolbarSidebar } from "@components/components/Sidebar/ToolbarSidebar";
@@ -1198,10 +1199,25 @@ const Ontology = ({
   useEffect(() => {
     if (currentVisibleNode?.id) {
       setCurrentVisibleNode((prev) => {
-        if (relatedNodes[currentVisibleNode?.id]) {
-          return relatedNodes[currentVisibleNode?.id];
+        const snap = relatedNodes[currentVisibleNode?.id];
+        if (!snap) return prev;
+        if (prev?.id !== snap.id) return snap;
+        // While a write is pending, a stale snapshot can arrive.
+        // Keep the fields being written so the newly added nodes doesn't flicker out.
+        const pending = pendingWrites.fields(snap.id);
+        if (pending.length === 0) return snap;
+        const prevAny = prev as any;
+        const snapAny = snap as any;
+        const merged: any = { ...snap, properties: { ...snap.properties } };
+        for (const field of pending) {
+          if (field.startsWith("properties.")) {
+            const p = field.slice("properties.".length);
+            merged.properties[p] = prevAny.properties?.[p] ?? snapAny.properties?.[p];
+          } else {
+            merged[field] = prevAny[field] ?? snapAny[field];
+          }
         }
-        return prev;
+        return merged;
       });
     }
   }, [relatedNodes, appName]);

--- a/src/pages/api/generate-inheritance-part-details.ts
+++ b/src/pages/api/generate-inheritance-part-details.ts
@@ -645,26 +645,66 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           (d: any) => d.userOverride,
         );
         for (const override of overriddenEntries) {
-          // Check that both from and to still exist in the current parts/generalization parts
+          // Both endpoints of the override must still exist on the node.
           const fromStillExists = generalizationParts.includes(override.from);
           const toStillExists = currentParts.includes(override.to);
+          if (!fromStillExists || !toStillExists) continue;
 
-          if (fromStillExists && toStillExists) {
-            // Find the computed entry for the same "from" and replace it
-            const computedIdx = detailsWithTitles.findIndex(
-              (d: any) => d.from === override.from,
-            );
-            if (computedIdx !== -1) {
-              const computedTo = detailsWithTitles[computedIdx].to;
-              // Replace with user's override
-              detailsWithTitles[computedIdx] = {
-                ...detailsWithTitles[computedIdx],
-                to: override.to,
-                toTitle: relatedNodes[override.to]?.title || override.toTitle || "",
-                userOverride: true,
-              };
+          // Point the generalization-part's row at the user's pick.
+          const computedIdx = detailsWithTitles.findIndex(
+            (d: any) => d.from === override.from,
+          );
+          if (computedIdx === -1) continue;
+
+          const displacedTo = detailsWithTitles[computedIdx].to;
+          detailsWithTitles[computedIdx] = {
+            ...detailsWithTitles[computedIdx],
+            to: override.to,
+            toTitle: relatedNodes[override.to]?.title || override.toTitle || "",
+            userOverride: true,
+            symbol: override.from === override.to ? "=" : ">",
+          };
+
+          // Drop the row the picked part already had, so it isn't listed twice.
+          for (let i = detailsWithTitles.length - 1; i >= 0; i--) {
+            if (i !== computedIdx && detailsWithTitles[i].to === override.to) {
+              detailsWithTitles.splice(i, 1);
             }
           }
+
+          // Give the displaced part a "+" row so it doesn't lose its row.
+          if (
+            displacedTo &&
+            displacedTo !== override.to &&
+            !detailsWithTitles.some((d: any) => d.to === displacedTo)
+          ) {
+            detailsWithTitles.push({
+              from: "",
+              to: displacedTo,
+              symbol: "+",
+              fromTitle: "",
+              toTitle: relatedNodes[displacedTo]?.title || "",
+              fromOptional: false,
+              toOptional: getCurrentPartOptionalStatus(
+                displacedTo,
+                currentNode,
+                relatedNodes,
+              ),
+              optionalChange: "none",
+              hops: 0,
+            });
+          }
+        }
+
+        // Re-sort into parts order after the override reshuffle.
+        if (overriddenEntries.length > 0) {
+          detailsWithTitles.sort((a: any, b: any) => {
+            const ia = currentParts.indexOf(a.to);
+            const ib = currentParts.indexOf(b.to);
+            return (
+              (ia === -1 ? Infinity : ia) - (ib === -1 ? Infinity : ib)
+            );
+          });
         }
       }
 

--- a/src/pages/api/nodes/parts/update.ts
+++ b/src/pages/api/nodes/parts/update.ts
@@ -1,0 +1,282 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import fbAuth from "@components/middlewares/fbAuth";
+import { db } from "@components/lib/firestoreServer/admin";
+import {
+  LOGS,
+  NODES,
+  NODES_LOGS,
+  USERS,
+} from "@components/lib/firestoreClient/collections";
+import { getDoerCreate } from "@components/lib/utils/helpers";
+import { computeDiffValue } from "@components/lib/utils/diffValue";
+import { FieldValue } from "firebase-admin/firestore";
+import { ICollection, INode, NodeChange } from "@components/types/INode";
+
+/**
+ * Saves a node's `parts`. The client sends the full new value; the server
+ * stores it, mirrors each change onto the linked nodes' `isPartOf`, and logs it.
+ */
+
+/** Validates the incoming collections; returns null if malformed. */
+function sanitizeCollections(value: any, selfId: string): ICollection[] | null {
+  if (!Array.isArray(value)) return null;
+  const seen = new Set<string>();
+  const out: ICollection[] = [];
+  for (const c of value) {
+    if (!c || typeof c.collectionName !== "string" || !Array.isArray(c.nodes)) {
+      return null;
+    }
+    const nodes = [];
+    for (const n of c.nodes) {
+      if (!n || typeof n.id !== "string") return null;
+      if (n.id === selfId || seen.has(n.id)) continue; // no self-link, no dupes
+      seen.add(n.id);
+      const node: any = {
+        id: n.id,
+        title: typeof n.title === "string" ? n.title : "",
+      };
+      if (n.optional === true) node.optional = true;
+      nodes.push(node);
+    }
+    out.push({ collectionName: c.collectionName, nodes });
+  }
+  return out;
+}
+
+/** Reads a stored value as collections, defaulting to an empty `main`. */
+function asCollections(value: any): ICollection[] {
+  if (Array.isArray(value) && value.length > 0) {
+    return JSON.parse(JSON.stringify(value));
+  }
+  return [{ collectionName: "main", nodes: [] }];
+}
+
+/** Every node id in a collections value. */
+function idsOf(collections: ICollection[]): Set<string> {
+  return new Set(collections.flatMap((c) => c.nodes.map((n) => n.id)));
+}
+
+/** Adds a node to the `main` collection; returns false if already there. */
+function addToMain(
+  collections: ICollection[],
+  linkNode: { id: string; title?: string },
+): boolean {
+  let main = collections.find((c) => c.collectionName === "main");
+  if (!main) {
+    main = { collectionName: "main", nodes: [] };
+    collections.unshift(main);
+  }
+  if (main.nodes.some((n) => n.id === linkNode.id)) return false;
+  main.nodes.push(linkNode);
+  return true;
+}
+
+/** Writes a log to LOGS under `uname`. */
+const recordLogs = async (logs: { [key: string]: any }, uname: string) => {
+  try {
+    if (uname === "ouhrac") return;
+    const logRef = db.collection(LOGS).doc();
+    const doerCreate = getDoerCreate(uname || "");
+    await logRef.set({
+      type: "info",
+      ...logs,
+      createdAt: new Date(),
+      doer: uname,
+      doerCreate,
+    });
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+/** Logs a NodeChange and updates the user's last-activity time. */
+async function writeChangeLog(change: NodeChange): Promise<void> {
+  if (!change.modifiedBy) return;
+  const diffValue = computeDiffValue(change);
+  if (diffValue) change.diffValue = diffValue;
+  await db
+    .collection(NODES_LOGS)
+    .doc()
+    .set(change as any);
+  if (change.modifiedBy !== "ouhrac") {
+    await db.collection(USERS).doc(change.modifiedBy).update({
+      lasChangeMadeAt: new Date(),
+    });
+  }
+}
+
+/**
+ * Stores the new `parts` and updates each linked node's `isPartOf`: added
+ * parts gain this node, removed parts lose it. Parts are a plain own value;
+ * inheritance is computed through another endpoint: `generate-inheritance-part-details`.
+ */
+async function changeParts(ctx: {
+  nodeId: string;
+  nodeData: INode;
+  parts: ICollection[];
+  inheritedPartsDetails?: any[];
+  uname?: string;
+  appName?: string;
+}): Promise<{ ok: true }> {
+  const { nodeId, nodeData, parts, inheritedPartsDetails, uname, appName } =
+    ctx;
+
+  const previousValue = asCollections(nodeData.properties?.parts);
+  const newValue = parts;
+
+  const prevIds = idsOf(previousValue);
+  const newIds = idsOf(newValue);
+  const added = [...newIds].filter((id) => !prevIds.has(id));
+  const removed = [...prevIds].filter((id) => !newIds.has(id));
+
+  const nodeUpdates: Record<string, any> = {
+    [`properties.parts`]: newValue,
+  };
+  // Reorder/optional edits don't change inheritance, so the client sends the
+  // already-patched details to store as-is. Update createdAt.
+  if (Array.isArray(inheritedPartsDetails)) {
+    nodeUpdates.inheritedPartsDetails = inheritedPartsDetails.map((g) => ({
+      ...g,
+      createdAt: new Date(),
+    }));
+  }
+  if (uname && uname !== "ouhrac") {
+    nodeUpdates.contributors = FieldValue.arrayUnion(uname);
+  }
+  await db.collection(NODES).doc(nodeId).update(nodeUpdates);
+
+  // Mirror onto each linked part's `isPartOf` (add this node, or drop it) and
+  // give each one its own log so the change shows in its activity feed.
+  const batch = db.batch();
+  const partLogs: NodeChange[] = [];
+  for (const id of added) {
+    const snap = await db.collection(NODES).doc(id).get();
+    const d = snap.data() as INode | undefined;
+    if (!d || d.deleted) continue;
+    const before = asCollections(d.properties?.isPartOf);
+    const after: ICollection[] = JSON.parse(JSON.stringify(before));
+    if (!addToMain(after, { id: nodeId, title: nodeData.title ?? "" })) continue;
+    batch.update(snap.ref, { [`properties.isPartOf`]: after });
+    if (uname) {
+      partLogs.push({
+        nodeId: id,
+        modifiedBy: uname,
+        modifiedProperty: "isPartOf",
+        previousValue: before,
+        newValue: after,
+        modifiedAt: new Date(),
+        changeType: "add element",
+        fullNode: d,
+        ...(appName ? { appName } : {}),
+      } as NodeChange);
+    }
+  }
+  for (const id of removed) {
+    const snap = await db.collection(NODES).doc(id).get();
+    const d = snap.data() as INode | undefined;
+    const raw = d?.properties?.isPartOf;
+    if (!Array.isArray(raw)) continue;
+    const before: ICollection[] = JSON.parse(JSON.stringify(raw));
+    const after: ICollection[] = JSON.parse(JSON.stringify(raw));
+    for (const c of after) {
+      c.nodes = (c.nodes || []).filter((n) => n.id !== nodeId);
+    }
+    batch.update(snap.ref, { [`properties.isPartOf`]: after });
+    if (uname && d) {
+      partLogs.push({
+        nodeId: id,
+        modifiedBy: uname,
+        modifiedProperty: "isPartOf",
+        previousValue: before,
+        newValue: after,
+        modifiedAt: new Date(),
+        changeType: "remove element",
+        fullNode: d,
+        ...(appName ? { appName } : {}),
+      } as NodeChange);
+    }
+  }
+  // Pure reorder/optional changes touch no other node, so the batch is empty.
+  if (added.length || removed.length) await batch.commit();
+
+  if (uname) {
+    await writeChangeLog({
+      nodeId,
+      modifiedBy: uname,
+      modifiedProperty: "parts",
+      previousValue,
+      newValue,
+      modifiedAt: new Date(),
+      changeType: "modify elements",
+      fullNode: nodeData,
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+  for (const log of partLogs) await writeChangeLog(log);
+
+  return { ok: true };
+}
+
+function fail(res: NextApiResponse, status: number, msg: string) {
+  return res.status(status).json({ error: msg, message: msg });
+}
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return fail(res, 405, "Method not allowed");
+  const data = req.body.data;
+  const { nodeId, appName, user } = data as {
+    nodeId?: string;
+    appName?: string;
+    user?: any;
+  };
+  const { uname } = user?.userData || {};
+
+  if (!nodeId || typeof nodeId !== "string") {
+    return fail(res, 400, "nodeId is required");
+  }
+
+  const parts = sanitizeCollections(data.parts, nodeId);
+  if (!parts) {
+    return fail(res, 400, "parts must be an array of collections");
+  }
+
+  try {
+    const nodeData = (await db.collection(NODES).doc(nodeId).get()).data() as
+      | INode
+      | undefined;
+    if (!nodeData || nodeData.deleted) return fail(res, 404, "Node not found");
+    if (appName && nodeData.appName && nodeData.appName !== appName) {
+      return fail(res, 403, "Node does not belong to this app");
+    }
+
+    const result = await changeParts({
+      nodeId,
+      nodeData,
+      parts,
+      inheritedPartsDetails: Array.isArray(data.inheritedPartsDetails)
+        ? data.inheritedPartsDetails
+        : undefined,
+      uname,
+      appName,
+    });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    console.error("nodes/parts/update error", error);
+    recordLogs(
+      {
+        type: "error",
+        error: JSON.stringify({
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        }),
+        at: "nodes/parts/update",
+      },
+      uname,
+    );
+    const message = error?.message || "Internal error";
+    return res.status(500).json({ error: message, message });
+  }
+}
+
+export default fbAuth(handler);


### PR DESCRIPTION
Hi @samadouhra

This PR moves parts editing from the client to a backend endpoint, similar to the generic property migration.

Changes

* Added a new /nodes/parts/update endpoint to handle all parts updates and keep isPartOf relationships in sync.
* Added a single saveParts function on the client that all parts edits go through.
* Moved all parts operations (add, remove, reorder, replace, optional toggle, and switch-to) to use the new endpoint instead of direct Firestore writes.
* Prevented incoming snapshots from overwriting in-flight edits.
* Made the editor use properties.parts as the source of truth so updates appear immediately.
* Only recompute inheritance details when parts are added, removed, or replaced.
* Fixed issues with “switch to” causing parts to get stuck in a loading state.
* Added a “Generating inheritance…” indicator while inheritance details are being recalculated.
* Improved the pending “Add Specialization” row behavior for consistency.

Notes

* Specializations, generalizations editing and cloning flows are unchanged.