### PR TITLE
Move specializations & generalizations editing to backend endpoints

### DIFF
--- a/src/components/LinkNode/LinkNode.tsx
+++ b/src/components/LinkNode/LinkNode.tsx
@@ -159,7 +159,7 @@ type ILinkNodeProps = {
   navigateToNode: (nodeID: string) => void;
   title: string;
   relatedNodes: { [nodeId: string]: INode };
-  fetchNode: (nodeId: string) => Promise<INode | null>;
+  fetchNode: (nodeId: string, force?: boolean) => Promise<INode | null>;
   linkLocked: any;
   locked: boolean;
   user: any;
@@ -447,6 +447,8 @@ const LinkNode = ({
             c.nodes = c.nodes.filter((n: { id: string }) => n.id !== linkId);
           }
         }
+        
+        onInstantTreeUpdate?.((tree) => tree);
 
         setCurrentVisibleNode((prev: any) =>
           prev && prev.id === nodeId ? { ...prev, [property]: value } : prev,
@@ -479,7 +481,7 @@ const LinkNode = ({
             property === "generalizations" &&
             value.flatMap((c) => c.nodes).length === 0;
           if (becameOrphan) {
-            const fresh = await fetchNode(nodeId);
+            const fresh = await fetchNode(nodeId, true);
             setCurrentVisibleNode((prev: any) =>
               prev?.id === nodeId && fresh ? fresh : prev,
             );
@@ -511,7 +513,7 @@ const LinkNode = ({
               .flatMap((c) => c.nodes)
               .filter((g) => g.id !== nodeId).length === 0;
           if (childOrphaned) {
-            const freshChild = await fetchNode(linkId);
+            const freshChild = await fetchNode(linkId, true);
             const childRootId = freshChild?.generalizations?.flatMap(
               (c) => c.nodes,
             )[0]?.id;

--- a/src/components/LinkNode/LinkNode.tsx
+++ b/src/components/LinkNode/LinkNode.tsx
@@ -89,7 +89,6 @@ import {
 import {
   Box,
   Button,
-  CircularProgress,
   IconButton,
   keyframes,
   Link,
@@ -130,6 +129,7 @@ import {
   removeLinkFromNode,
 } from "@components/lib/utils/instantTreeUpdate";
 import { pendingWrites } from "@components/lib/utils/pendingWrites";
+import SyncedSpinner from "@components/components/SyncedSpinner";
 
 const isInUnclassified = (rootNode: INode | undefined, childId: string) =>
   !!rootNode?.specializations?.some(
@@ -678,7 +678,7 @@ const LinkNode = ({
             (loadingIds.has(link.id) ? (
               <LoadingButton
                 loading
-                loadingIndicator={<CircularProgress size={20} />}
+                loadingIndicator={<SyncedSpinner size={20} />}
                 sx={{ borderRadius: "16px", p: "3px", minWidth: "40px" }}
                 disabled
               />
@@ -735,7 +735,7 @@ const LinkNode = ({
                 {loadingIds.has(link.id) ? (
                   <LoadingButton
                     loading
-                    loadingIndicator={<CircularProgress size={20} />}
+                    loadingIndicator={<SyncedSpinner size={20} />}
                     sx={{
                       borderRadius: "16px",
                       padding: "3px",

--- a/src/components/LinkNode/LinkNode.tsx
+++ b/src/components/LinkNode/LinkNode.tsx
@@ -77,8 +77,6 @@ import {
   updatePartsAndPartsOf,
   updatePropertyOf,
   updateInheritanceWhenUnlinkAGeneralization,
-  updateLinksForInheritance,
-  updateLinksForInheritanceSpecializations,
 } from "@components/lib/utils/helpers";
 import { breakInheritanceAndCopyParts } from "@components/lib/utils/partsHelper";
 import {
@@ -119,13 +117,26 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { getTitleDeleted } from "@components/lib/utils/string.utils";
 import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
 import LinkOffIcon from "@mui/icons-material/LinkOff";
-import { UNCLASSIFIED } from "@components/lib/CONSTANTS";
+import {
+  UNCLASSIFIED,
+  UNCLASSIFIED_COLLECTION,
+} from "@components/lib/CONSTANTS";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import LinkNodeTitle from "./LinkNodeTitle";
 import { Post } from "@components/lib/utils/Post";
 import { LoadingButton } from "@mui/lab";
-import { removeLinkFromNode } from "@components/lib/utils/instantTreeUpdate";
-import { triggerUpdateDerivedPaths } from "@components/lib/utils/triggerUpdateDerivedPaths";
+import {
+  addLinkToNode,
+  removeLinkFromNode,
+} from "@components/lib/utils/instantTreeUpdate";
+import { pendingWrites } from "@components/lib/utils/pendingWrites";
+
+const isInUnclassified = (rootNode: INode | undefined, childId: string) =>
+  !!rootNode?.specializations?.some(
+    (c) =>
+      c.collectionName === UNCLASSIFIED_COLLECTION &&
+      c.nodes.some((n) => n.id === childId),
+  );
 
 const glowGreen = keyframes`
   0% {
@@ -180,6 +191,7 @@ const LinkNode = ({
   property,
   currentVisibleNode,
   setCurrentVisibleNode,
+  setSnackbarMessage,
   navigateToNode,
   title,
   relatedNodes,
@@ -342,18 +354,22 @@ const LinkNode = ({
         }
       }
 
+      // The node this unlink will orphan.
+      // Read live state so secondary unlink action have updated generalization count.
       const nodeD =
-        property === "generalizations" ? relatedNodes[currentNodeId] : linkNode;
+        property === "generalizations" ? currentVisibleNode : linkNode;
       const linksLength = nodeD.generalizations.flatMap((c) => c.nodes).length;
       const firstGen = nodeD.generalizations[0]?.nodes[0]?.id || "";
-      if (
-        linksLength <= 1 &&
-        ((property === "specializations" &&
-          relatedNodes[currentNodeId]?.title.trim().toLowerCase() ===
-            "unclassified") ||
-          (property === "generalizations" &&
-            relatedNodes[firstGen]?.title === "unclassified"))
-      ) {
+
+      // Block the already unclassified node
+      const alreadyUnclassified =
+        property === "generalizations"
+          ? !!relatedNodes[firstGen]?.root &&
+            isInUnclassified(relatedNodes[firstGen], currentNodeId)
+          : !!relatedNodes[currentNodeId]?.root &&
+            collectionName === UNCLASSIFIED_COLLECTION;
+
+      if (linksLength <= 1 && alreadyUnclassified) {
         await confirmIt(
           <Box>
             <Box
@@ -416,208 +432,124 @@ const LinkNode = ({
           "Keep",
         ))
       ) {
-        const nodeDoc = await getDoc(
-          doc(collection(db, NODES), currentVisibleNode?.id),
-        );
-        if (nodeDoc.exists()) {
-          const nodeData = nodeDoc.data() as INode;
-          const parentLogId = doc(collection(db, NODES_LOGS)).id;
-          const parentLog = {
-            logId: parentLogId,
-            nodeId: currentVisibleNode?.id,
-            nodeTitle: nodeData.title ?? "",
-            changeType: "remove element" as const,
-          };
-          const previousValue = JSON.parse(
-            JSON.stringify(
-              nodeData[property as "specializations" | "generalizations"],
-            ),
-          );
-          if (linkIndex !== -1) {
-            nodeData[property as "specializations" | "generalizations"][
-              collectionIndex
-            ].nodes.splice(linkIndex, 1);
-          }
-          //check if this link is includes in other collections of the node or not
-          //to be able to remove it
-          const shouldBeRemovedFromParent = !nodeData[
+        const nodeId = currentVisibleNode?.id;
+        // Build this side without the unlinked chip for the instant UI. The
+        // server gets only `removeIds` and handles the rest..
+        const source =
+          currentVisibleNode?.[
             property as "specializations" | "generalizations"
-          ].some((c: { nodes: ILinkNode[] }) => {
-            const cIndex = c.nodes.findIndex((p) => p.id === linkId);
-            return cIndex !== -1;
+          ] || [];
+        const value: ICollection[] = JSON.parse(JSON.stringify(source));
+        if (linkIndex !== -1 && value[collectionIndex]) {
+          value[collectionIndex].nodes.splice(linkIndex, 1);
+        } else {
+          for (const c of value) {
+            c.nodes = c.nodes.filter((n: { id: string }) => n.id !== linkId);
+          }
+        }
+
+        setCurrentVisibleNode((prev: any) =>
+          prev && prev.id === nodeId ? { ...prev, [property]: value } : prev,
+        );
+
+        pendingWrites.start(nodeId, property);
+        try {
+          await Post("/nodes/hierarchy/unlink", {
+            nodeId,
+            side: property,
+            removeIds: [linkId],
+            ...(appName ? { appName } : {}),
           });
-          await updateDoc(nodeDoc.ref, nodeData);
-          if (shouldBeRemovedFromParent) {
-            await removeNodeLink(
-              property as "specializations" | "generalizations",
-              currentVisibleNode?.id,
-              linkId,
-              parentLog,
-              user?.uname,
-              appName,
-            );
-          }
-          if (shouldBeRemovedFromParent && linkNode && !linkNode.nodeType) {
-            const nodeType = linkNode.nodeType;
-            const unclassifiedNodeDocs = await getDocs(
-              query(
-                collection(db, NODES),
-                where("unclassified", "==", true),
-                where("nodeType", "==", nodeType),
-              ),
-            );
 
-            if (unclassifiedNodeDocs.docs.length > 0 && previousValue) {
-              const unclassifiedNodeDoc = unclassifiedNodeDocs.docs[0];
-              let unclassifiedNode: INode | null =
-                relatedNodes[unclassifiedNodeDoc.id] || null;
-              if (!unclassifiedNode) {
-                const fetchedNode = await fetchNode(unclassifiedNodeDoc.id);
-                if (!fetchedNode) {
-                  return;
-                }
-                unclassifiedNode = fetchedNode;
-              }
-
-              if (property === "specializations") {
-                const nodeRef = doc(collection(db, NODES), linkId);
-                const generalizations = linkNode.generalizations;
-                const generalizationsLength = generalizations.flatMap(
-                  (c) => c.nodes,
-                ).length;
-
-                let mCollectionIdx = generalizations.findIndex(
-                  (c) => c.collectionName === "main",
-                );
-                if (mCollectionIdx === -1) {
-                  generalizations.unshift({
-                    collectionName: "main",
-                    nodes: [],
-                  });
-                  mCollectionIdx = 0;
-                }
-                if (mCollectionIdx !== -1) {
-                  generalizations[mCollectionIdx].nodes = generalizations[
-                    mCollectionIdx
-                  ].nodes.filter((g) => g.id !== nodeDoc.id);
-                  if (generalizationsLength === 1) {
-                    generalizations[0].nodes.push({
-                      id: unclassifiedNodeDoc.id,
-                      title: unclassifiedNode?.title ?? "",
-                    });
-                  }
-
-                  updateDoc(nodeRef, {
-                    generalizations,
-                  });
-                }
-                if (generalizationsLength === 1) {
-                  const specializations = unclassifiedNode.specializations;
-
-                  const mainCollectionIdx = specializations.findIndex(
-                    (c) => c.collectionName === "main",
-                  );
-                  if (mainCollectionIdx !== -1) {
-                    specializations[mainCollectionIdx].nodes.push({
-                      id: linkId,
-                      title:
-                        relatedNodes[linkId]?.title ?? linkNode?.title ?? "",
-                    });
-                    updateDoc(unclassifiedNodeDoc.ref, {
-                      specializations,
-                    });
-                  }
-                }
-              }
-
-              if (property === "generalizations") {
-                const nodesLength = previousValue.flatMap(
-                  (c: ICollection) => c.nodes,
-                ).length;
-
-                const generalizations = nodeData.generalizations;
-                if (nodesLength === 1) {
-                  generalizations[0].nodes.push({
-                    id: unclassifiedNodeDoc.id,
-                    title: unclassifiedNode?.title ?? "",
-                  });
-
-                  const specializations = unclassifiedNode.specializations;
-
-                  const mainCollectionIdx = specializations.findIndex(
-                    (c) => c.collectionName === "main",
-                  );
-
-                  specializations[mainCollectionIdx].nodes.push({
-                    id: nodeDoc.id,
-                    title: nodeData.title ?? "",
-                  });
-
-                  updateDoc(unclassifiedNodeDoc.ref, {
-                    specializations,
-                  });
-                }
-              }
-            }
-          }
-
-          saveNewChangeLog(
-            db,
-            {
-              nodeId: currentVisibleNode?.id,
-              modifiedBy: user?.uname,
-              modifiedProperty: property,
-              previousValue,
-              newValue:
-                nodeData[property as "specializations" | "generalizations"],
-              modifiedAt: new Date(),
-              changeType: "remove element",
-              fullNode: currentVisibleNode,
-              ...(appName ? { appName } : {}),
-            },
-            parentLogId,
-          );
-
-          // Instant tree update for local user
           if (onInstantTreeUpdate) {
-            onInstantTreeUpdate((tree) => {
-              return removeLinkFromNode(
+            onInstantTreeUpdate((tree) =>
+              removeLinkFromNode(
                 tree,
-                currentVisibleNode?.id,
+                nodeId,
                 linkId,
                 property,
                 collectionIndex,
-              );
-            });
+              ),
+            );
           }
 
-          if (property === "generalizations") {
-            const currentNewLinks = nodeData["generalizations"][0].nodes;
-            updateLinksForInheritance(
-              db,
-              currentNodeId,
-              [],
-              currentNewLinks,
-              nodeData,
-              relatedNodes,
+          // Unclassified: the server moved this node under its root. Its local
+          // generalizations are now empty, so re-fetch to show the new root
+          const becameOrphan =
+            property === "generalizations" &&
+            value.flatMap((c) => c.nodes).length === 0;
+          if (becameOrphan) {
+            const fresh = await fetchNode(nodeId);
+            setCurrentVisibleNode((prev: any) =>
+              prev?.id === nodeId && fresh ? fresh : prev,
             );
+            // The server put this node under its root; show it there in the tree
+            const newRootId = fresh?.generalizations?.flatMap((c) => c.nodes)[0]
+              ?.id;
+            if (newRootId && onInstantTreeUpdate) {
+              onInstantTreeUpdate((tree) =>
+                addLinkToNode(
+                  tree,
+                  newRootId,
+                  nodeId,
+                  "specializations",
+                  UNCLASSIFIED_COLLECTION,
+                  relatedNodes,
+                  fresh?.title,
+                  fresh?.nodeType,
+                ),
+              );
+            }
           }
-          if (property === "specializations") {
-            updateLinksForInheritanceSpecializations(
-              db,
-              nodeDoc.id,
-              [],
-              [{ id: linkId }],
-              nodeData,
-              relatedNodes,
-            );
+
+          // If the unlinked child lost its last generalization, the server moved
+          // it under its root. Show it there so it doesn't vanish until the
+          // snapshot lands (the generalizations case above, but for the child).
+          const childOrphaned =
+            property === "specializations" &&
+            (relatedNodes[linkId]?.generalizations || [])
+              .flatMap((c) => c.nodes)
+              .filter((g) => g.id !== nodeId).length === 0;
+          if (childOrphaned) {
+            const freshChild = await fetchNode(linkId);
+            const childRootId = freshChild?.generalizations?.flatMap(
+              (c) => c.nodes,
+            )[0]?.id;
+            if (childRootId && onInstantTreeUpdate) {
+              onInstantTreeUpdate((tree) =>
+                addLinkToNode(
+                  tree,
+                  childRootId,
+                  linkId,
+                  "specializations",
+                  UNCLASSIFIED_COLLECTION,
+                  relatedNodes,
+                  freshChild?.title,
+                  freshChild?.nodeType,
+                ),
+              );
+            }
           }
-          if (
-            property === "specializations" ||
-            property === "generalizations"
-          ) {
-            await triggerUpdateDerivedPaths([currentVisibleNode.id, linkId]);
-          }
+        } catch (error: any) {
+          const fresh = await fetchNode(nodeId);
+          setCurrentVisibleNode((prev: any) =>
+            prev?.id === nodeId && fresh ? fresh : prev,
+          );
+          const reason =
+            (typeof error === "string" ? error : error?.message) ||
+            "Please try again.";
+          setSnackbarMessage(`Failed to unlink "${property}": ${reason}`);
+          recordLogs({
+            type: "error",
+            error: JSON.stringify({
+              name: error?.name,
+              message: typeof error === "string" ? error : error?.message,
+              stack: error?.stack,
+            }),
+            at: "unlinkSpecializationOrGeneralization",
+          });
+        } finally {
+          pendingWrites.end(nodeId, property);
         }
       }
     } catch (error: any) {
@@ -629,7 +561,7 @@ const LinkNode = ({
           message: error.message,
           stack: error.stack,
         }),
-        at: "updateInheritance",
+        at: "unlinkSpecializationOrGeneralization",
       });
     }
   };

--- a/src/components/LinkNode/LinkNode.tsx
+++ b/src/components/LinkNode/LinkNode.tsx
@@ -611,6 +611,20 @@ const LinkNode = ({
   const queueEntry = clonedNodesQueue[link.id];
   const isQueuedClone = queueEntry?.property === property;
   const queuedTitle = queueEntry?.title;
+  // Editable title for a pending clone
+  const updateQueuedTitle = (value: string) => {
+    setClonedNodesQueue((prev: any) => ({
+      ...prev,
+      [link.id]: { ...prev[link.id], title: value },
+    }));
+  };
+  const isEditableClone =
+    isQueuedClone &&
+    property !== "parts" &&
+    enableEdit &&
+    !selectedDiffNode &&
+    !currentImprovement &&
+    !loadingIds.has(link.id);
   return (
     <Box
       id={`${link.id}-${property}`}
@@ -654,15 +668,34 @@ const LinkNode = ({
             }}
           />
         </ListItemIcon>
-        <LinkNodeTitle
-          title={isQueuedClone ? queuedTitle : title}
-          link={link}
-          relatedNodes={relatedNodes}
-          property={property}
-          selectedProperty={selectedProperty}
-          onNavigate={handleNavigateToNode}
-          linkColor={getLinkColor(link.change)}
-        />
+        {isEditableClone ? (
+          <TextField
+            size="small"
+            autoFocus
+            value={queuedTitle ?? ""}
+            onChange={(e) => updateQueuedTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (queuedTitle ?? "").trim()) {
+                saveNewSpecialization(link.id, collectionName);
+              }
+            }}
+            placeholder="New node title"
+            sx={{
+              flex: 1,
+              "& .MuiInputBase-root": { borderRadius: "12px" },
+            }}
+          />
+        ) : (
+          <LinkNodeTitle
+            title={isQueuedClone ? queuedTitle : title}
+            link={link}
+            relatedNodes={relatedNodes}
+            property={property}
+            selectedProperty={selectedProperty}
+            onNavigate={handleNavigateToNode}
+            linkColor={getLinkColor(link.change)}
+          />
+        )}
 
         <Box sx={{ display: "flex", alignItems: "center", ml: "auto" }}>
           {link.changeType === "sort" && (
@@ -685,14 +718,21 @@ const LinkNode = ({
             ) : (
               <Box sx={{ display: "flex" }}>
                 <Tooltip title="Save new specialization">
-                  <IconButton
-                    sx={{ ml: "8px", borderRadius: "18px", p: 0.2 }}
-                    onClick={() =>
-                      saveNewSpecialization(link.id, collectionName)
-                    }
-                  >
-                    <CheckIcon sx={{ color: "green" }} />
-                  </IconButton>
+                  <span>
+                    <IconButton
+                      sx={{ ml: "8px", borderRadius: "18px", p: 0.2 }}
+                      disabled={!(queuedTitle ?? "").trim()}
+                      onClick={() =>
+                        saveNewSpecialization(link.id, collectionName)
+                      }
+                    >
+                      <CheckIcon
+                        sx={{
+                          color: (queuedTitle ?? "").trim() ? "green" : "gray",
+                        }}
+                      />
+                    </IconButton>
+                  </span>
                 </Tooltip>
                 <Tooltip title="Discard">
                   <IconButton

--- a/src/components/OntologyComponents/DraggableTree.tsx
+++ b/src/components/OntologyComponents/DraggableTree.tsx
@@ -10,23 +10,19 @@ import EditOffIcon from "@mui/icons-material/EditOff";
 import ChatIcon from "@mui/icons-material/Chat";
 import { buildOneLevelFromSpecializations } from "@components/lib/utils/loadOutlineFromPathIds";
 
-import {
-  saveNewChangeLog,
-  unlinkPropertyOf,
-  updateLinksForInheritance,
-} from "@components/lib/utils/helpers";
+import { recordLogs } from "@components/lib/utils/helpers";
 import {
   collection,
   doc,
   getDoc,
   getFirestore,
-  updateDoc,
 } from "firebase/firestore";
 import { ICollection, TreeData } from "@components/types/INode";
 import { NODES } from "@components/lib/firestoreClient/collections";
+import { Post } from "@components/lib/utils/Post";
+import { pendingWrites } from "@components/lib/utils/pendingWrites";
 import { useAuth } from "../context/AuthContext";
 import { FillFlexParent } from "./fill-flex-parent";
-import { triggerUpdateDerivedPaths } from "@components/lib/utils/triggerUpdateDerivedPaths";
 import { findNode, removeNode } from "./treeUtils";
 import { userHasOntologyEditAccess } from "@components/lib/utils/helpers";
 
@@ -52,6 +48,8 @@ function DraggableTree({
   setSnackbarMessage,
   nodes,
   currentVisibleNode,
+  setCurrentVisibleNode,
+  fetchNode,
   onOpenNodesTree,
   treeRef,
   treeType,
@@ -67,6 +65,8 @@ function DraggableTree({
   setSnackbarMessage: any;
   nodes: any;
   currentVisibleNode: any;
+  setCurrentVisibleNode?: (node: any | ((prev: any) => any)) => void;
+  fetchNode?: (nodeId: string, force?: boolean) => Promise<any>;
   onOpenNodesTree: any;
   treeRef: any;
   treeType?: string;
@@ -621,25 +621,6 @@ function DraggableTree({
     }
   }, [treeRef, treeData, firstLoad]);
 
-  const moveElement = (
-    arr: ICollection[],
-    fromIndex: number,
-    toIndex: number,
-  ) => {
-    if (
-      fromIndex < 0 ||
-      fromIndex >= arr.length ||
-      toIndex < 0 ||
-      toIndex >= arr.length
-    ) {
-      throw new Error("Invalid indices");
-    }
-
-    const element = arr.splice(fromIndex, 1)[0];
-    arr.splice(toIndex, 0, element);
-
-    return arr;
-  };
   const handleMove = async (args: {
     dragIds: string[];
     dragNodes: NodeApi<PaginatedTreeData>[];
@@ -691,16 +672,71 @@ function DraggableTree({
         return;
       }
 
+      // A collection can't be nested inside another collection — reject before
+      // the instant edit so the tree doesn't briefly show the nesting.
+      if (draggedNodes[0].category && toParent.category) {
+        setSnackbarMessage(
+          "Collections can't be placed inside another collection.",
+        );
+        return;
+      }
+
+      // Drop pagination/loading fields and keep lazy flags so chevrons persist after edits
+      const cleanTreeData = (data: PaginatedTreeData[]): TreeData[] => {
+        return data
+          .filter((node) => !node.isLoadMore && !node.isLoadingPlaceholder)
+          .map((node) => {
+            const {
+              isLoadMore,
+              isLoadingPlaceholder,
+              parentId,
+              totalChildren,
+              loadedChildren,
+              allChildren,
+              isTopLoader,
+              isBottomLoader,
+              loadDirection,
+              children,
+              ...rest
+            } = node;
+            return {
+              ...rest,
+              children: children
+                ? cleanTreeData(children as PaginatedTreeData[])
+                : undefined,
+            } as TreeData;
+          });
+      };
+
+      // Snapshot the tree (deep — the instant edit splices shared nested
+      // children arrays) and the viewed node, so a rejected write rolls back.
+      const prevTreeData: PaginatedTreeData[] = JSON.parse(
+        JSON.stringify(treeData),
+      );
+      const prevVisible = currentVisibleNode;
+      const revert = () => {
+        setTreeData(prevTreeData);
+        if (onInstantTreeUpdate) {
+          onInstantTreeUpdate(() => cleanTreeData(prevTreeData));
+        }
+        if (prevVisible && setCurrentVisibleNode) {
+          setCurrentVisibleNode((cur: any) =>
+            cur && cur.id === prevVisible.id ? prevVisible : cur,
+          );
+        }
+      };
+
       // Local update for immediate visual feedback
       const newData = [...treeData];
 
-      // Find dragged node's current visual position before removing it
+      // Find dragged node's current visual position before removing it.
+      // Match by tree `id` (unique): category rows all share the owning node's
+      // `nodeId`, so matching on nodeId would resolve the wrong row.
       let draggedNodeVisualIndex = -1;
       if (args.parentNode?.children && args.dragNodes[0]) {
         for (let i = 0; i < args.parentNode.children.length; i++) {
           if (
-            args.parentNode.children[i].data.nodeId ===
-            args.dragNodes[0].data.nodeId
+            args.parentNode.children[i].data.id === args.dragNodes[0].data.id
           ) {
             draggedNodeVisualIndex = i;
             break;
@@ -737,87 +773,102 @@ function DraggableTree({
       });
       setTreeData(newData);
 
-      // Update shared tree state with local update to prevent glitch when treeViewData updates
       if (onInstantTreeUpdate) {
-        // Drop pagination/loading fields and keep lazy flags so chevrons persist after edits
-        const cleanTreeData = (data: PaginatedTreeData[]): TreeData[] => {
-          return data
-            .filter((node) => !node.isLoadMore && !node.isLoadingPlaceholder)
-            .map((node) => {
-              const {
-                isLoadMore,
-                isLoadingPlaceholder,
-                parentId,
-                totalChildren,
-                loadedChildren,
-                allChildren,
-                isTopLoader,
-                isBottomLoader,
-                loadDirection,
-                children,
-                ...rest
-              } = node;
-              return {
-                ...rest,
-                children: children
-                  ? cleanTreeData(children as PaginatedTreeData[])
-                  : undefined,
-              } as TreeData;
-            });
-        };
-
         onInstantTreeUpdate(() => cleanTreeData(newData));
       }
 
+      // Collection reorder: sort endpoint
       if (draggedNodes[0].category) {
-        const parentId = args.parentId;
-        if (parentId) {
-          const nodeRef = doc(collection(db, NODES), parentId);
-          const nodeData = await ensureNodeDoc(parentId);
-          if (!nodeData) {
-            setSnackbarMessage(
-              "Could not load parent node; reorder not saved.",
-            );
-            return;
+        // The owning node — args.parentId is a tree id, not the Firestore id.
+        const parentNodeId = args.parentNode?.data?.nodeId;
+        if (!parentNodeId) return;
+        const nodeData = await ensureNodeDoc(parentNodeId);
+        if (!nodeData) {
+          revert();
+          setSnackbarMessage("Could not load parent node; reorder not saved.");
+          return;
+        }
+        const specializations: ICollection[] = JSON.parse(
+          JSON.stringify(nodeData.specializations),
+        );
+
+        // Put the stored collections in the new visual order of the category
+        // rows, keeping each collection's nodes as-is. "main" goes where its
+        // direct children appear; any collection without a row is added at the
+        // end so none are lost.
+        const owningChildren = (targetParent?.children ||
+          []) as PaginatedTreeData[];
+        const order: string[] = [];
+        let mainPlaced = false;
+        for (const child of owningChildren) {
+          if (child.category) {
+            order.push((child.name || "").replace(/^\[|\]$/g, ""));
+          } else if (!child.isLoadMore && !mainPlaced) {
+            order.push("main");
+            mainPlaced = true;
           }
-          const specializations = nodeData.specializations;
-          const previousValue = JSON.parse(JSON.stringify(specializations));
-          const draggedElement = args.dragIds[0];
-          const index = draggedElement.indexOf("-");
-          const draggedCollection = draggedElement.substring(index + 1);
-          const fromIndex = specializations.findIndex(
-            (c: ICollection) => c.collectionName === draggedCollection,
+        }
+        const byName = new Map(
+          specializations.map((c) => [c.collectionName, c]),
+        );
+        const newSpecializations: ICollection[] = [];
+        for (const name of order) {
+          const c = byName.get(name);
+          if (c) {
+            newSpecializations.push(c);
+            byName.delete(name);
+          }
+        }
+        for (const c of byName.values()) newSpecializations.push(c);
+
+        if (setCurrentVisibleNode && currentVisibleNode?.id === parentNodeId) {
+          setCurrentVisibleNode((prev: any) =>
+            prev && prev.id === parentNodeId
+              ? { ...prev, specializations: newSpecializations }
+              : prev,
           );
-          const newSpecializations = moveElement(
-            specializations,
-            fromIndex,
-            args.index,
-          );
-          await updateDoc(nodeRef, { specializations: newSpecializations });
-          saveNewChangeLog(db, {
-            nodeId: parentId,
-            modifiedBy: user?.uname,
-            modifiedProperty: "specializations",
-            previousValue,
-            newValue: newSpecializations,
-            modifiedAt: new Date(),
-            changeType: "sort collections",
-            fullNode: nodeData,
+        }
+
+        pendingWrites.start(parentNodeId, "specializations");
+        try {
+          await Post("/nodes/hierarchy/sort", {
+            nodeId: parentNodeId,
+            side: "specializations",
+            value: newSpecializations,
+            sortType: "collections",
             ...(appName ? { appName } : {}),
           });
+        } catch (error: any) {
+          revert();
+          setSnackbarMessage(
+            `Failed to reorder collections: ${
+              (typeof error === "string" ? error : error?.message) ||
+              "Please try again."
+            }`,
+          );
+          recordLogs({
+            type: "error",
+            error: JSON.stringify({
+              name: error?.name,
+              message: typeof error === "string" ? error : error?.message,
+              stack: error?.stack,
+            }),
+            at: "handleMove/sort-collections",
+          });
+        } finally {
+          pendingWrites.end(parentNodeId, "specializations");
         }
         return;
       }
 
       if (toParent.nodeId === fromParents[0].nodeId) {
-        const nodeRef = doc(collection(db, NODES), toParent.nodeId);
         const nodeData = await ensureNodeDoc(toParent.nodeId);
         if (!nodeData) {
+          revert();
           setSnackbarMessage("Could not load parent node; reorder not saved.");
           return;
         }
 
-        // Determine source and target collection names
         let from = "main";
         if (fromParents[0].category) {
           from = fromParents[0].name.replace(/^\[|\]$/g, "");
@@ -827,18 +878,17 @@ function DraggableTree({
           to = toParent.name.replace(/^\[|\]$/g, "");
         }
 
-        const specializations = nodeData.specializations;
-        const previousValue = JSON.parse(JSON.stringify(specializations));
-
-        // Find collection indices
+        const specializations: ICollection[] = JSON.parse(
+          JSON.stringify(nodeData.specializations),
+        );
         const fromCollectionIdx = specializations.findIndex(
-          (s: ICollection) => s.collectionName === from,
+          (s) => s.collectionName === from,
         );
         const toCollectionIdx = specializations.findIndex(
-          (s: ICollection) => s.collectionName === to,
+          (s) => s.collectionName === to,
         );
-
         if (fromCollectionIdx === -1 || toCollectionIdx === -1) {
+          revert();
           return;
         }
 
@@ -846,38 +896,29 @@ function DraggableTree({
           // SAME COLLECTION REORDERING
           const currentIndex = specializations[
             fromCollectionIdx
-          ].nodes.findIndex(
-            (n: { id: string }) => n.id === draggedNodes[0].nodeId,
-          );
-
+          ].nodes.findIndex((n) => n.id === draggedNodes[0].nodeId);
           if (currentIndex === -1) {
-            console.error(
-              "[HANDLE MOVE] Node not found in collection:",
-              draggedNodes[0].nodeId,
-            );
+            revert();
             return;
           }
-
           const [movedNode] = specializations[fromCollectionIdx].nodes.splice(
             currentIndex,
             1,
           );
 
-          // Find dragged node's position for adjustment
-          let draggedNodeVisualIndex = -1;
+          let visualIndex = -1;
           if (args.parentNode?.children) {
             for (let i = 0; i < args.parentNode.children.length; i++) {
               if (
                 args.parentNode.children[i].data.nodeId ===
                 draggedNodes[0].nodeId
               ) {
-                draggedNodeVisualIndex = i;
+                visualIndex = i;
                 break;
               }
             }
           }
 
-          // Count category/load-more nodes before args.index
           let categoryCount = 0;
           if (args.parentNode?.children) {
             for (
@@ -892,60 +933,21 @@ function DraggableTree({
             }
           }
 
-          // Calculate target index for Firestore array
-          let firestoreTargetIndex = args.index - categoryCount;
-
-          // Dragging down operation needs to be adjusted
-          let firestoreSpliceIndex = firestoreTargetIndex;
-          if (
-            draggedNodeVisualIndex >= 0 &&
-            draggedNodeVisualIndex < args.index
-          ) {
-            firestoreSpliceIndex--; // Dragging down - adjust for shifted array
+          let firestoreSpliceIndex = args.index - categoryCount;
+          if (visualIndex >= 0 && visualIndex < args.index) {
+            firestoreSpliceIndex--; // dragging down is adjusted for shifted array
           }
-
-          // Insert at calculated position
           specializations[fromCollectionIdx].nodes.splice(
             firestoreSpliceIndex,
             0,
             movedNode,
           );
-
-          await updateDoc(nodeRef, { specializations });
-
-          saveNewChangeLog(db, {
-            nodeId: toParent.nodeId,
-            modifiedBy: user?.uname,
-            modifiedProperty: "specializations",
-            previousValue,
-            newValue: specializations,
-            modifiedAt: new Date(),
-            changeType: "sort elements",
-            fullNode: nodeData,
-            ...(appName ? { appName } : {}),
-          });
-          return;
         } else {
-          // CROSS COLLECTION MOVE
+          // CROSS COLLECTION
+          specializations[fromCollectionIdx].nodes = specializations[
+            fromCollectionIdx
+          ].nodes.filter((n) => n.id !== draggedNodes[0].nodeId);
 
-          // Find current index in SOURCE collection
-          let originalFromIndex = 0;
-          if (fromCollectionIdx !== -1) {
-            originalFromIndex = specializations[
-              fromCollectionIdx
-            ].nodes.findIndex(
-              (n: { id: string }) => n.id === draggedNodes[0].nodeId,
-            );
-
-            // Remove from source collection
-            specializations[fromCollectionIdx].nodes = specializations[
-              fromCollectionIdx
-            ].nodes.filter(
-              (n: { id: string }) => n.id !== draggedNodes[0].nodeId,
-            );
-          }
-
-          // Count category/load-more nodes before args.index in target collection
           let categoryCount = 0;
           if (args.parentNode?.children) {
             for (
@@ -959,171 +961,109 @@ function DraggableTree({
               }
             }
           }
-
-          // Calculate target index
-          let toFirestoreIndex = args.index - categoryCount;
-
-          // Insert into target collection
+          const toFirestoreIndex = args.index - categoryCount;
           specializations[toCollectionIdx].nodes.splice(toFirestoreIndex, 0, {
             id: draggedNodes[0].nodeId,
             title: nodes[draggedNodes[0].nodeId]?.title ?? "",
           });
+        }
 
-          await updateDoc(nodeRef, { specializations });
+        if (setCurrentVisibleNode && currentVisibleNode?.id === toParent.nodeId) {
+          setCurrentVisibleNode((prev: any) =>
+            prev && prev.id === toParent.nodeId
+              ? { ...prev, specializations }
+              : prev,
+          );
+        }
 
-          saveNewChangeLog(db, {
+        pendingWrites.start(toParent.nodeId, "specializations");
+        try {
+          await Post("/nodes/hierarchy/sort", {
             nodeId: toParent.nodeId,
-            modifiedBy: user?.uname,
-            modifiedProperty: "specializations",
-            previousValue,
-            newValue: specializations,
-            modifiedAt: new Date(),
-            changeType: "sort elements",
-            fullNode: nodeData,
+            side: "specializations",
+            value: specializations,
+            sortType: "elements",
             ...(appName ? { appName } : {}),
           });
-          return;
+        } catch (error: any) {
+          revert();
+          setSnackbarMessage(
+            `Failed to reorder: ${
+              (typeof error === "string" ? error : error?.message) ||
+              "Please try again."
+            }`,
+          );
+          recordLogs({
+            type: "error",
+            error: JSON.stringify({
+              name: error?.name,
+              message: typeof error === "string" ? error : error?.message,
+              stack: error?.stack,
+            }),
+            at: "handleMove/sort-elements",
+          });
+        } finally {
+          pendingWrites.end(toParent.nodeId, "specializations");
         }
+        return;
       }
 
-      setSnackbarMessage(
-        `Node${draggedNodes.length > 1 ? "s" : ""} has been moved to ${toParent.name}`,
-      );
-      // if (draggedNodes[0].category) {
-      //   return;
-      //   /*  updateLinksForInheritance(
-      //   db,
-      //   specializationId,
-      //   addedLinks,
-      //   removedLinks,
-      //   specializationData,
-      //   newLinks,
-      //   nodes,
-      // ); */
-      // } else {
+      // ── Cross-parent relocation → move endpoint ──
       const generalizationId = fromParents[0].nodeId;
-      const addedLinks = [toParent.nodeId];
-      const removedLinks = [generalizationId];
       const specializationId = draggedNodes[0].nodeId;
-      const specializationData = await ensureNodeDoc(specializationId);
-      if (!specializationData) {
-        setSnackbarMessage("Could not load dragged node; move not saved.");
-        return;
-      }
-      const newLinks = [toParent.nodeId];
+      const toCollectionName = toParent.category
+        ? toParent.name.replace(/^\[|\]$/g, "")
+        : "main";
 
-      const newGeneralizations = specializationData.generalizations;
-      const previousValue = JSON.parse(JSON.stringify(newGeneralizations));
-
-      newGeneralizations[0].nodes = newGeneralizations[0].nodes.filter(
-        (n: { id: string }) => n.id !== generalizationId,
-      );
-
-      newGeneralizations[0].nodes.push({
-        id: toParent.nodeId,
-        title: nodes[toParent.nodeId]?.title ?? "",
-      });
-
-      const docRef = doc(collection(db, NODES), specializationId);
-
-      await updateDoc(docRef, {
-        generalizations: newGeneralizations,
-      });
-
-      for (let linkId of removedLinks) {
-        await unlinkPropertyOf(db, "generalizations", specializationId, linkId);
-      }
-
-      const newGeneralizationData = await ensureNodeDoc(toParent.nodeId);
-      if (!newGeneralizationData) {
-        setSnackbarMessage("Could not load target node; move not saved.");
-        return;
-      }
-      const specializations = newGeneralizationData.specializations;
-      const previousSValue = JSON.parse(JSON.stringify(specializations));
-
-      const alreadyExist = newGeneralizationData.specializations
-        .flatMap((c: ICollection) => c.nodes)
-        .map((n: { id: string }) => n.id);
-
-      if (!alreadyExist.includes(specializationId)) {
-        let targetCollectionIndex = 0;
-
-        if (toParent.category) {
-          targetCollectionIndex = specializations.findIndex(
-            (s: ICollection) => s.collectionName === toParent.name,
-          );
-        } else {
-          const mainCollectionIndex = specializations.findIndex(
-            (s: ICollection) => s.collectionName === "main",
-          );
-
-          if (mainCollectionIndex !== -1) {
-            targetCollectionIndex = mainCollectionIndex;
+      pendingWrites.start(specializationId, "generalizations");
+      try {
+        await Post("/nodes/hierarchy/move", {
+          nodeId: specializationId,
+          fromParentId: generalizationId,
+          toParentId: toParent.nodeId,
+          toCollectionName,
+          ...(appName ? { appName } : {}),
+        });
+        setSnackbarMessage(
+          `Node${draggedNodes.length > 1 ? "s" : ""} has been moved to ${toParent.name}`,
+        );
+        // If the detail panel shows one of the affected nodes, refresh it —
+        // the move changed its generalizations or specializations server-side.
+        const viewedId = currentVisibleNode?.id;
+        if (
+          fetchNode &&
+          setCurrentVisibleNode &&
+          (viewedId === specializationId ||
+            viewedId === generalizationId ||
+            viewedId === toParent.nodeId)
+        ) {
+          const fresh = await fetchNode(viewedId, true);
+          if (fresh) {
+            setCurrentVisibleNode((cur: any) =>
+              cur?.id === fresh.id ? fresh : cur,
+            );
           }
         }
-
-        if (targetCollectionIndex === -1) {
-          targetCollectionIndex = 0;
-        }
-
-        specializations[targetCollectionIndex].nodes.splice(args.index, 0, {
-          id: specializationId,
-          title: nodes[specializationId]?.title ?? "",
+      } catch (error: any) {
+        revert();
+        setSnackbarMessage(
+          `Failed to move "${nodes[specializationId]?.title ?? "node"}": ${
+            (typeof error === "string" ? error : error?.message) ||
+            "Please try again."
+          }`,
+        );
+        recordLogs({
+          type: "error",
+          error: JSON.stringify({
+            name: error?.name,
+            message: typeof error === "string" ? error : error?.message,
+            stack: error?.stack,
+          }),
+          at: "handleMove/move",
         });
-
-        await updateDoc(doc(collection(db, NODES), toParent.nodeId), {
-          specializations,
-        });
+      } finally {
+        pendingWrites.end(specializationId, "generalizations");
       }
-      /* Specialization Change Log */
-      saveNewChangeLog(db, {
-        nodeId: specializationId,
-        modifiedBy: user?.uname,
-        modifiedProperty: "generalizations",
-        previousValue,
-        newValue: newGeneralizations,
-        modifiedAt: new Date(),
-        changeType: "modify elements",
-        fullNode: specializationData,
-        ...(appName ? { appName } : {}),
-      });
-
-      saveNewChangeLog(db, {
-        nodeId: toParent.nodeId,
-        modifiedBy: user?.uname,
-        modifiedProperty: "specializations",
-        previousValue: previousSValue,
-        newValue: specializations,
-        modifiedAt: new Date(),
-        changeType: "modify elements",
-        fullNode: newGeneralizationData,
-        ...(appName ? { appName } : {}),
-      });
-
-      // await updateLinks(
-      //   newLinks,
-      //   { id: specializationId },
-      //   "specializations",
-      //   nodes,
-      //   db,
-      // );
-      const currentNewLinks = newGeneralizations[0].nodes;
-      await updateLinksForInheritance(
-        db,
-        specializationId,
-        addedLinks.map((id) => {
-          return { id };
-        }),
-        currentNewLinks,
-        specializationData,
-        nodes,
-      );
-      await triggerUpdateDerivedPaths([
-        specializationId,
-        toParent.nodeId,
-        generalizationId,
-      ]);
     } catch (error) {
       console.error(error);
     }

--- a/src/components/OntologyComponents/ExpandSearchResult.tsx
+++ b/src/components/OntologyComponents/ExpandSearchResult.tsx
@@ -5,13 +5,13 @@ import {
   Button,
   IconButton,
   Tooltip,
-  CircularProgress,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import LockIcon from "@mui/icons-material/Lock";
 import { INode } from "@components/types/INode";
+import SyncedSpinner from "@components/components/SyncedSpinner";
 import InsertLinkIcon from "@mui/icons-material/InsertLink";
 import LinkOffIcon from "@mui/icons-material/LinkOff";
 import React, { useEffect, useState } from "react";
@@ -273,7 +273,7 @@ const NodeLabel = ({
           }
         >
           {isLoading ? (
-            <CircularProgress size={18} sx={{ color: "orange" }} />
+            <SyncedSpinner size={18} />
           ) : (
             <Tooltip title={isChecked ? "Unlink" : "Link"} placement="left">
               {isChecked ? (

--- a/src/components/OntologyComponents/ExpandSearchResult.tsx
+++ b/src/components/OntologyComponents/ExpandSearchResult.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   IconButton,
   Tooltip,
+  CircularProgress,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -29,6 +30,7 @@ const ExpandSearchResult = ({
   selectedProperty,
   addACloneNodeQueue,
   currentVisibleNode,
+  loadingIds,
 }: {
   searchResultsForSelection: any;
   markItemAsChecked: any;
@@ -43,6 +45,7 @@ const ExpandSearchResult = ({
   selectedProperty: any;
   addACloneNodeQueue: any;
   currentVisibleNode: any;
+  loadingIds?: Set<string>;
 }) => {
   const [expanded, setExpanded] = useState<string[]>([]);
   const [optimisticLinkedIds, setOptimisticLinkedIds] = useState<Set<string>>(
@@ -90,6 +93,7 @@ const ExpandSearchResult = ({
           currentVisibleNode={currentVisibleNode}
           optimisticLinkedIds={optimisticLinkedIds}
           setOptimisticLinkedIds={setOptimisticLinkedIds}
+          loadingIds={loadingIds}
         />
       }
     />
@@ -130,6 +134,7 @@ const ExpandSearchResult = ({
               currentVisibleNode={currentVisibleNode}
               optimisticLinkedIds={optimisticLinkedIds}
               setOptimisticLinkedIds={setOptimisticLinkedIds}
+              loadingIds={loadingIds}
             />
           }
           sx={{
@@ -189,6 +194,7 @@ const NodeLabel = ({
   currentVisibleNode,
   optimisticLinkedIds,
   setOptimisticLinkedIds,
+  loadingIds,
 }: {
   node: any;
   markItemAsChecked: any;
@@ -204,10 +210,12 @@ const NodeLabel = ({
   currentVisibleNode: any;
   optimisticLinkedIds: Set<string>;
   setOptimisticLinkedIds: React.Dispatch<React.SetStateAction<Set<string>>>;
+  loadingIds?: Set<string>;
 }) => {
   const isChecked =
     checkedItems.has(node.id) || optimisticLinkedIds.has(node.id);
   const isLocked = !user?.manageLock && node.locked;
+  const isLoading = loadingIds?.has(node.id);
 
   return (
     <ListItem
@@ -234,6 +242,7 @@ const NodeLabel = ({
         <IconButton
           onClick={(e) => {
             e.stopPropagation();
+            if (isLoading) return;
             if (isChecked) {
               setOptimisticLinkedIds((prev) => {
                 const updated = new Set(prev);
@@ -256,19 +265,24 @@ const NodeLabel = ({
           /*           variant={isChecked ? "contained" : "outlined"} */
           sx={{ borderRadius: "25px", ml: "auto", fontSize: "0.8rem" }}
           disabled={
-            isChecked &&
-            (disabledAddButton ||
-              (selectedProperty === "specializations" &&
-                getNumOfGeneralizations(node.id)))
+            isLoading ||
+            (isChecked &&
+              (disabledAddButton ||
+                (selectedProperty === "specializations" &&
+                  getNumOfGeneralizations(node.id))))
           }
         >
-          <Tooltip title={isChecked ? "Unlink" : "Link"} placement="left">
-            {isChecked ? (
-              <LinkOffIcon sx={{ color: isChecked ? "orange" : "" }} />
-            ) : (
-              <InsertLinkIcon />
-            )}
-          </Tooltip>
+          {isLoading ? (
+            <CircularProgress size={18} sx={{ color: "orange" }} />
+          ) : (
+            <Tooltip title={isChecked ? "Unlink" : "Link"} placement="left">
+              {isChecked ? (
+                <LinkOffIcon sx={{ color: isChecked ? "orange" : "" }} />
+              ) : (
+                <InsertLinkIcon />
+              )}
+            </Tooltip>
+          )}
         </IconButton>
       ) : (
         <LockIcon sx={{ color: "orange", mx: "15px" }} />

--- a/src/components/OntologyComponents/Node.tsx
+++ b/src/components/OntologyComponents/Node.tsx
@@ -158,7 +158,7 @@ type INodeProps = {
   user: User;
   mainSpecializations: MainSpecializations;
   relatedNodes: { [id: string]: INode };
-  fetchNode: (nodeId: string) => Promise<INode | null>;
+  fetchNode: (nodeId: string, force?: boolean) => Promise<INode | null>;
   addNodesToCache: (
     nodes: { [id: string]: INode },
     parentNodeId?: string,
@@ -1359,7 +1359,7 @@ const Node = ({
                   .flatMap((c: ICollection) => c.nodes)
                   .filter((g: { id: string }) => g.id !== nodeId);
                 if (childGensAfter.length > 0) continue;
-                const freshChild = await fetchNode(removedId);
+                const freshChild = await fetchNode(removedId, true);
                 const childRootId = freshChild?.generalizations?.flatMap(
                   (c) => c.nodes,
                 )[0]?.id;

--- a/src/components/OntologyComponents/Node.tsx
+++ b/src/components/OntologyComponents/Node.tsx
@@ -1237,8 +1237,8 @@ const Node = ({
               });
             }
           } catch (error: any) {
-            // Nothing was saved, so the screen won't correct itself —
-            // re-fetch the node and reset (only if the user is still on it).
+            // The save failed, so re-fetch the node and reset the view
+            // (only if the user is still looking at it).
             const fresh = await fetchNode(nodeId);
             setCurrentVisibleNode((prev: any) =>
               prev?.id === nodeId && fresh ? fresh : prev,
@@ -1258,6 +1258,151 @@ const Node = ({
               }),
               at: "handleSaveLinkChanges",
             });
+          }
+          return;
+        }
+
+        // Specializations/generalizations go through the hierarchy API. The
+        // client sends the full new value; the server handles the rest (reverse
+        // links, inheritance, derived paths, moving orphans under their root).
+        if (
+          selectedProperty === "specializations" ||
+          selectedProperty === "generalizations"
+        ) {
+          const baseNode =
+            currentVisibleNode?.id === nodeId
+              ? currentVisibleNode
+              : relatedNodes[nodeId];
+          const source = (baseNode as any)?.[selectedProperty];
+          const next: ICollection[] =
+            Array.isArray(source) && source.length
+              ? JSON.parse(JSON.stringify(source))
+              : [{ collectionName: "main", nodes: [] }];
+          for (const c of next) {
+            c.nodes = (c.nodes || []).filter(
+              (n: { id: string }) => !removedElements.includes(n.id),
+            );
+          }
+          let i = next.findIndex((c) => c.collectionName === selectedCollection);
+          if (i === -1) i = 0;
+          const existing = new Set(
+            next.flatMap((c) => c.nodes.map((n: { id: string }) => n.id)),
+          );
+          next[i].nodes.push(...addedLinks.filter((l) => !existing.has(l.id)));
+
+          if (
+            selectedProperty === "generalizations" &&
+            next.flatMap((c) => c.nodes).length === 0
+          ) {
+            await confirmIt(
+              "You cannot remove all the generalizations for this node. Make sure it links to at least one generalization.",
+              "OK",
+              "",
+            );
+            return;
+          }
+
+          setCurrentVisibleNode((prev: any) =>
+            prev && prev.id === nodeId
+              ? { ...prev, [selectedProperty]: next }
+              : prev,
+          );
+
+          pendingWrites.start(nodeId, selectedProperty);
+          try {
+            await Post("/nodes/hierarchy/link", {
+              nodeId,
+              side: selectedProperty,
+              value: next,
+              ...(appName ? { appName } : {}),
+            });
+
+            if (onInstantTreeUpdate) {
+              let collectionIdx = next.findIndex(
+                (c) => c.collectionName === selectedCollection,
+              );
+              if (collectionIdx === -1) collectionIdx = 0;
+              onInstantTreeUpdate((tree) => {
+                let updatedTree = tree;
+                for (const removedId of removedElements) {
+                  updatedTree = removeLinkFromNode(
+                    updatedTree,
+                    nodeId,
+                    removedId,
+                    selectedProperty,
+                    collectionIdx,
+                  );
+                }
+                for (const addedId of addedElements) {
+                  updatedTree = addLinkToNode(
+                    updatedTree,
+                    nodeId,
+                    addedId,
+                    selectedProperty,
+                    selectedCollection || "main",
+                    relatedNodes,
+                    relatedNodes[addedId]?.title,
+                  );
+                }
+                return updatedTree;
+              });
+            }
+
+            // If a removed child lost its last generalization, the server moved
+            // it under its root. Show it there so it doesn't disappear until the
+            // snapshot lands.
+            if (selectedProperty === "specializations" && onInstantTreeUpdate) {
+              for (const removedId of removedElements) {
+                const childGensAfter = (
+                  relatedNodes[removedId]?.generalizations || []
+                )
+                  .flatMap((c: ICollection) => c.nodes)
+                  .filter((g: { id: string }) => g.id !== nodeId);
+                if (childGensAfter.length > 0) continue;
+                const freshChild = await fetchNode(removedId);
+                const childRootId = freshChild?.generalizations?.flatMap(
+                  (c) => c.nodes,
+                )[0]?.id;
+                if (childRootId) {
+                  onInstantTreeUpdate((tree) =>
+                    addLinkToNode(
+                      tree,
+                      childRootId,
+                      removedId,
+                      "specializations",
+                      "unclassified",
+                      relatedNodes,
+                      freshChild?.title,
+                      freshChild?.nodeType,
+                    ),
+                  );
+                }
+              }
+            }
+          } catch (error: any) {
+            // The save failed, so re-fetch the node and reset the view
+            // (only if the user is still looking at it).
+            const fresh = await fetchNode(nodeId);
+            setCurrentVisibleNode((prev: any) =>
+              prev?.id === nodeId && fresh ? fresh : prev,
+            );
+            const reason =
+              (typeof error === "string" ? error : error?.message) ||
+              "Please try again.";
+            setSnackbarMessage(
+              `Failed to update "${selectedProperty}": ${reason}`,
+            );
+            recordLogs({
+              type: "error",
+              error: JSON.stringify({
+                name: error?.name,
+                message: typeof error === "string" ? error : error?.message,
+                stack: error?.stack,
+              }),
+              at: "handleSaveLinkChanges",
+            });
+          } finally {
+            pendingWrites.end(nodeId, selectedProperty);
           }
           return;
         }
@@ -1612,6 +1757,8 @@ const Node = ({
       setCurrentVisibleNode,
       setSnackbarMessage,
       fetchNode,
+      currentVisibleNode,
+      confirmIt,
     ],
   );
 
@@ -1859,8 +2006,8 @@ const Node = ({
         ...(appName ? { appName } : {}),
       });
     } catch (error: any) {
-      // Nothing was saved, so the screen won't correct itself —
-      // re-fetch the node and reset (only if the user is still on it).
+      // The save failed, so re-fetch the node and reset the view
+      // (only if the user is still looking at it).
       const fresh = await fetchNode(targetNodeId);
       setCurrentVisibleNode((prev: any) =>
         prev?.id === targetNodeId && fresh ? fresh : prev,

--- a/src/components/StructuredProperty/CollectionStructure.tsx
+++ b/src/components/StructuredProperty/CollectionStructure.tsx
@@ -461,7 +461,6 @@ const CollectionStructure = ({
           const newArray = [...propertyValue];
           const [movedElement] = newArray.splice(sourceIndex, 1);
           newArray.splice(destinationIndex, 0, movedElement);
-          const nodeRef = doc(collection(db, NODES), currentVisibleNode?.id);
 
           if (
             property === "specializations" ||
@@ -532,23 +531,9 @@ const CollectionStructure = ({
             } finally {
               pendingWrites.end(currentVisibleNode.id, property);
             }
-          } else {
-            if (nodeData.inheritance) {
-              nodeData.inheritance[property].ref = null;
-              nodeData.inheritance[property].title = "";
-            }
-            updateDoc(nodeRef, {
-              [`properties.${property}`]: newArray,
-              [`inheritance.${property}.ref`]: null,
-              [`inheritance.${property}.title`]: "",
-            });
-
-            updateInheritance({
-              nodeId: currentVisibleNode?.id,
-              updatedProperties: [property],
-              db,
-            });
           }
+          // No generic branch: generic properties have a single collection, and
+          // collection dragging is gated to specializations.
         }
       } catch (error: any) {
         console.error(error);
@@ -699,43 +684,66 @@ const CollectionStructure = ({
               pendingWrites.end(currentVisibleNode.id, property);
             }
           } else {
-            const nodeRef = doc(collection(db, NODES), currentVisibleNode?.id);
-            updateDoc(nodeRef, {
-              [`properties.${property}`]: propertyValue,
-              [`inheritance.${property}.ref`]: null,
-              [`inheritance.${property}.title`]: "",
-            });
-            updateInheritance({
-              nodeId: currentVisibleNode?.id,
-              updatedProperties: [property],
-              db,
-            });
+            // Instant update; reordering an inherited value overrides it, so
+            // null the ref locally too. The snapshot is gated by pendingWrites.
+            setCurrentVisibleNode((prev: any) =>
+              prev && prev.id === currentVisibleNode?.id
+                ? {
+                    ...prev,
+                    properties: { ...prev.properties, [property]: propertyValue },
+                    inheritance: {
+                      ...prev.inheritance,
+                      [property]: {
+                        ...(prev.inheritance?.[property] || {}),
+                        ref: null,
+                        title: "",
+                      },
+                    },
+                  }
+                : prev,
+            );
 
-            saveNewChangeLog(db, {
-              nodeId: currentVisibleNode?.id,
-              modifiedBy: user?.uname || "",
-              modifiedProperty: property,
-              previousValue,
-              newValue: propertyValue,
-              modifiedAt: new Date(),
-              changeType: "sort elements",
-              changeDetails: {
-                draggableNodeId: draggableId,
-                sourceCollectionIndex,
-                destinationCollectionIndex,
-                destinationIndex,
-              },
-              fullNode: currentVisibleNode,
-              ...(appName ? { appName } : {}),
-            });
-
-            recordLogs({
-              action: "sort elements",
-              field: property,
-              sourceCategory: sourceCollectionIndex,
-              destinationCategory: destinationCollectionIndex,
-              nodeId: currentVisibleNode?.id,
-            });
+            pendingWrites.start(currentVisibleNode.id, `properties.${property}`);
+            try {
+              await Post("/nodes/properties/update", {
+                action: "sort-links",
+                nodeId: currentVisibleNode.id,
+                propertyName: property,
+                value: propertyValue,
+                changeDetails: {
+                  draggableNodeId: draggableId,
+                  sourceCollectionIndex,
+                  destinationCollectionIndex,
+                  destinationIndex,
+                },
+                ...(appName ? { appName } : {}),
+              });
+            } catch (error: any) {
+              const fresh = await fetchNode(currentVisibleNode.id);
+              if (fresh) {
+                setCurrentVisibleNode((prev: any) =>
+                  prev?.id === fresh.id ? fresh : prev,
+                );
+                setEditableProperty((fresh as any).properties?.[property] ?? []);
+              }
+              setSnackbarMessage(
+                `Failed to reorder "${property}": ${
+                  (typeof error === "string" ? error : error?.message) ||
+                  "Please try again."
+                }`,
+              );
+              recordLogs({
+                type: "error",
+                error: JSON.stringify({
+                  name: error?.name,
+                  message: typeof error === "string" ? error : error?.message,
+                  stack: error?.stack,
+                }),
+                at: "handleSorting",
+              });
+            } finally {
+              pendingWrites.end(currentVisibleNode.id, `properties.${property}`);
+            }
           }
 
         }

--- a/src/components/StructuredProperty/CollectionStructure.tsx
+++ b/src/components/StructuredProperty/CollectionStructure.tsx
@@ -28,22 +28,14 @@ import AddIcon from "@mui/icons-material/Add";
 import NewCollection from "../Collection/NewCollection";
 import LinkNode from "../LinkNode/LinkNode";
 import { useAuth } from "../context/AuthContext";
-import {
-  recordLogs,
-  saveNewChangeLog,
-  unlinkPropertyOf,
-  updateLinksForInheritance,
-} from "@components/lib/utils/helpers";
+import { recordLogs } from "@components/lib/utils/helpers";
 import {
   collection,
   doc,
   getFirestore,
   updateDoc,
 } from "firebase/firestore";
-import {
-  NODES,
-  NODES_LOGS,
-} from "@components/lib/firestoreClient/collections";
+import { NODES } from "@components/lib/firestoreClient/collections";
 import { Post } from "@components/lib/utils/Post";
 import { pendingWrites } from "@components/lib/utils/pendingWrites";
 import {
@@ -789,46 +781,9 @@ const CollectionStructure = ({
 
         const currentNodeId = currentVisibleNode.id;
 
-        // Remove nodeBId from currentVisibleNode's specializations
-        await unlinkPropertyOf(db, "generalizations", nodeBId, currentNodeId);
-
-        setSnackbarMessage(
-          `"${getTitle(nodes, nodeBId)}" has been moved under "${getTitle(nodes, nodeAId)}"`,
-        );
-
-        // Update nodeB's generalizations: remove currentNodeId, add nodeAId
-        const nodeBGeneralizations: ICollection[] = JSON.parse(
-          JSON.stringify(nodeBData.generalizations),
-        );
-        for (const col of nodeBGeneralizations) {
-          col.nodes = col.nodes.filter(
-            (n: { id: string }) => n.id !== currentNodeId,
-          );
-        }
-        nodeBGeneralizations[0].nodes.push({
-          id: nodeAId,
-          title: getTitle(nodes, nodeAId) ?? "",
-        });
-        await updateDoc(doc(collection(db, NODES), nodeBId), {
-          generalizations: nodeBGeneralizations,
-        });
-
-        // Add nodeBId to nodeA's specializations in main collection
-        const nodeASpecs: ICollection[] = JSON.parse(
-          JSON.stringify(nodeAData.specializations),
-        );
-        const mainIdx = nodeASpecs.findIndex(
-          (c) => c.collectionName === "main",
-        );
-        nodeASpecs[mainIdx !== -1 ? mainIdx : 0].nodes.push({
-          id: nodeBId,
-          title: getTitle(nodes, nodeBId) ?? "",
-        });
-        await updateDoc(doc(collection(db, NODES), nodeAId), {
-          specializations: nodeASpecs,
-        });
-
-        // Remove nodeBId from the visible list
+        // Instant: drop nodeB from the current node's specializations and the
+        // visible list, and move it under nodeA in the tree. The snapshot is
+        // gated by pendingWrites until the server write lands.
         setEditableProperty((prev: ICollection[]) => {
           const next: ICollection[] = JSON.parse(JSON.stringify(prev));
           if (next[sourceCollectionIndex]) {
@@ -838,83 +793,63 @@ const CollectionStructure = ({
           }
           return next;
         });
-
-        // Snapshot specializations before/after nodeBId removal — `unlinkPropertyOf`
-        // above mutated Firestore but not `currentVisibleNode` locally.
-        const previousSpecializations: ICollection[] =
-          currentVisibleNode.specializations || [];
-        const newSpecializations: ICollection[] = previousSpecializations.map(
-          (col) => ({
-            ...col,
-            nodes: col.nodes.filter((n: ILinkNode) => n.id !== nodeBId),
-          }),
+        setCurrentVisibleNode((prev: any) =>
+          prev && prev.id === currentNodeId
+            ? {
+                ...prev,
+                specializations: (prev.specializations || []).map(
+                  (col: ICollection) => ({
+                    ...col,
+                    nodes: col.nodes.filter((n: ILinkNode) => n.id !== nodeBId),
+                  }),
+                ),
+              }
+            : prev,
         );
-
-        // Reserve a parent-log id so the child log on nodeB can reference it via
-        // `triggeredBy.logId`. Not passed to `unlinkPropertyOf` above because that
-        // call is itself part of the parent mutation.
-        const parentLogId = doc(collection(db, NODES_LOGS)).id;
-        const parentLog = {
-          logId: parentLogId,
-          nodeId: currentNodeId,
-          nodeTitle: currentVisibleNode.title ?? "",
-          changeType: "modify elements" as const,
-        };
-
-        saveNewChangeLog(
-          db,
-          {
-            nodeId: currentNodeId,
-            modifiedBy: user.uname,
-            modifiedProperty: "specializations",
-            previousValue: previousSpecializations,
-            newValue: newSpecializations,
-            modifiedAt: new Date(),
-            changeType: "modify elements",
-            changeDetails: {
-              action: "nest-specialization",
-              movedNode: nodeBId,
-              newParent: nodeAId,
-            },
-            fullNode: currentVisibleNode,
-            ...(appName ? { appName } : {}),
-          },
-          parentLogId,
-        );
-        saveNewChangeLog(db, {
-          nodeId: nodeBId,
-          modifiedBy: user.uname,
-          modifiedProperty: "generalizations",
-          previousValue: nodeBData.generalizations,
-          newValue: nodeBGeneralizations,
-          modifiedAt: new Date(),
-          changeType: "modify elements",
-          changeDetails: {
-            action: "nest-specialization",
-            removedParent: currentNodeId,
-            newParent: nodeAId,
-          },
-          fullNode: nodeBData,
-          ...(appName ? { appName } : {}),
-          triggeredBy: parentLog,
-        });
-
-        // Instant tree update: move nodeBId from currentNode's subtree to nodeA's subtree
         if (onInstantTreeUpdate) {
           onInstantTreeUpdate((tree) =>
             moveNodeInTree(tree, nodeBId, currentNodeId, nodeAId, 0),
           );
         }
-
-        // Inheritance update
-        await updateLinksForInheritance(
-          db,
-          nodeBId,
-          [{ id: nodeAId }],
-          nodeBGeneralizations[0].nodes,
-          nodeBData,
-          nodes,
+        setSnackbarMessage(
+          `"${getTitle(nodes, nodeBId)}" has been moved under "${getTitle(nodes, nodeAId)}"`,
         );
+
+        pendingWrites.start(currentNodeId, "specializations");
+        try {
+          await Post("/nodes/hierarchy/move", {
+            nodeId: nodeBId,
+            fromParentId: currentNodeId,
+            toParentId: nodeAId,
+            toCollectionName: "main",
+            ...(appName ? { appName } : {}),
+          });
+        } catch (error: any) {
+          const fresh = await fetchNode(currentNodeId);
+          if (fresh) {
+            setCurrentVisibleNode((prev: any) =>
+              prev?.id === fresh.id ? fresh : prev,
+            );
+            setEditableProperty((fresh as any).specializations ?? []);
+          }
+          setSnackbarMessage(
+            `Failed to move "${getTitle(nodes, nodeBId)}": ${
+              (typeof error === "string" ? error : error?.message) ||
+              "Please try again."
+            }`,
+          );
+          recordLogs({
+            type: "error",
+            error: JSON.stringify({
+              name: error?.name,
+              message: typeof error === "string" ? error : error?.message,
+              stack: error?.stack,
+            }),
+            at: "handleSpecializationLink",
+          });
+        } finally {
+          pendingWrites.end(currentNodeId, "specializations");
+        }
       } catch (error: any) {
         console.error(error);
         recordLogs({
@@ -929,13 +864,14 @@ const CollectionStructure = ({
     },
     [
       currentVisibleNode,
-      db,
       nodes,
       user,
-      propertyValue,
       appName,
+      fetchNode,
       setEditableProperty,
+      setCurrentVisibleNode,
       onInstantTreeUpdate,
+      setSnackbarMessage,
     ],
   );
 

--- a/src/components/StructuredProperty/CollectionStructure.tsx
+++ b/src/components/StructuredProperty/CollectionStructure.tsx
@@ -31,14 +31,12 @@ import { useAuth } from "../context/AuthContext";
 import {
   recordLogs,
   saveNewChangeLog,
-  updateInheritance,
   unlinkPropertyOf,
   updateLinksForInheritance,
 } from "@components/lib/utils/helpers";
 import {
   collection,
   doc,
-  getDoc,
   getFirestore,
   updateDoc,
 } from "firebase/firestore";
@@ -955,151 +953,106 @@ const CollectionStructure = ({
 
         setOpenAddCollection(false);
 
-        const nodeDoc = await getDoc(
-          doc(collection(db, NODES), currentVisibleNode?.id),
-        );
-        if (!nodeDoc.exists()) return;
-
-        const nodeData = nodeDoc.data();
-        const isSpecialization =
-          property === "specializations" || property === "generalizations";
-
-        const propertyPath = isSpecialization
-          ? property
-          : `properties.${property}`;
-
-        const existIndex = nodeData[propertyPath].findIndex(
-          (c: ICollection) => c.collectionName === newCollection,
-        );
-        // Check if the collection already exists
-        if (existIndex !== -1) {
+        // Only specializations expose collection editing.
+        const current = [...(currentVisibleNode?.[property] || [])];
+        if (
+          current.some((c: ICollection) => c.collectionName === newCollection)
+        ) {
           confirmIt(`This collection already exists!`, "Ok", "");
           return;
         }
+        const newArray = [{ collectionName: newCollection, nodes: [] }, ...current];
 
-        // Create a deep copy of the previous value for logs
-        let previousValue = JSON.parse(
-          JSON.stringify(
-            isSpecialization
-              ? nodeData[propertyPath] || {}
-              : nodeData.properties[property] || {},
-          ),
+        // Instant update; the snapshot for this side is gated by pendingWrites.
+        setCurrentVisibleNode((prev: any) =>
+          prev && prev.id === currentVisibleNode?.id
+            ? { ...prev, [property]: newArray }
+            : prev,
         );
+        if (selectedProperty === property) setEditableProperty(newArray);
 
-        // Add new collection
-        if (isSpecialization) {
-          nodeData[propertyPath].unshift({
-            collectionName: newCollection,
-            nodes: [],
-          });
-        } else {
-          nodeData.properties[property].unshift({
-            collectionName: newCollection,
-            nodes: [],
+        if (onInstantTreeUpdate) {
+          onInstantTreeUpdate((tree) => {
+            const updateTreeNode = (nodes: any[]): any[] => {
+              return nodes.map((node) => {
+                if (node.nodeId === currentVisibleNode.id) {
+                  const collectionExists = node.children?.some(
+                    (child: any) =>
+                      child.name === `[${newCollection}]` && child.category,
+                  );
+                  if (collectionExists) return node;
+                  const newCollectionNode = {
+                    id: `${node.id}-${newCollection}`,
+                    nodeId: node.nodeId,
+                    name: `[${newCollection}]`,
+                    category: true,
+                    children: [],
+                  };
+                  return {
+                    ...node,
+                    children: [newCollectionNode, ...(node.children || [])],
+                  };
+                }
+                if (node.children) {
+                  return { ...node, children: updateTreeNode(node.children) };
+                }
+                return node;
+              });
+            };
+            return updateTreeNode(tree);
           });
         }
-        debugger;
-        // Log the new collection addition
-        logChange("add collection", null, newCollection, nodeDoc, property);
 
-        // Update inheritance if necessary
-        if (!isSpecialization) {
-          updateInheritance({
-            nodeId: nodeDoc.id,
-            updatedProperties: [property],
-            db,
+        pendingWrites.start(currentVisibleNode.id, property);
+        try {
+          await Post("/nodes/hierarchy/collection", {
+            nodeId: currentVisibleNode.id,
+            side: property,
+            action: "add",
+            collectionName: newCollection,
+            ...(appName ? { appName } : {}),
           });
-        }
-
-        // Update the node document with the new collection
-        const updateData = {
-          [propertyPath]: isSpecialization
-            ? nodeData[propertyPath]
-            : nodeData.properties[property],
-        };
-        await updateDoc(nodeDoc.ref, updateData);
-
-        // Save the change log
-        saveNewChangeLog(db, {
-          nodeId: currentVisibleNode?.id,
-          modifiedBy: user?.uname,
-          modifiedProperty: property,
-          previousValue,
-          newValue: nodeData[propertyPath] || nodeData.properties[property],
-          modifiedAt: new Date(),
-          changeType: "add collection",
-          fullNode: currentVisibleNode,
-          changeDetails: {
-            addedCollection: newCollection || "",
-          },
-          ...(appName ? { appName } : {}),
-        });
-
-        // Queue tree update after adding collection
-        if (currentVisibleNode?.id && newCollection) {
-          // Instant update: Add new collection node to tree
-          if (onInstantTreeUpdate) {
-            onInstantTreeUpdate((tree) => {
-              const updateTreeNode = (nodes: any[]): any[] => {
-                return nodes.map((node) => {
-                  if (node.nodeId === currentVisibleNode.id) {
-                    // Check if collection already exists
-                    const collectionExists = node.children?.some(
-                      (child: any) => child.name === `[${newCollection}]` && child.category
-                    );
-
-                    if (collectionExists) {
-                      return node;
-                    }
-
-                    // Add new collection node (empty) to children
-                    const newCollectionNode = {
-                      id: `${node.id}-${newCollection}`,
-                      nodeId: node.nodeId,
-                      name: `[${newCollection}]`,
-                      category: true,
-                      children: [],
-                    };
-                    const newChildren = [
-                      newCollectionNode,
-                      ...(node.children || []),
-                    ];
-                    return { ...node, children: newChildren };
-                  }
-                  if (node.children) {
-                    return { ...node, children: updateTreeNode(node.children) };
-                  }
-                  return node;
-                });
-              };
-              const updatedTree = updateTreeNode(tree);
-              return updatedTree;
-            });
+        } catch (error: any) {
+          const fresh = await fetchNode(currentVisibleNode.id);
+          if (fresh) {
+            setCurrentVisibleNode((prev: any) =>
+              prev?.id === fresh.id ? fresh : prev,
+            );
+            if (selectedProperty === property)
+              setEditableProperty((fresh as any)[property] ?? []);
           }
-
+          setSnackbarMessage(
+            `Failed to add collection: ${
+              (typeof error === "string" ? error : error?.message) ||
+              "Please try again."
+            }`,
+          );
+          recordLogs({
+            type: "error",
+            error: JSON.stringify({
+              name: error?.name,
+              message: typeof error === "string" ? error : error?.message,
+              stack: error?.stack,
+            }),
+            at: "addCollection",
+          });
+        } finally {
+          pendingWrites.end(currentVisibleNode.id, property);
         }
       } catch (error: any) {
-        console.error({
-          type: "error",
-          error: JSON.stringify({
-            name: error.name,
-            message: error.message,
-            stack: error.stack,
-          }),
-          at: "addCollection",
-        });
-        // recordLogs({
-        //   type: "error",
-        //   error: JSON.stringify({
-        //     name: error.name,
-        //     message: error.message,
-        //     stack: error.stack,
-        //   }),
-        //   at: "addCollection",
-        // });
+        console.error(error);
       }
     },
-    [user?.uname, db, currentVisibleNode?.id, property],
+    [
+      user?.uname,
+      currentVisibleNode,
+      property,
+      appName,
+      fetchNode,
+      selectedProperty,
+      onInstantTreeUpdate,
+      confirmIt,
+    ],
   );
   const saveNewAndSwapIt = (newPartTitle: string, partId: string) => {
     try {
@@ -1164,134 +1117,87 @@ const CollectionStructure = ({
         if (!newCollection || !user?.uname || newCollection === editCollection)
           return;
 
-        const nodeDoc = await getDoc(
-          doc(collection(db, NODES), currentVisibleNode?.id),
-        );
-        if (!nodeDoc.exists()) return;
-
-        const nodeData = nodeDoc.data();
-        const isSpecialization =
-          property === "specializations" || property === "generalizations";
-
-        const propertyPath = isSpecialization
-          ? property
-          : `properties.${property}`;
-
-        // Create a deep copy of the previous value for logs
-        let previousValue = JSON.parse(
-          JSON.stringify(
-            isSpecialization
-              ? nodeData[propertyPath]
-              : nodeData.properties[property] || {},
-          ),
+        const renamed = [...(currentVisibleNode?.[property] || [])].map(
+          (c: ICollection) =>
+            c.collectionName === editCollection
+              ? { ...c, collectionName: newCollection }
+              : c,
         );
 
-        // Find the collection to be edited
-        if (isSpecialization) {
-          const collection = nodeData[propertyPath].find(
-            (c: ICollection) => c.collectionName === editCollection,
-          );
-          if (collection) {
-            collection.collectionName = newCollection;
-          }
-        } else {
-          const collection = nodeData.properties[property].find(
-            (c: ICollection) => c.collectionName === editCollection,
-          );
-          if (collection) {
-            collection.collectionName = newCollection;
-          }
-        }
-
-        // Log the edited category
-        logChange(
-          "Edited a category",
-          editCollection,
-          newCollection,
-          nodeDoc,
-          property,
+        // Instant update; the snapshot for this side is gated by pendingWrites.
+        setCurrentVisibleNode((prev: any) =>
+          prev && prev.id === currentVisibleNode?.id
+            ? { ...prev, [property]: renamed }
+            : prev,
         );
+        if (selectedProperty === property) setEditableProperty(renamed);
 
-        // Update inheritance if necessary
-        if (!isSpecialization) {
-          updateInheritance({
-            nodeId: nodeDoc.id,
-            updatedProperties: [property],
-            db,
+        if (onInstantTreeUpdate && editCollection && newCollection) {
+          onInstantTreeUpdate((tree) => {
+            const updateTreeNode = (nodes: any[]): any[] => {
+              return nodes.map((node) => {
+                if (node.nodeId === currentVisibleNode.id && node.children) {
+                  const newChildren = node.children.map((child: any) => {
+                    if (child.name === `[${editCollection}]`) {
+                      return {
+                        ...child,
+                        name: `[${newCollection}]`,
+                        id: child.id.replace(
+                          `-${editCollection}`,
+                          `-${newCollection}`,
+                        ),
+                      };
+                    }
+                    return child;
+                  });
+                  return { ...node, children: newChildren };
+                }
+                if (node.children) {
+                  return { ...node, children: updateTreeNode(node.children) };
+                }
+                return node;
+              });
+            };
+            return updateTreeNode(tree);
           });
         }
 
-        // Update the node document with the edited collection
-        const updateData = {
-          [propertyPath]: isSpecialization
-            ? nodeData[propertyPath]
-            : nodeData.properties[property],
-        };
-
-        setEditableProperty((prev: ICollection[]) => {
-          const _prev = [...prev];
-          const collection = _prev.find(
-            (c: ICollection) => c.collectionName === editCollection,
+        pendingWrites.start(currentVisibleNode.id, property);
+        try {
+          await Post("/nodes/hierarchy/collection", {
+            nodeId: currentVisibleNode.id,
+            side: property,
+            action: "rename",
+            collectionName: editCollection,
+            newName: newCollection,
+            ...(appName ? { appName } : {}),
+          });
+        } catch (error: any) {
+          const fresh = await fetchNode(currentVisibleNode.id);
+          if (fresh) {
+            setCurrentVisibleNode((prev: any) =>
+              prev?.id === fresh.id ? fresh : prev,
+            );
+            if (selectedProperty === property)
+              setEditableProperty((fresh as any)[property] ?? []);
+          }
+          setSnackbarMessage(
+            `Failed to rename collection: ${
+              (typeof error === "string" ? error : error?.message) ||
+              "Please try again."
+            }`,
           );
-          if (collection) {
-            collection.collectionName = newCollection;
-          }
-          return _prev;
-        });
-        await updateDoc(nodeDoc.ref, updateData);
-
-        // Save the change log
-        saveNewChangeLog(db, {
-          nodeId: currentVisibleNode?.id,
-          modifiedBy: user?.uname,
-          modifiedProperty: property,
-          previousValue,
-          newValue: nodeData[propertyPath] || nodeData.properties[property],
-          modifiedAt: new Date(),
-          changeType: "edit collection",
-          fullNode: currentVisibleNode,
-          changeDetails: {
-            modifiedCollection: editCollection || "",
-            newValue: newCollection,
-          },
-          ...(appName ? { appName } : {}),
-        });
-
-        // Queue tree update after editing collection name
-        if (currentVisibleNode?.id) {
-          // Instant update: Rename collection node in tree
-          if (onInstantTreeUpdate && editCollection && newCollection) {
-            onInstantTreeUpdate((tree) => {
-              const updateTreeNode = (nodes: any[]): any[] => {
-                return nodes.map((node) => {
-                  if (node.nodeId === currentVisibleNode.id && node.children) {
-                    // Find and rename the collection node
-                    const newChildren = node.children.map((child: any) => {
-                      if (child.name === `[${editCollection}]`) {
-                        return {
-                          ...child,
-                          name: `[${newCollection}]`,
-                          id: child.id.replace(
-                            `-${editCollection}`,
-                            `-${newCollection}`,
-                          ),
-                        };
-                      }
-                      return child;
-                    });
-                    return { ...node, children: newChildren };
-                  }
-                  if (node.children) {
-                    return { ...node, children: updateTreeNode(node.children) };
-                  }
-                  return node;
-                });
-              };
-              const updatedTree = updateTreeNode(tree);
-              return updatedTree;
-            });
-          }
-
+          recordLogs({
+            type: "error",
+            error: JSON.stringify({
+              name: error?.name,
+              message: typeof error === "string" ? error : error?.message,
+              stack: error?.stack,
+            }),
+            at: "saveEditCollection",
+          });
+        } finally {
+          pendingWrites.end(currentVisibleNode.id, property);
         }
       } catch (error: any) {
         console.error(error);
@@ -1307,7 +1213,16 @@ const CollectionStructure = ({
       }
       setEditCollection(null);
     },
-    [property, editCollection, user?.uname],
+    [
+      property,
+      editCollection,
+      user?.uname,
+      currentVisibleNode,
+      appName,
+      fetchNode,
+      selectedProperty,
+      onInstantTreeUpdate,
+    ],
   );
   const deleteCollection = useCallback(
     async (property: string, collectionIdx: number, collectionName: string) => {
@@ -1330,141 +1245,99 @@ const CollectionStructure = ({
         ))
       ) {
         try {
-          const nodeDoc = await getDoc(
-            doc(collection(db, NODES), currentVisibleNode?.id),
+          const current = [...(currentVisibleNode?.[property] || [])];
+          const target = current.find(
+            (c: ICollection) => c.collectionName === collectionName,
           );
-          if (nodeDoc.exists()) {
-            let previousValue = null;
-            const nodeData = nodeDoc.data();
-            const isSpecialization =
-              property === "specializations" || property === "generalizations";
+          if (!target) return;
 
-            const propertyPath = isSpecialization
-              ? property
-              : `properties.${property}`;
+          // Merge the deleted collection's nodes into "main", then drop it.
+          const newArray: ICollection[] = JSON.parse(JSON.stringify(current));
+          let main = newArray.find((c) => c.collectionName === "main");
+          if (!main) {
+            main = { collectionName: "main", nodes: [] };
+            newArray.push(main);
+          }
+          const existing = new Set(main.nodes.map((n: ILinkNode) => n.id));
+          for (const node of target.nodes) {
+            if (existing.has(node.id)) continue;
+            main.nodes.push(node);
+            existing.add(node.id);
+          }
+          newArray.splice(
+            newArray.findIndex((c) => c.collectionName === collectionName),
+            1,
+          );
 
-            // Handle collection deletion for both 'specializations' and other properties
-            previousValue = JSON.parse(
-              JSON.stringify(
-                isSpecialization
-                  ? nodeData[propertyPath]
-                  : nodeData.properties[property],
-              ),
-            );
+          // Instant update; the snapshot for this side is gated by pendingWrites.
+          setCurrentVisibleNode((prev: any) =>
+            prev && prev.id === currentVisibleNode?.id
+              ? { ...prev, [property]: newArray }
+              : prev,
+          );
+          if (selectedProperty === property) setEditableProperty(newArray);
 
-            // Merge the category into "main" and delete the category
-            if (isSpecialization) {
-              let mainCollectionIdx = nodeData[propertyPath].findIndex(
-                (c: { collectionName: string }) => c.collectionName === "main",
-              );
-
-              if (mainCollectionIdx === -1) {
-                nodeData[propertyPath].push({
-                  collectionName: "main",
-                  nodes: [],
+          if (onInstantTreeUpdate && collectionName) {
+            onInstantTreeUpdate((tree) => {
+              const updateTreeNode = (nodes: any[]): any[] => {
+                return nodes.map((node) => {
+                  if (node.nodeId === currentVisibleNode.id && node.children) {
+                    const deletedCollNode = node.children.find(
+                      (c: any) => c.name === `[${collectionName}]`,
+                    );
+                    if (deletedCollNode) {
+                      const childrenToMove = deletedCollNode.children || [];
+                      const newChildren = node.children
+                        .filter((c: any) => c.name !== `[${collectionName}]`)
+                        .concat(childrenToMove);
+                      return { ...node, children: newChildren };
+                    }
+                  }
+                  if (node.children) {
+                    return { ...node, children: updateTreeNode(node.children) };
+                  }
+                  return node;
                 });
-                mainCollectionIdx = nodeData[propertyPath].length - 1;
-              }
-
-              nodeData[propertyPath][mainCollectionIdx].nodes = [
-                ...(nodeData[propertyPath][mainCollectionIdx].nodes || []),
-                ...nodeData[propertyPath][collectionIdx].nodes,
-              ];
-              nodeData[propertyPath].splice(collectionIdx, 1);
-            } else {
-              let mainCollectionIdx = nodeData.properties[property].findIndex(
-                (c: { collectionName: string }) => c.collectionName === "main",
-              );
-              if (mainCollectionIdx === -1) {
-                nodeData.properties[property].push({
-                  collectionName: "main",
-                  nodes: [],
-                });
-                mainCollectionIdx = nodeData.properties[property].length - 1;
-              }
-              nodeData.properties[property][mainCollectionIdx] = [
-                ...(nodeData.properties[property][mainCollectionIdx].nodes ||
-                  []),
-                ...nodeData.properties[property][collectionIdx].nodes,
-              ];
-              nodeData.properties[property].splice(collectionIdx, 1);
-            }
-
-            // Prepare the updated document data
-            const updateData = {
-              [propertyPath]: isSpecialization
-                ? nodeData[propertyPath]
-                : nodeData.properties[property],
-            };
-
-            // Update the node document
-            await updateDoc(nodeDoc.ref, updateData);
-
-            recordLogs({
-              action: "Deleted a collection",
-              category: collectionIdx,
-              node: nodeDoc.id,
+              };
+              return updateTreeNode(tree);
             });
+          }
 
-            // Log the changes
-            saveNewChangeLog(db, {
-              nodeId: currentVisibleNode?.id,
-              modifiedBy: user?.uname,
-              modifiedProperty: property,
-              previousValue,
-              newValue: isSpecialization
-                ? nodeData[propertyPath]
-                : nodeData.properties[property],
-              modifiedAt: new Date(),
-              changeType: "delete collection",
-              fullNode: currentVisibleNode,
-              changeDetails: {
-                deletedCollection: collectionName || "",
-              },
+          pendingWrites.start(currentVisibleNode.id, property);
+          try {
+            await Post("/nodes/hierarchy/collection", {
+              nodeId: currentVisibleNode.id,
+              side: property,
+              action: "delete",
+              collectionName,
               ...(appName ? { appName } : {}),
             });
-
-            // Queue tree update after deleting collection
-            if (currentVisibleNode?.id) {
-              // Instant update: Remove collection node and merge children to main
-              if (onInstantTreeUpdate && collectionName) {
-                onInstantTreeUpdate((tree) => {
-                  const updateTreeNode = (nodes: any[]): any[] => {
-                    return nodes.map((node) => {
-                      if (
-                        node.nodeId === currentVisibleNode.id &&
-                        node.children
-                      ) {
-                        // Find the collection node being deleted
-                        const deletedCollNode = node.children.find(
-                          (c: any) => c.name === `[${collectionName}]`,
-                        );
-                        if (deletedCollNode) {
-                          // Remove the collection node and move its children to main (direct children)
-                          const childrenToMove = deletedCollNode.children || [];
-                          const newChildren = node.children
-                            .filter(
-                              (c: any) => c.name !== `[${collectionName}]`,
-                            )
-                            .concat(childrenToMove);
-                          return { ...node, children: newChildren };
-                        }
-                      }
-                      if (node.children) {
-                        return {
-                          ...node,
-                          children: updateTreeNode(node.children),
-                        };
-                      }
-                      return node;
-                    });
-                  };
-                  const updatedTree = updateTreeNode(tree);
-                  return updatedTree;
-                });
-              }
-
+          } catch (error: any) {
+            const fresh = await fetchNode(currentVisibleNode.id);
+            if (fresh) {
+              setCurrentVisibleNode((prev: any) =>
+                prev?.id === fresh.id ? fresh : prev,
+              );
+              if (selectedProperty === property)
+                setEditableProperty((fresh as any)[property] ?? []);
             }
+            setSnackbarMessage(
+              `Failed to delete collection: ${
+                (typeof error === "string" ? error : error?.message) ||
+                "Please try again."
+              }`,
+            );
+            recordLogs({
+              type: "error",
+              error: JSON.stringify({
+                name: error?.name,
+                message: typeof error === "string" ? error : error?.message,
+                stack: error?.stack,
+              }),
+              at: "deleteCollection",
+            });
+          } finally {
+            pendingWrites.end(currentVisibleNode.id, property);
           }
         } catch (error: any) {
           console.error("error", error);
@@ -1480,7 +1353,15 @@ const CollectionStructure = ({
         }
       }
     },
-    [confirmIt, currentVisibleNode, db, user?.uname],
+    [
+      confirmIt,
+      currentVisibleNode,
+      user?.uname,
+      appName,
+      fetchNode,
+      selectedProperty,
+      onInstantTreeUpdate,
+    ],
   );
   const handleEditCollection = (collectionName: string) => {
     setEditCollection(collectionName);

--- a/src/components/StructuredProperty/CollectionStructure.tsx
+++ b/src/components/StructuredProperty/CollectionStructure.tsx
@@ -38,6 +38,7 @@ import {
 import { NODES } from "@components/lib/firestoreClient/collections";
 import { Post } from "@components/lib/utils/Post";
 import { pendingWrites } from "@components/lib/utils/pendingWrites";
+import SyncedSpinner from "@components/components/SyncedSpinner";
 import {
   DndContext,
   DragOverlay,
@@ -385,21 +386,7 @@ const CollectionStructure = ({
             }}
           >
             {isLoading ? (
-              <Box
-                sx={{
-                  width: "16px",
-                  height: "16px",
-                  border: "2px solid rgba(255, 165, 0, 0.3)",
-                  borderTop: "2px solid rgba(255, 165, 0, 0.8)",
-                  borderRadius: "50%",
-                  animation: "spin 1s linear infinite",
-                  marginRight: "8px",
-                  "@keyframes spin": {
-                    "0%": { transform: "rotate(0deg)" },
-                    "100%": { transform: "rotate(360deg)" },
-                  },
-                }}
-              />
+              <SyncedSpinner size={16} color="rgba(255, 165, 0, 0.8)" />
             ) : (
               <>•••</>
             )}

--- a/src/components/StructuredProperty/CollectionStructure.tsx
+++ b/src/components/StructuredProperty/CollectionStructure.tsx
@@ -46,6 +46,8 @@ import {
   NODES,
   NODES_LOGS,
 } from "@components/lib/firestoreClient/collections";
+import { Post } from "@components/lib/utils/Post";
+import { pendingWrites } from "@components/lib/utils/pendingWrites";
 import {
   DndContext,
   DragOverlay,
@@ -483,9 +485,53 @@ const CollectionStructure = ({
               });
             }
 
-            updateDoc(nodeRef, {
-              [property]: newArray,
-            });
+            // Instant update; the snapshot for this side is gated by
+            // pendingWrites until the server write lands.
+            setCurrentVisibleNode((prev: any) =>
+              prev && prev.id === currentVisibleNode?.id
+                ? { ...prev, [property]: newArray }
+                : prev,
+            );
+
+            pendingWrites.start(currentVisibleNode.id, property);
+            try {
+              await Post("/nodes/hierarchy/sort", {
+                nodeId: currentVisibleNode.id,
+                side: property,
+                value: newArray,
+                sortType: "collections",
+                changeDetails: {
+                  sourceCollectionIndex: sourceIndex,
+                  destinationCollectionIndex: destinationIndex,
+                },
+                ...(appName ? { appName } : {}),
+              });
+            } catch (error: any) {
+              const fresh = await fetchNode(currentVisibleNode.id);
+              if (fresh) {
+                setCurrentVisibleNode((prev: any) =>
+                  prev?.id === fresh.id ? fresh : prev,
+                );
+                setEditableProperty((fresh as any)[property] ?? []);
+              }
+              setSnackbarMessage(
+                `Failed to reorder collections: ${
+                  (typeof error === "string" ? error : error?.message) ||
+                  "Please try again."
+                }`,
+              );
+              recordLogs({
+                type: "error",
+                error: JSON.stringify({
+                  name: error?.name,
+                  message: typeof error === "string" ? error : error?.message,
+                  stack: error?.stack,
+                }),
+                at: "handleCollectionSorting",
+              });
+            } finally {
+              pendingWrites.end(currentVisibleNode.id, property);
+            }
           } else {
             if (nodeData.inheritance) {
               nodeData.inheritance[property].ref = null;
@@ -517,7 +563,7 @@ const CollectionStructure = ({
         });
       }
     },
-    [property, currentVisibleNode],
+    [property, currentVisibleNode, appName, fetchNode],
   );
 
   const handleSorting = useCallback(
@@ -578,15 +624,82 @@ const CollectionStructure = ({
             );
           }
 
-          const nodeRef = doc(collection(db, NODES), currentVisibleNode?.id);
           if (
             property === "specializations" ||
             property === "generalizations"
           ) {
-            updateDoc(nodeRef, {
-              [property]: propertyValue,
-            });
+            if (property === "specializations" && onInstantTreeUpdate) {
+              const fromCollectionName =
+                propertyValue[sourceCollectionIndex]?.collectionName;
+              const toCollectionName =
+                propertyValue[destinationCollectionIndex]?.collectionName;
+
+              onInstantTreeUpdate((tree) =>
+                reorderChildInTree(
+                  tree,
+                  currentVisibleNode.id,
+                  draggableId,
+                  sourceCollectionIndex,
+                  destinationCollectionIndex,
+                  nodeIdx,
+                  destinationIndex,
+                  fromCollectionName,
+                  toCollectionName,
+                ),
+              );
+            }
+
+            // Instant update; the snapshot for this side is gated by
+            // pendingWrites until the server write lands.
+            setCurrentVisibleNode((prev: any) =>
+              prev && prev.id === currentVisibleNode?.id
+                ? { ...prev, [property]: propertyValue }
+                : prev,
+            );
+
+            pendingWrites.start(currentVisibleNode.id, property);
+            try {
+              await Post("/nodes/hierarchy/sort", {
+                nodeId: currentVisibleNode.id,
+                side: property,
+                value: propertyValue,
+                sortType: "elements",
+                changeDetails: {
+                  draggableNodeId: draggableId,
+                  sourceCollectionIndex,
+                  destinationCollectionIndex,
+                  destinationIndex,
+                },
+                ...(appName ? { appName } : {}),
+              });
+            } catch (error: any) {
+              const fresh = await fetchNode(currentVisibleNode.id);
+              if (fresh) {
+                setCurrentVisibleNode((prev: any) =>
+                  prev?.id === fresh.id ? fresh : prev,
+                );
+                setEditableProperty((fresh as any)[property] ?? []);
+              }
+              setSnackbarMessage(
+                `Failed to reorder "${property}": ${
+                  (typeof error === "string" ? error : error?.message) ||
+                  "Please try again."
+                }`,
+              );
+              recordLogs({
+                type: "error",
+                error: JSON.stringify({
+                  name: error?.name,
+                  message: typeof error === "string" ? error : error?.message,
+                  stack: error?.stack,
+                }),
+                at: "handleSorting",
+              });
+            } finally {
+              pendingWrites.end(currentVisibleNode.id, property);
+            }
           } else {
+            const nodeRef = doc(collection(db, NODES), currentVisibleNode?.id);
             updateDoc(nodeRef, {
               [`properties.${property}`]: propertyValue,
               [`inheritance.${property}.ref`]: null,
@@ -597,226 +710,34 @@ const CollectionStructure = ({
               updatedProperties: [property],
               db,
             });
-          }
 
-          saveNewChangeLog(db, {
-            nodeId: currentVisibleNode?.id,
-            modifiedBy: user?.uname || "",
-            modifiedProperty: property,
-            previousValue,
-            newValue: propertyValue,
-            modifiedAt: new Date(),
-            changeType: "sort elements",
-            changeDetails: {
-              draggableNodeId: draggableId,
-              sourceCollectionIndex,
-              destinationCollectionIndex,
-              destinationIndex,
-            },
-            fullNode: currentVisibleNode,
-            ...(appName ? { appName } : {}),
-          });
-
-          if (property === "specializations" && onInstantTreeUpdate) {
-
-            // Get collection names from propertyValue array
-            const fromCollectionName = propertyValue[sourceCollectionIndex]?.collectionName;
-            const toCollectionName = propertyValue[destinationCollectionIndex]?.collectionName;
-
-            onInstantTreeUpdate((tree) => {
-              return reorderChildInTree(
-                tree,
-                currentVisibleNode.id,
-                draggableId,
+            saveNewChangeLog(db, {
+              nodeId: currentVisibleNode?.id,
+              modifiedBy: user?.uname || "",
+              modifiedProperty: property,
+              previousValue,
+              newValue: propertyValue,
+              modifiedAt: new Date(),
+              changeType: "sort elements",
+              changeDetails: {
+                draggableNodeId: draggableId,
                 sourceCollectionIndex,
                 destinationCollectionIndex,
-                nodeIdx,
                 destinationIndex,
-                fromCollectionName,
-                toCollectionName
-              );
+              },
+              fullNode: currentVisibleNode,
+              ...(appName ? { appName } : {}),
+            });
+
+            recordLogs({
+              action: "sort elements",
+              field: property,
+              sourceCategory: sourceCollectionIndex,
+              destinationCategory: destinationCollectionIndex,
+              nodeId: currentVisibleNode?.id,
             });
           }
 
-          // Queue tree update after sorting elements
-          if (currentVisibleNode?.id) {
-            // Instant update: Reorder children in tree to reflect collection changes
-            if (onInstantTreeUpdate) {
-              // onInstantTreeUpdate((tree) => {
-              //   // Helper to find and update the current node's children in the tree
-              //   const updateTreeNode = (nodes: any[]): any[] => {
-              //     return nodes.map((node) => {
-              //       // Find the current visible node in the tree
-              //       if (node.nodeId === currentVisibleNode.id) {
-              //         if (!node.children) return node;
-              //         // Get source and destination collection names
-              //         const sourceCollName =
-              //           propertyValue[sourceCollectionIndex]?.collectionName;
-              //         const destCollName =
-              //           propertyValue[destinationCollectionIndex]
-              //             ?.collectionName;
-              //         if (!sourceCollName || !destCollName) return node;
-              //         // Case 1: Same collection - just reorder
-              //         if (
-              //           sourceCollectionIndex === destinationCollectionIndex
-              //         ) {
-              //           // Find the collection in the tree
-              //           if (sourceCollName === "main") {
-              //             // Main collection children are direct children
-              //             const childIndex = node.children.findIndex(
-              //               (c: any) => c.nodeId === draggableId,
-              //             );
-              //             if (childIndex !== -1) {
-              //               const newChildren = [...node.children];
-              //               const [movedChild] = newChildren.splice(
-              //                 childIndex,
-              //                 1,
-              //               );
-              //               newChildren.splice(
-              //                 destination.index,
-              //                 0,
-              //                 movedChild,
-              //               );
-              //               return { ...node, children: newChildren };
-              //             }
-              //           } else {
-              //             // Find collection node like "[collectionName]"
-              //             const collectionNode = node.children.find(
-              //               (c: any) => c.name === `[${sourceCollName}]`,
-              //             );
-              //             if (collectionNode && collectionNode.children) {
-              //               const childIndex =
-              //                 collectionNode.children.findIndex(
-              //                   (c: any) => c.nodeId === draggableId,
-              //                 );
-              //               if (childIndex !== -1) {
-              //                 const newCollChildren = [
-              //                   ...collectionNode.children,
-              //                 ];
-              //                 const [movedChild] = newCollChildren.splice(
-              //                   childIndex,
-              //                   1,
-              //                 );
-              //                 newCollChildren.splice(
-              //                   destination.index,
-              //                   0,
-              //                   movedChild,
-              //                 );
-              //                 const updatedCollNode = {
-              //                   ...collectionNode,
-              //                   children: newCollChildren,
-              //                 };
-              //                 const newChildren = node.children.map((c: any) =>
-              //                   c.name === `[${sourceCollName}]`
-              //                     ? updatedCollNode
-              //                     : c,
-              //                 );
-              //                 return { ...node, children: newChildren };
-              //               }
-              //             }
-              //           }
-              //         } else {
-              //           // Case 2: Different collections - move between them
-              //           let movedChild: any = null;
-              //           let newChildren = [...node.children];
-              //           // Remove from source
-              //           if (sourceCollName === "main") {
-              //             const childIndex = newChildren.findIndex(
-              //               (c: any) => c.nodeId === draggableId,
-              //             );
-              //             if (childIndex !== -1) {
-              //               [movedChild] = newChildren.splice(childIndex, 1);
-              //             }
-              //           } else {
-              //             const sourceCollNode = newChildren.find(
-              //               (c: any) => c.name === `[${sourceCollName}]`,
-              //             );
-              //             if (sourceCollNode && sourceCollNode.children) {
-              //               const childIndex =
-              //                 sourceCollNode.children.findIndex(
-              //                   (c: any) => c.nodeId === draggableId,
-              //                 );
-              //               if (childIndex !== -1) {
-              //                 [movedChild] = sourceCollNode.children.splice(
-              //                   childIndex,
-              //                   1,
-              //                 );
-              //                 newChildren = newChildren.map((c: any) =>
-              //                   c.name === `[${sourceCollName}]`
-              //                     ? { ...sourceCollNode }
-              //                     : c,
-              //                 );
-              //               }
-              //             }
-              //           }
-              //           // Add to destination
-              //           if (movedChild) {
-              //             if (destCollName === "main") {
-              //               newChildren.splice(
-              //                 destination.index,
-              //                 0,
-              //                 movedChild,
-              //               );
-              //             } else {
-              //               let destCollNode = newChildren.find(
-              //                 (c: any) => c.name === `[${destCollName}]`,
-              //               );
-              //               if (!destCollNode) {
-              //                 // Create collection node if it doesn't exist
-              //                 destCollNode = {
-              //                   id: `${node.id}-${destCollName}`,
-              //                   nodeId: node.nodeId,
-              //                   name: `[${destCollName}]`,
-              //                   category: true,
-              //                   children: [],
-              //                 };
-              //                 newChildren.push(destCollNode);
-              //               }
-              //               const destChildren = [
-              //                 ...(destCollNode.children || []),
-              //               ];
-              //               destChildren.splice(
-              //                 destination.index,
-              //                 0,
-              //                 movedChild,
-              //               );
-              //               newChildren = newChildren.map((c: any) =>
-              //                 c.name === `[${destCollName}]`
-              //                   ? { ...c, children: destChildren }
-              //                   : c,
-              //               );
-              //             }
-              //           }
-              //           return { ...node, children: newChildren };
-              //         }
-              //       }
-              //       // Recursively process children
-              //       if (node.children) {
-              //         return {
-              //           ...node,
-              //           children: updateTreeNode(node.children),
-              //         };
-              //       }
-              //       return node;
-              //     });
-              //   };
-              //   const updatedTree = updateTreeNode(tree);
-              //     "[INSTANT UPDATE] Reordered children in tree after collection sorting",
-              //   );
-              //   return updatedTree;
-              // });
-            }
-
-          }
-
-          // Record a log of the sorting action
-          recordLogs({
-            action: "sort elements",
-            field: property,
-            sourceCategory: sourceCollectionIndex,
-            destinationCategory: destinationCollectionIndex,
-            nodeId: currentVisibleNode?.id,
-          });
         }
       } catch (error: any) {
         // Log any errors that occur during the sorting process
@@ -831,7 +752,7 @@ const CollectionStructure = ({
         });
       }
     },
-    [currentVisibleNode, db, nodes, recordLogs, property],
+    [currentVisibleNode, db, nodes, recordLogs, property, appName, fetchNode],
   );
 
   const handleSpecializationLink = useCallback(

--- a/src/components/StructuredProperty/InheritedPartsViewer.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewer.tsx
@@ -13,7 +13,6 @@ import {
   Link,
   Popover,
   Button,
-  CircularProgress,
 } from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import ArrowRightAltIcon from "@mui/icons-material/ArrowRightAlt";
@@ -43,6 +42,7 @@ import {
 } from "firebase/firestore";
 
 import { INHERITANCE_FOR_PARTS_COLLECTION_NAME } from "@components/lib/firestoreClient/collections";
+import SyncedSpinner from "@components/components/SyncedSpinner";
 
 interface GeneralizationNode {
   id: string;
@@ -273,7 +273,7 @@ const InheritedPartsViewer: React.FC<InheritedPartsViewerProps> = ({
             py: 2,
           }}
         >
-          <CircularProgress size={16} />
+          <SyncedSpinner size={16} />
           <Typography
             variant="body2"
             sx={{

--- a/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
@@ -12,7 +12,6 @@ import {
   MenuItem,
   ListSubheader,
   Popover,
-  CircularProgress,
   TextField,
 } from "@mui/material";
 import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
@@ -37,6 +36,7 @@ import GeneralizationTabs from "./GeneralizationTabs";
 
 import { Timestamp } from "firebase/firestore";
 import { recordLogs } from "@components/lib/utils/helpers";
+import SyncedSpinner from "@components/components/SyncedSpinner";
 
 interface GeneralizationNode {
   id: string;
@@ -757,7 +757,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
               py: 2,
             }}
           >
-            <CircularProgress size={16} />
+            <SyncedSpinner size={16} />
             <Typography
               variant="body2"
               sx={{
@@ -945,10 +945,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                             title="Calculating inheritance for this part"
                             placement="top"
                           >
-                            <CircularProgress
-                              size={18}
-                              sx={{ color: "orange" }}
-                            />
+                            <SyncedSpinner size={18} />
                           </Tooltip>
                         ) : entry.symbol === "x" ? (
                           <CloseIcon sx={{ fontSize: 20, color: "orange" }} />
@@ -1226,7 +1223,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                                           gap: 1,
                                         }}
                                       >
-                                        <CircularProgress size={16} />
+                                        <SyncedSpinner size={16} />
                                         <Typography
                                           sx={{
                                             fontStyle: "italic",
@@ -1643,7 +1640,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
               {/* Spinner + label while the gen→node mapping recomputes. */}
               {showRecomputeSpinner ? (
                 <>
-                  <CircularProgress size={20} sx={{ color: "orange" }} />
+                  <SyncedSpinner size={20} />
                   <Typography
                     sx={{
                       fontSize: "0.8rem",

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -560,99 +560,103 @@ const StructuredProperty = ({
       const queued = clonedNodesQueue[nId];
       const property = queued.property;
 
-      // Spec/gen go through the cloning endpoint: it creates the new node as a
-      // specialization of the searched node and links it into this node's side.
-      if (property === "specializations" || property === "generalizations") {
-        const targetId = currentVisibleNode?.id;
-        setCurrentVisibleNode((prev: any) => {
-          if (!prev || prev.id !== targetId) return prev;
-          const next: ICollection[] = JSON.parse(
-            JSON.stringify(
-              Array.isArray(prev[property]) && prev[property].length
-                ? prev[property]
-                : [{ collectionName: "main", nodes: [] }],
-            ),
-          );
-          let i = next.findIndex((c) => c.collectionName === collectionName);
-          if (i === -1) i = 0;
-          if (!next.flatMap((c) => c.nodes).some((n) => n.id === nId)) {
-            next[i].nodes.push({ id: nId, title: queued.title });
-          }
-          return { ...prev, [property]: next };
-        });
+      // All "Add Specialization" goes through the cloning endpoint: it creates
+      // the new node as a specialization of the searched node and links it into
+      // this node's section (spec/gen top-level, parts/generic under properties).
+      const targetId = currentVisibleNode?.id;
+      const isHierarchy =
+        property === "specializations" || property === "generalizations";
+      const fieldKey = isHierarchy ? property : `properties.${property}`;
 
-        pendingWrites.start(targetId, property);
-        try {
-          await Post("/nodes/hierarchy/cloning", {
-            newNodeId: nId,
-            title: queued.title,
-            generalizationId: queued.id,
-            targetNodeId: targetId,
-            targetProperty: property,
-            collectionName,
-            ...(appName ? { appName } : {}),
-          });
-          await Post("/triggerChroma", { nodeId: nId, update: true });
-          const fresh = await fetchNode(targetId, true);
-          setCurrentVisibleNode((prev: any) =>
-            prev?.id === targetId && fresh ? fresh : prev,
-          );
-          await fetchNode(nId, true);
-        } catch (error: any) {
-          const fresh = await fetchNode(targetId, true);
-          setCurrentVisibleNode((prev: any) =>
-            prev?.id === targetId && fresh ? fresh : prev,
-          );
-          const reason =
-            (typeof error === "string" ? error : error?.message) ||
-            "Please try again.";
-          setSnackbarMessage(`Failed to add specialization: ${reason}`);
-          recordLogs({
-            type: "error",
-            error: JSON.stringify({
-              name: error?.name,
-              message: typeof error === "string" ? error : error?.message,
-              stack: error?.stack,
-            }),
-            at: "saveNewSpecialization",
-          });
-        } finally {
-          pendingWrites.end(targetId, property);
+      setCurrentVisibleNode((prev: any) => {
+        if (!prev || prev.id !== targetId) return prev;
+        let base: any;
+        if (isHierarchy) {
+          base = prev[property];
+        } else if (property === "parts") {
+          base = prev.properties?.parts;
+        } else {
+          const ref = prev.inheritance?.[property]?.ref;
+          base =
+            ref && relatedNodes[ref]
+              ? relatedNodes[ref].properties?.[property]
+              : prev.properties?.[property];
         }
-        setLoadingIds((prev: Set<string>) => {
-          const _prev = new Set(prev);
-          _prev.delete(nId);
-          return _prev;
-        });
-        setClonedNodesQueue((prev: any) => {
-          const _prev = { ...prev };
-          delete _prev[nId];
-          return _prev;
-        });
-        return;
-      }
+        const next: ICollection[] = JSON.parse(
+          JSON.stringify(
+            Array.isArray(base) && base.length
+              ? base
+              : [{ collectionName: "main", nodes: [] }],
+          ),
+        );
+        let i = next.findIndex((c) => c.collectionName === collectionName);
+        if (i === -1) i = 0;
+        if (!next.flatMap((c) => c.nodes).some((n) => n.id === nId)) {
+          next[i].nodes.push({ id: nId, title: queued.title });
+        }
+        if (isHierarchy) return { ...prev, [property]: next };
+        const updated: any = {
+          ...prev,
+          properties: { ...prev.properties, [property]: next },
+        };
+        // A generic link edit overrides the inherited value on this node.
+        if (property !== "parts" && prev.inheritance?.[property]) {
+          updated.inheritance = {
+            ...prev.inheritance,
+            [property]: { ...prev.inheritance[property], ref: null, title: "" },
+          };
+        }
+        return updated;
+      });
 
-      const addedElements: string[] = [nId];
-      await handleSaveLinkChanges(
-        [],
-        addedElements,
-        property,
-        currentVisibleNode?.id,
-        collectionName,
-      );
+      pendingWrites.start(targetId, fieldKey);
+      try {
+        await Post("/nodes/hierarchy/cloning", {
+          newNodeId: nId,
+          title: queued.title,
+          generalizationId: queued.id,
+          targetNodeId: targetId,
+          targetProperty: property,
+          collectionName,
+          ...(appName ? { appName } : {}),
+        });
+        await Post("/triggerChroma", { nodeId: nId, update: true });
+        const fresh = await fetchNode(targetId, true);
+        setCurrentVisibleNode((prev: any) =>
+          prev?.id === targetId && fresh ? fresh : prev,
+        );
+        await fetchNode(nId, true);
+      } catch (error: any) {
+        const fresh = await fetchNode(targetId, true);
+        setCurrentVisibleNode((prev: any) =>
+          prev?.id === targetId && fresh ? fresh : prev,
+        );
+        const reason =
+          (typeof error === "string" ? error : error?.message) ||
+          "Please try again.";
+        setSnackbarMessage(`Failed to add specialization: ${reason}`);
+        recordLogs({
+          type: "error",
+          error: JSON.stringify({
+            name: error?.name,
+            message: typeof error === "string" ? error : error?.message,
+            stack: error?.stack,
+          }),
+          at: "saveNewSpecialization",
+        });
+      } finally {
+        pendingWrites.end(targetId, fieldKey);
+      }
       setLoadingIds((prev: Set<string>) => {
         const _prev = new Set(prev);
         _prev.delete(nId);
         return _prev;
       });
-      const id = queued.id;
-      const title = queued.title;
       setClonedNodesQueue((prev: any) => {
         const _prev = { ...prev };
         delete _prev[nId];
         return _prev;
       });
-      await handleCloning({ id }, title, nId, collectionName, property);
     } catch (error) {
       console.error(error);
     }

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -85,7 +85,7 @@ type IStructuredPropertyProps = {
   setCurrentVisibleNode: any;
   property: string;
   relatedNodes: { [id: string]: INode };
-  fetchNode: (nodeId: string) => Promise<INode | null>;
+  fetchNode: (nodeId: string, force?: boolean) => Promise<INode | null>;
   addNodesToCache?: (
     nodes: { [id: string]: INode },
     parentNodeId?: string,
@@ -559,8 +559,80 @@ const StructuredProperty = ({
       });
       const queued = clonedNodesQueue[nId];
       const property = queued.property;
-      const addedElements: string[] = [nId];
 
+      // Spec/gen go through the cloning endpoint: it creates the new node as a
+      // specialization of the searched node and links it into this node's side.
+      if (property === "specializations" || property === "generalizations") {
+        const targetId = currentVisibleNode?.id;
+        setCurrentVisibleNode((prev: any) => {
+          if (!prev || prev.id !== targetId) return prev;
+          const next: ICollection[] = JSON.parse(
+            JSON.stringify(
+              Array.isArray(prev[property]) && prev[property].length
+                ? prev[property]
+                : [{ collectionName: "main", nodes: [] }],
+            ),
+          );
+          let i = next.findIndex((c) => c.collectionName === collectionName);
+          if (i === -1) i = 0;
+          if (!next.flatMap((c) => c.nodes).some((n) => n.id === nId)) {
+            next[i].nodes.push({ id: nId, title: queued.title });
+          }
+          return { ...prev, [property]: next };
+        });
+
+        pendingWrites.start(targetId, property);
+        try {
+          await Post("/nodes/hierarchy/cloning", {
+            newNodeId: nId,
+            title: queued.title,
+            generalizationId: queued.id,
+            targetNodeId: targetId,
+            targetProperty: property,
+            collectionName,
+            ...(appName ? { appName } : {}),
+          });
+          await Post("/triggerChroma", { nodeId: nId, update: true });
+          const fresh = await fetchNode(targetId, true);
+          setCurrentVisibleNode((prev: any) =>
+            prev?.id === targetId && fresh ? fresh : prev,
+          );
+          await fetchNode(nId, true);
+        } catch (error: any) {
+          const fresh = await fetchNode(targetId, true);
+          setCurrentVisibleNode((prev: any) =>
+            prev?.id === targetId && fresh ? fresh : prev,
+          );
+          const reason =
+            (typeof error === "string" ? error : error?.message) ||
+            "Please try again.";
+          setSnackbarMessage(`Failed to add specialization: ${reason}`);
+          recordLogs({
+            type: "error",
+            error: JSON.stringify({
+              name: error?.name,
+              message: typeof error === "string" ? error : error?.message,
+              stack: error?.stack,
+            }),
+            at: "saveNewSpecialization",
+          });
+        } finally {
+          pendingWrites.end(targetId, property);
+        }
+        setLoadingIds((prev: Set<string>) => {
+          const _prev = new Set(prev);
+          _prev.delete(nId);
+          return _prev;
+        });
+        setClonedNodesQueue((prev: any) => {
+          const _prev = { ...prev };
+          delete _prev[nId];
+          return _prev;
+        });
+        return;
+      }
+
+      const addedElements: string[] = [nId];
       await handleSaveLinkChanges(
         [],
         addedElements,

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -10,9 +10,9 @@ import {
   useMediaQuery,
   IconButton,
   Slide,
-  CircularProgress,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
+import SyncedSpinner from "@components/components/SyncedSpinner";
 import {
   capitalizeFirstLetter,
   getPropertyValue,
@@ -1428,7 +1428,7 @@ const StructuredProperty = ({
               p: "12px",
             }}
           >
-            <CircularProgress size={18} />
+            <SyncedSpinner size={18} />
             <Typography
               sx={{
                 fontSize: "14px",

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -10,6 +10,7 @@ import {
   useMediaQuery,
   IconButton,
   Slide,
+  CircularProgress,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import {
@@ -30,7 +31,7 @@ import {
   InheritedPartsDetail,
   INode,
 } from "@components/types/INode";
-import { DISPLAY } from "@components/lib/CONSTANTS";
+import { DISPLAY, UNCLASSIFIED } from "@components/lib/CONSTANTS";
 import {
   collection,
   doc,
@@ -427,6 +428,21 @@ const StructuredProperty = ({
     processCollectionData,
     db,
   ]);
+
+  const isReparenting =
+    property === "generalizations" &&
+    !(typeof currentVisibleNode?.root === "boolean" && currentVisibleNode.root) &&
+    (currentVisibleNode?.generalizations || []).flatMap(
+      (c: ICollection) => c.nodes,
+    ).length === 0;
+
+  const reparentRootName = useMemo(() => {
+    const nt = currentVisibleNode?.nodeType;
+    const root = Object.values(relatedNodes).find(
+      (n: any) => n?.root && n?.nodeType === nt && !n?.deleted,
+    ) as INode | undefined;
+    return root?.title || UNCLASSIFIED[nt] || "Unclassified";
+  }, [relatedNodes, currentVisibleNode?.nodeType]);
 
   useEffect(() => {
     if (property === "parts") {
@@ -1327,7 +1343,29 @@ const StructuredProperty = ({
               </Box>
             )}
         </Box>
-        {(property !== "parts" || !enableEdit) &&
+        {isReparenting && (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: "10px",
+              p: "12px",
+            }}
+          >
+            <CircularProgress size={18} />
+            <Typography
+              sx={{
+                fontSize: "14px",
+                fontStyle: "italic",
+                color: "text.secondary",
+              }}
+            >
+              {`Moving under "${reparentRootName}"…`}
+            </Typography>
+          </Box>
+        )}
+        {!isReparenting &&
+          (property !== "parts" || !enableEdit) &&
           currentVisibleNode.propertyType[property] !== "string-array" && (
             <CollectionStructure
               locked={locked}

--- a/src/components/StructuredProperty/StructuredPropertySelector.tsx
+++ b/src/components/StructuredProperty/StructuredPropertySelector.tsx
@@ -381,10 +381,18 @@ const StructuredPropertySelector = ({
   ]);
 
   useEffect(() => {
-    if (selectedProperty && currentVisibleNode) {
-      refreshEditableProperty();
-    }
-  }, [selectedProperty, currentVisibleNode?.id, refreshEditableProperty]);
+    if (!selectedProperty || !currentVisibleNode) return;
+    const hasPendingClone = Object.values(clonedNodesQueue || {}).some(
+      (e: any) => e?.property === selectedProperty,
+    );
+    if (hasPendingClone) return;
+    refreshEditableProperty();
+  }, [
+    selectedProperty,
+    currentVisibleNode?.id,
+    refreshEditableProperty,
+    clonedNodesQueue,
+  ]);
 
   const getSelectingModelTitle = (
     property: string,

--- a/src/components/StructuredProperty/StructuredPropertySelector.tsx
+++ b/src/components/StructuredProperty/StructuredPropertySelector.tsx
@@ -667,9 +667,8 @@ const StructuredPropertySelector = ({
           currentVisibleNode?.id,
           selectedCollection,
         );
-
-        // Refresh editableProperty after database update
-        setTimeout(() => refreshEditableProperty(), 100);
+        // editableProperty re-syncs from currentVisibleNode in the refresh
+        // effect once the instant update or snapshot lands.
       } catch (error) {
         console.error("Error saving link changes:", error);
       }
@@ -895,6 +894,7 @@ const StructuredPropertySelector = ({
           getNumOfGeneralizations={getNumOfGeneralizations}
           selectedProperty={selectedProperty}
           currentVisibleNode={currentVisibleNode}
+          loadingIds={loadingIds}
         />
       )
     );

--- a/src/components/SyncedSpinner.tsx
+++ b/src/components/SyncedSpinner.tsx
@@ -1,0 +1,45 @@
+import { Box } from "@mui/material";
+import { keyframes } from "@mui/system";
+import { useRef } from "react";
+
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+`;
+
+const SPIN_MS = 1000;
+
+/**
+ * A spinner whose rotation is tied to the clock, so every spinner on the page
+ * turns together and a new one starts in sync with the rest.
+ */
+export const SyncedSpinner = ({
+  size = 20,
+  color = "orange",
+  thickness = 2,
+}: {
+  size?: number;
+  color?: string;
+  thickness?: number;
+}) => {
+  const delay = useRef(`-${Date.now() % SPIN_MS}ms`);
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: "inline-block",
+        boxSizing: "border-box",
+        width: size,
+        height: size,
+        border: `${thickness}px solid`,
+        borderColor: "rgba(125,125,125,0.25)",
+        borderTopColor: color,
+        borderRadius: "50%",
+        animation: `${spin} ${SPIN_MS}ms linear infinite`,
+        animationDelay: delay.current,
+      }}
+    />
+  );
+};
+
+export default SyncedSpinner;

--- a/src/lib/CONSTANTS.ts
+++ b/src/lib/CONSTANTS.ts
@@ -98,6 +98,9 @@ export const PROPERTIES_ORDER: any = {
   ],
 };
 
+// A node left with no generalization is moved under its type's root, into this collection
+export const UNCLASSIFIED_COLLECTION = "unclassified";
+
 export const UNCLASSIFIED: any = {
   activity: "Unclassified",
   object: "Unclassified Objects",

--- a/src/lib/server/hierarchy.ts
+++ b/src/lib/server/hierarchy.ts
@@ -753,6 +753,79 @@ export async function removeFromUnclassified(
   return parkedRootId;
 }
 
+/**
+ * Builds a new node that is a child of `source` and inherits its properties.
+ * Only returns the object; the caller writes it to the database.
+ */
+export function buildSpecializationNode(
+  source: INode,
+  newNodeId: string,
+  title: string,
+  uname: string,
+  appName?: string,
+): INode {
+  const inheritance: any = JSON.parse(JSON.stringify(source.inheritance || {}));
+  for (const property in inheritance) {
+    if (inheritance[property].title === undefined) inheritance[property].title = "";
+    if (!inheritance[property].ref && property !== "isPartOf") {
+      inheritance[property].ref = source.id;
+      inheritance[property].title = source.title ?? "";
+    }
+  }
+
+  const properties: any = {};
+  for (const property in source.properties || {}) {
+    if (source.inheritance?.[property]?.inheritanceType === "neverInherit") {
+      properties[property] = defaultValueForProperty(
+        (source.propertyType as any)?.[property],
+      );
+      if (inheritance[property]) {
+        inheritance[property].ref = null;
+        inheritance[property].title = "";
+      }
+    } else {
+      properties[property] = source.properties[property];
+    }
+  }
+
+  const newNode: any = {
+    ...source,
+    id: newNodeId,
+    title,
+    createdBy: uname,
+    contributors: [],
+    contributorsByProperty: {},
+    textValue: {},
+    unclassified: false,
+    deleted: false,
+    locked: false,
+    inheritance,
+    specializations: [{ collectionName: "main", nodes: [] }],
+    generalizations: [
+      {
+        collectionName: "main",
+        nodes: [{ id: source.id, title: source.title ?? "" }],
+      },
+    ],
+    propertyOf: {},
+    numberOfGeneralizations: (source.numberOfGeneralizations || 0) + 1,
+    properties: { ...properties, isPartOf: [{ collectionName: "main", nodes: [] }] },
+    propertyType: { ...(source.propertyType || {}) },
+    nodeType: source.nodeType,
+    ...(appName ? { appName } : {}),
+    createdAt: new Date(),
+  };
+  delete newNode.root;
+  delete newNode.oNetTask;
+  if (newNode?.textValue?.specializations) delete newNode.textValue.specializations;
+  if (newNode?.textValue?.generalizations) delete newNode.textValue.generalizations;
+  if (newNode.properties?.["ONetID"]) {
+    delete newNode.properties["ONetID"];
+    delete newNode.propertyType?.["ONetID"];
+  }
+  return newNode as INode;
+}
+
 // ──────── Endpoint context type ────────
 
 export type ChangeCtx = {

--- a/src/lib/server/hierarchy.ts
+++ b/src/lib/server/hierarchy.ts
@@ -663,6 +663,96 @@ export async function reparentToUnclassified(
   }
 }
 
+/**
+ * The opposite of `reparentToUnclassified`: when a node in a root's
+ * `unclassified` collection gains a real generalization, drop the root link and
+ * its entry in that collection (each logged as "remove element"), unless the
+ * root is its only generalization. Returns the removed root's id, or null.
+ */
+export async function removeFromUnclassified(
+  nodeId: string,
+  cache: NodeCache,
+  parentLog: NodeChange["triggeredBy"],
+  uname: string | undefined,
+  appName: string | undefined,
+  childLogs: NodeChange[],
+): Promise<string | null> {
+  cache.delete(nodeId);
+  const node = await getNode(nodeId, cache);
+  if (!node) return null;
+  const genIds = generalizationIds(node);
+
+  let parkedRootId: string | undefined;
+  for (const gid of genIds) {
+    const root = await getNode(gid, cache);
+    if (!root?.root) continue;
+    const parked = (root.specializations || []).some(
+      (c) =>
+        c.collectionName === UNCLASSIFIED_COLLECTION &&
+        (c.nodes || []).some((n) => n.id === nodeId),
+    );
+    if (parked) {
+      parkedRootId = gid;
+      break;
+    }
+  }
+  if (!parkedRootId) return null;
+  if (genIds.filter((id) => id !== parkedRootId).length === 0) return null;
+
+  const root = await getNode(parkedRootId, cache);
+  if (!root) return null;
+
+  const beforeGens = asCollections(node.generalizations);
+  const afterGens: ICollection[] = beforeGens.map((c) => ({
+    ...c,
+    nodes: (c.nodes || []).filter((n) => n.id !== parkedRootId),
+  }));
+  await db.collection(NODES).doc(nodeId).update({ generalizations: afterGens });
+  cache.set(nodeId, { ...node, generalizations: afterGens });
+  if (uname) {
+    childLogs.push({
+      nodeId,
+      modifiedBy: uname,
+      modifiedProperty: "generalizations",
+      previousValue: beforeGens,
+      newValue: afterGens,
+      modifiedAt: new Date(),
+      changeType: "remove element",
+      fullNode: node,
+      triggeredBy: parentLog,
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+
+  const beforeSpecs = asCollections(root.specializations);
+  const afterSpecs: ICollection[] = beforeSpecs.map((c) =>
+    c.collectionName === UNCLASSIFIED_COLLECTION
+      ? { ...c, nodes: (c.nodes || []).filter((n) => n.id !== nodeId) }
+      : c,
+  );
+  await db
+    .collection(NODES)
+    .doc(parkedRootId)
+    .update({ specializations: afterSpecs });
+  cache.set(parkedRootId, { ...root, specializations: afterSpecs });
+  if (uname) {
+    childLogs.push({
+      nodeId: parkedRootId,
+      modifiedBy: uname,
+      modifiedProperty: "specializations",
+      previousValue: beforeSpecs,
+      newValue: afterSpecs,
+      modifiedAt: new Date(),
+      changeType: "remove element",
+      fullNode: root,
+      triggeredBy: parentLog,
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+
+  return parkedRootId;
+}
+
 // ──────── Endpoint context type ────────
 
 export type ChangeCtx = {

--- a/src/lib/server/hierarchy.ts
+++ b/src/lib/server/hierarchy.ts
@@ -1,0 +1,675 @@
+import {
+  db,
+  MAX_TRANSACTION_WRITES,
+} from "@components/lib/firestoreServer/admin";
+import {
+  LOGS,
+  NODES,
+  NODES_LOGS,
+  USERS,
+} from "@components/lib/firestoreClient/collections";
+import { getDoerCreate } from "@components/lib/utils/helpers";
+import { computeDiffValue } from "@components/lib/utils/diffValue";
+import { FieldValue } from "firebase-admin/firestore";
+import { ICollection, INode, NodeChange } from "@components/types/INode";
+import { isReachableAlongSpecializations } from "@components/lib/server/updateDerivedPaths";
+import { UNCLASSIFIED_COLLECTION } from "../CONSTANTS";
+
+/**
+ * Shared helpers for the specializations/generalizations endpoints (link,
+ * unlink, move, sort, ...). Each endpoint does its own work; this file only
+ * holds the pieces they reuse.
+ */
+
+// ──────── Types, errors & small utilities ────────
+
+export type Side = "specializations" | "generalizations";
+
+export const PARTS_EDGES = new Set(["parts", "isPartOf"]);
+
+export class HttpError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export const hasOwn = (obj: any, key: string) =>
+  !!obj && Object.prototype.hasOwnProperty.call(obj, key);
+
+export const oppositeOf = (side: Side): Side =>
+  side === "specializations" ? "generalizations" : "specializations";
+
+// ──────── Collection & id helpers ────────
+
+/** Checks the incoming collections; returns null if malformed. */
+export function sanitizeCollections(
+  value: any,
+  selfId: string,
+): ICollection[] | null {
+  if (!Array.isArray(value)) return null;
+  const seen = new Set<string>();
+  const out: ICollection[] = [];
+  for (const c of value) {
+    if (!c || typeof c.collectionName !== "string" || !Array.isArray(c.nodes)) {
+      return null;
+    }
+    const nodes = [];
+    for (const n of c.nodes) {
+      if (!n || typeof n.id !== "string") return null;
+      if (n.id === selfId || seen.has(n.id)) continue; // skip self-links and dupes
+      seen.add(n.id);
+      nodes.push({
+        id: n.id,
+        title: typeof n.title === "string" ? n.title : "",
+      });
+    }
+    out.push({ collectionName: c.collectionName, nodes });
+  }
+  return out;
+}
+
+/** Reads a stored side as collections; defaults to an empty `main`. */
+export function asCollections(value: any): ICollection[] {
+  if (Array.isArray(value) && value.length > 0) {
+    return JSON.parse(JSON.stringify(value));
+  }
+  return [{ collectionName: "main", nodes: [] }];
+}
+
+/** All node ids across every collection. */
+export function idsOf(collections: ICollection[]): Set<string> {
+  return new Set(collections.flatMap((c) => c.nodes.map((n) => n.id)));
+}
+
+/** Adds a node to `main`; returns false if it's already there. */
+export function addToMain(
+  collections: ICollection[],
+  linkNode: { id: string; title?: string },
+): boolean {
+  let main = collections.find((c) => c.collectionName === "main");
+  if (!main) {
+    main = { collectionName: "main", nodes: [] };
+    collections.unshift(main);
+  }
+  if (main.nodes.some((n) => n.id === linkNode.id)) return false;
+  main.nodes.push(linkNode);
+  return true;
+}
+
+/** Adds a node to a named collection (created at the end); false if present. */
+export function addToCollection(
+  collections: ICollection[],
+  collectionName: string,
+  linkNode: { id: string; title?: string },
+): boolean {
+  let target = collections.find((c) => c.collectionName === collectionName);
+  if (!target) {
+    target = { collectionName, nodes: [] };
+    collections.push(target);
+  }
+  if (target.nodes.some((n) => n.id === linkNode.id)) return false;
+  target.nodes.push(linkNode);
+  return true;
+}
+
+export function specializationIds(
+  node: Pick<INode, "specializations">,
+): string[] {
+  return (node.specializations || []).flatMap((collection) =>
+    (collection.nodes || []).map((n) => n.id),
+  );
+}
+
+export function generalizationIds(
+  node: Pick<INode, "generalizations">,
+): string[] {
+  return (node.generalizations || []).flatMap((collection) =>
+    (collection.nodes || []).map((n) => n.id),
+  );
+}
+
+/** Starting value for a newly inherited property that carries no value. */
+export function defaultValueForProperty(propertyType: string): any {
+  if (propertyType === "string-array") return [];
+  if (propertyType === "numeric") return 0;
+  return "";
+}
+
+/** Which ids were added vs removed between the stored value and the new one. */
+export function diffSides(
+  previous: ICollection[],
+  next: ICollection[],
+): { added: string[]; removed: string[]; newIds: Set<string> } {
+  const prevIds = idsOf(previous);
+  const newIds = idsOf(next);
+  const added = [...newIds].filter((id) => !prevIds.has(id));
+  const removed = [...prevIds].filter((id) => !newIds.has(id));
+  return { added, removed, newIds };
+}
+
+// ──────── Subtree traversal ────────
+
+/**
+ * Visits every specialization below `rootId` (not the root itself). `apply`
+ * returns the update to save for a node, or `null` to skip it. When
+ * `descendPastSkipped` is false, skipping a node also skips everything below
+ * it — so a node that owns or overrides a property shields its children.
+ */
+export async function walkSpecializations(
+  rootId: string,
+  apply: (node: INode, nodeId: string) => Record<string, any> | null,
+  { descendPastSkipped = true }: { descendPastSkipped?: boolean } = {},
+): Promise<void> {
+  const visited = new Set<string>([rootId]);
+  const rootSnap = await db.collection(NODES).doc(rootId).get();
+  const rootData = rootSnap.data() as INode | undefined;
+  if (!rootData) return;
+
+  const queue = specializationIds(rootData).filter((id) => !visited.has(id));
+  queue.forEach((id) => visited.add(id));
+
+  let batch = db.batch();
+  let pending = 0;
+
+  while (queue.length > 0) {
+    const currentId = queue.shift() as string;
+    const snap = await db.collection(NODES).doc(currentId).get();
+    const data = snap.data() as INode | undefined;
+    if (!data) continue;
+
+    const update = apply(data, currentId);
+    if (update) {
+      batch.update(snap.ref, update);
+      pending += 1;
+      if (pending >= MAX_TRANSACTION_WRITES) {
+        await batch.commit();
+        batch = db.batch();
+        pending = 0;
+      }
+    } else if (!descendPastSkipped) {
+      continue; // this node shields its subtree, so don't descend
+    }
+
+    for (const childId of specializationIds(data)) {
+      if (!visited.has(childId)) {
+        visited.add(childId);
+        queue.push(childId);
+      }
+    }
+  }
+
+  if (pending > 0) await batch.commit();
+}
+
+// ──────── Logging ────────
+
+/** Writes a log entry to LOGS, attributed to `uname`. */
+export const recordLogs = async (
+  logs: { [key: string]: any },
+  uname: string,
+) => {
+  try {
+    if (uname === "ouhrac") return;
+    const logRef = db.collection(LOGS).doc();
+    const doerCreate = getDoerCreate(uname || "");
+    await logRef.set({
+      type: "info",
+      ...logs,
+      createdAt: new Date(),
+      doer: uname,
+      doerCreate,
+    });
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+/**
+ * Writes a NodeChange to NODES_LOGS, then updates the node's contributors and
+ * the user's last-activity time. Pass `preGeneratedId` so child logs can point
+ * back to the parent via `triggeredBy.logId`.
+ */
+export async function writeChangeLog(
+  change: NodeChange,
+  preGeneratedId?: string,
+): Promise<void> {
+  if (!change.modifiedBy) return;
+  const diffValue = computeDiffValue(change);
+  if (diffValue) change.diffValue = diffValue;
+  const logRef = preGeneratedId
+    ? db.collection(NODES_LOGS).doc(preGeneratedId)
+    : db.collection(NODES_LOGS).doc();
+  await logRef.set(change as any);
+  if (change.modifiedBy === "ouhrac") return;
+  await db.collection(USERS).doc(change.modifiedBy).update({
+    lasChangeMadeAt: new Date(),
+  });
+  const nodeUpdates: Record<string, any> = {
+    contributors: FieldValue.arrayUnion(change.modifiedBy),
+  };
+  if (change.modifiedProperty) {
+    nodeUpdates[`contributorsByProperty.${change.modifiedProperty}`] =
+      FieldValue.arrayUnion(change.modifiedBy);
+  }
+  await db.collection(NODES).doc(change.nodeId).update(nodeUpdates);
+}
+
+// ──────── Node fetching & root lookup ────────
+
+export type NodeCache = Map<string, INode | undefined>;
+
+export async function getNode(
+  id: string,
+  cache: NodeCache,
+): Promise<INode | undefined> {
+  if (cache.has(id)) return cache.get(id);
+  const data = (await db.collection(NODES).doc(id).get()).data() as
+    | INode
+    | undefined;
+  cache.set(id, data);
+  return data;
+}
+
+/** Finds the root node for a node's type (one root per app + nodeType). */
+export async function findRootId(node: INode): Promise<string | undefined> {
+  if (!node.nodeType) return undefined;
+  let q = db
+    .collection(NODES)
+    .where("root", "==", true)
+    .where("nodeType", "==", node.nodeType)
+    .where("deleted", "==", false);
+  if (node.appName) q = q.where("appName", "==", node.appName);
+  const snap = await q.limit(1).get();
+  return snap.empty ? undefined : snap.docs[0].id;
+}
+
+// ──────── Orphan detection & cycle checks ────────
+
+export type Reparent = { orphanId: string; rootId: string };
+
+/**
+ * Finds nodes that a removal would leave with no generalization, and the root
+ * each should move under. Looks up the roots first, so a missing root fails
+ * before anything is written. Two cases: this node loses its last
+ * generalization, or a removed child loses its last generalization.
+ */
+export async function collectOrphanReparents(
+  side: Side,
+  nodeId: string,
+  nodeData: INode,
+  removed: string[],
+  newIds: Set<string>,
+  cache: NodeCache,
+): Promise<Reparent[]> {
+  const reparents: Reparent[] = [];
+  if (side === "generalizations" && newIds.size === 0) {
+    const rootId = await findRootId(nodeData);
+    if (!rootId) {
+      throw new HttpError(
+        400,
+        "No root node found to reparent this node under.",
+      );
+    }
+    reparents.push({ orphanId: nodeId, rootId });
+  }
+  if (side === "specializations") {
+    for (const id of removed) {
+      const spec = await getNode(id, cache);
+      if (!spec) continue;
+      const remainingGens = generalizationIds(spec).filter((g) => g !== nodeId);
+      if (remainingGens.length === 0) {
+        const rootId = await findRootId(spec);
+        if (!rootId) {
+          throw new HttpError(
+            400,
+            `No root node found to reparent "${spec.title ?? id}" under.`,
+          );
+        }
+        reparents.push({ orphanId: id, rootId });
+      }
+    }
+  }
+  return reparents;
+}
+
+/** Rejects the whole save if any added edge would create a cycle. */
+export async function assertNoCycle(
+  side: Side,
+  nodeId: string,
+  addedIds: string[],
+): Promise<void> {
+  for (const id of addedIds) {
+    const wouldCycle =
+      side === "generalizations"
+        ? await isReachableAlongSpecializations(db, nodeId, id)
+        : await isReachableAlongSpecializations(db, id, nodeId);
+    if (wouldCycle) {
+      throw new HttpError(
+        400,
+        "This link would create a cycle in the hierarchy.",
+      );
+    }
+  }
+}
+
+// ──────── Reciprocal edge updates ────────
+
+/** Takes `nodeId` off the opposite side of each removed link; logs each. */
+export async function applyReciprocityRemove(
+  nodeId: string,
+  opposite: Side,
+  removedIds: string[],
+  cache: NodeCache,
+  parentLog: NodeChange["triggeredBy"],
+  uname: string | undefined,
+  appName: string | undefined,
+  childLogs: NodeChange[],
+): Promise<void> {
+  for (const id of removedIds) {
+    const linked = await getNode(id, cache);
+    if (!linked) continue;
+    const before = asCollections(linked[opposite]);
+    const after: ICollection[] = JSON.parse(JSON.stringify(before));
+    for (const c of after) {
+      c.nodes = (c.nodes || []).filter((n) => n.id !== nodeId);
+    }
+    await db
+      .collection(NODES)
+      .doc(id)
+      .update({ [opposite]: after });
+    cache.set(id, { ...linked, [opposite]: after });
+    if (uname) {
+      childLogs.push({
+        nodeId: id,
+        modifiedBy: uname,
+        modifiedProperty: opposite,
+        previousValue: before,
+        newValue: after,
+        modifiedAt: new Date(),
+        changeType: "remove element",
+        fullNode: linked,
+        triggeredBy: parentLog,
+        ...(appName ? { appName } : {}),
+      } as NodeChange);
+    }
+  }
+}
+
+/** Adds `nodeId` to the opposite side's `main` of each added link; logs each. */
+export async function applyReciprocityAdd(
+  nodeId: string,
+  nodeTitle: string,
+  opposite: Side,
+  addedIds: string[],
+  cache: NodeCache,
+  parentLog: NodeChange["triggeredBy"],
+  uname: string | undefined,
+  appName: string | undefined,
+  childLogs: NodeChange[],
+): Promise<void> {
+  for (const id of addedIds) {
+    const linked = await getNode(id, cache);
+    if (!linked) continue;
+    const before = asCollections(linked[opposite]);
+    const after: ICollection[] = JSON.parse(JSON.stringify(before));
+    if (!addToMain(after, { id: nodeId, title: nodeTitle })) continue;
+    await db
+      .collection(NODES)
+      .doc(id)
+      .update({ [opposite]: after });
+    cache.set(id, { ...linked, [opposite]: after });
+    if (uname) {
+      childLogs.push({
+        nodeId: id,
+        modifiedBy: uname,
+        modifiedProperty: opposite,
+        previousValue: before,
+        newValue: after,
+        modifiedAt: new Date(),
+        changeType: "add element",
+        fullNode: linked,
+        triggeredBy: parentLog,
+        ...(appName ? { appName } : {}),
+      } as NodeChange);
+    }
+  }
+}
+
+// ──────── Inheritance recompute ────────
+
+/**
+ * Recomputes which properties `nodeId` inherits from its current
+ * generalizations, then pushes the result down to its specializations. For
+ * each inherited property: keep it if a generalization still provides it, move
+ * it to one that owns it, or drop it if none do. Properties the generalizations
+ * have but the node lacks get added.
+ * `parts`/`isPartOf` are skipped — they inherit separately via `inheritanceParts`.
+ */
+export async function recomputeInheritance(
+  nodeId: string,
+  cache: NodeCache,
+): Promise<void> {
+  const node = await getNode(nodeId, cache);
+  if (!node) return;
+  const gens = generalizationIds(node);
+
+  const titleOf = async (id: string) => (await getNode(id, cache))?.title ?? "";
+
+  const deleted: string[] = [];
+  const repoint: Record<string, { ref: string; title: string }> = {};
+  for (const property in node.inheritance || {}) {
+    if (PARTS_EDGES.has(property)) continue;
+    const ref = node.inheritance[property]?.ref;
+    if (!ref) continue; // the node owns this value, nothing to recompute
+
+    let reachable = false;
+    const owners: string[] = [];
+    for (const genId of gens) {
+      const gen = await getNode(genId, cache);
+      if (!gen) continue;
+      if (ref === genId || ref === gen.inheritance?.[property]?.ref) {
+        reachable = true;
+        break;
+      }
+      if (hasOwn(gen.properties, property)) owners.push(genId);
+    }
+    if (reachable) continue;
+
+    if (owners.length > 0) {
+      const owner = await getNode(owners[0], cache);
+      const targetRef = owner?.inheritance?.[property]?.ref || owners[0];
+      repoint[property] = { ref: targetRef, title: await titleOf(targetRef) };
+    } else {
+      deleted.push(property);
+    }
+  }
+
+  const added: Record<
+    string,
+    { value: any; type: string; ref: string; title: string }
+  > = {};
+  for (const genId of gens) {
+    const gen = await getNode(genId, cache);
+    if (!gen) continue;
+    for (const property in gen.properties || {}) {
+      if (PARTS_EDGES.has(property)) continue;
+      if (hasOwn(node.properties, property) || added[property]) continue;
+      const targetRef = gen.inheritance?.[property]?.ref || genId;
+      const type = (gen.propertyType as any)?.[property];
+      const value =
+        gen.inheritance?.[property]?.inheritanceType === "neverInherit"
+          ? defaultValueForProperty(type)
+          : gen.properties[property];
+      added[property] = {
+        value,
+        type,
+        ref: targetRef,
+        title: await titleOf(targetRef),
+      };
+    }
+  }
+
+  if (
+    deleted.length === 0 &&
+    Object.keys(repoint).length === 0 &&
+    Object.keys(added).length === 0
+  ) {
+    return;
+  }
+
+  const del = FieldValue.delete();
+  const deleteFields = (p: string) => ({
+    [`inheritance.${p}`]: del,
+    [`properties.${p}`]: del,
+    [`textValue.${p}`]: del,
+    [`propertyType.${p}`]: del,
+  });
+  const repointFields = (p: string) => ({
+    [`inheritance.${p}.ref`]: repoint[p].ref,
+    [`inheritance.${p}.title`]: repoint[p].title,
+  });
+  const addFields = (p: string) => {
+    const u: Record<string, any> = {
+      [`inheritance.${p}`]: {
+        inheritanceType: "inheritUnlessAlreadyOverRidden",
+        ref: added[p].ref,
+        title: added[p].title,
+      },
+      [`properties.${p}`]: added[p].value,
+    };
+    if (added[p].type) u[`propertyType.${p}`] = added[p].type;
+    return u;
+  };
+
+  // The node itself inherited through the removed link, so update it directly.
+  const rootUpdate: Record<string, any> = {};
+  for (const p of deleted) Object.assign(rootUpdate, deleteFields(p));
+  for (const p in repoint) Object.assign(rootUpdate, repointFields(p));
+  for (const p in added) Object.assign(rootUpdate, addFields(p));
+  if (Object.keys(rootUpdate).length) {
+    await db.collection(NODES).doc(nodeId).update(rootUpdate);
+  }
+
+  // One property at a time. Each walk stops at a descendant that blocks
+  // inheritance (it overrode the property, can't inherit, or owns it).
+  const inheritsProp = (d: INode, p: string) => {
+    const inh = d.inheritance?.[p];
+    return !!inh && inh.inheritanceType !== "neverInherit" && inh.ref !== null;
+  };
+  for (const p of deleted) {
+    await walkSpecializations(
+      nodeId,
+      (d) => (inheritsProp(d, p) ? deleteFields(p) : null),
+      { descendPastSkipped: false },
+    );
+  }
+  for (const p in repoint) {
+    await walkSpecializations(
+      nodeId,
+      (d) => {
+        const inh = d.inheritance?.[p];
+        if (!inh || inh.inheritanceType === "neverInherit") return null;
+        const canInherit =
+          inh.inheritanceType === "alwaysInherit" ||
+          (inh.inheritanceType === "inheritUnlessAlreadyOverRidden" &&
+            inh.ref !== null);
+        return canInherit ? repointFields(p) : null;
+      },
+      { descendPastSkipped: false },
+    );
+  }
+  for (const p in added) {
+    await walkSpecializations(
+      nodeId,
+      (d) => (hasOwn(d.properties, p) ? null : addFields(p)),
+      { descendPastSkipped: false },
+    );
+  }
+}
+
+// ──────── Reparenting orphans ────────
+
+/**
+ * Moves an orphaned node under its type's root: the orphan gets the root as a
+ * generalization (in `main`), and the root gets the orphan as a specialization
+ * in its `unclassified` collection. Both sides log an "add element" change. The
+ * orphan is re-read fresh because the caller just changed its generalizations.
+ */
+export async function reparentToUnclassified(
+  orphanId: string,
+  rootId: string,
+  cache: NodeCache,
+  parentLog: NodeChange["triggeredBy"],
+  uname: string | undefined,
+  appName: string | undefined,
+  childLogs: NodeChange[],
+): Promise<void> {
+  cache.delete(orphanId);
+  const orphan = await getNode(orphanId, cache);
+  const root = await getNode(rootId, cache);
+  if (!orphan || !root) return;
+
+  const orphanGens = asCollections(orphan.generalizations);
+  if (addToMain(orphanGens, { id: rootId, title: root.title ?? "" })) {
+    await db
+      .collection(NODES)
+      .doc(orphanId)
+      .update({ generalizations: orphanGens });
+    if (uname) {
+      childLogs.push({
+        nodeId: orphanId,
+        modifiedBy: uname,
+        modifiedProperty: "generalizations",
+        previousValue: asCollections(orphan.generalizations),
+        newValue: orphanGens,
+        modifiedAt: new Date(),
+        changeType: "add element",
+        fullNode: orphan,
+        triggeredBy: parentLog,
+        ...(appName ? { appName } : {}),
+      } as NodeChange);
+    }
+    cache.set(orphanId, { ...orphan, generalizations: orphanGens });
+  }
+
+  const rootSpecs = asCollections(root.specializations);
+  if (
+    addToCollection(rootSpecs, UNCLASSIFIED_COLLECTION, {
+      id: orphanId,
+      title: orphan.title ?? "",
+    })
+  ) {
+    await db
+      .collection(NODES)
+      .doc(rootId)
+      .update({ specializations: rootSpecs });
+    if (uname) {
+      childLogs.push({
+        nodeId: rootId,
+        modifiedBy: uname,
+        modifiedProperty: "specializations",
+        previousValue: asCollections(root.specializations),
+        newValue: rootSpecs,
+        modifiedAt: new Date(),
+        changeType: "add element",
+        fullNode: root,
+        triggeredBy: parentLog,
+        ...(appName ? { appName } : {}),
+      } as NodeChange);
+    }
+    cache.set(rootId, { ...root, specializations: rootSpecs });
+  }
+}
+
+// ──────── Endpoint context type ────────
+
+export type ChangeCtx = {
+  nodeId: string;
+  nodeData: INode;
+  side: Side;
+  value: ICollection[];
+  uname?: string;
+  appName?: string;
+};

--- a/src/lib/server/hierarchy.ts
+++ b/src/lib/server/hierarchy.ts
@@ -149,6 +149,27 @@ export function diffSides(
   return { added, removed, newIds };
 }
 
+/** True when `next` has the same nodes as `previous`, just in a different order. */
+export function isSameMembership(
+  previous: ICollection[],
+  next: ICollection[],
+): boolean {
+  const a = idsOf(previous);
+  const b = idsOf(next);
+  if (a.size !== b.size) return false;
+  for (const id of a) if (!b.has(id)) return false;
+  return true;
+}
+
+/** Saves a new order for one side's collections, without changing their nodes. */
+export async function writeSideOrder(
+  nodeId: string,
+  side: Side,
+  value: ICollection[],
+): Promise<void> {
+  await db.collection(NODES).doc(nodeId).update({ [side]: value });
+}
+
 // ──────── Subtree traversal ────────
 
 /**

--- a/src/lib/server/hierarchy.ts
+++ b/src/lib/server/hierarchy.ts
@@ -418,7 +418,11 @@ export async function applyReciprocityRemove(
   }
 }
 
-/** Adds `nodeId` to the opposite side's `main` of each added link; logs each. */
+/**
+ * Adds `nodeId` to the opposite side of each added link; logs each. Lands in
+ * `main` by default, or in `collectionName` when given (e.g. move's target
+ * collection on the new parent).
+ */
 export async function applyReciprocityAdd(
   nodeId: string,
   nodeTitle: string,
@@ -429,13 +433,18 @@ export async function applyReciprocityAdd(
   uname: string | undefined,
   appName: string | undefined,
   childLogs: NodeChange[],
+  collectionName?: string,
 ): Promise<void> {
   for (const id of addedIds) {
     const linked = await getNode(id, cache);
     if (!linked) continue;
     const before = asCollections(linked[opposite]);
     const after: ICollection[] = JSON.parse(JSON.stringify(before));
-    if (!addToMain(after, { id: nodeId, title: nodeTitle })) continue;
+    const added =
+      collectionName && collectionName !== "main"
+        ? addToCollection(after, collectionName, { id: nodeId, title: nodeTitle })
+        : addToMain(after, { id: nodeId, title: nodeTitle });
+    if (!added) continue;
     await db
       .collection(NODES)
       .doc(id)

--- a/src/lib/utils/instantTreeUpdate.ts
+++ b/src/lib/utils/instantTreeUpdate.ts
@@ -446,6 +446,42 @@ export const addLinkToNode = (
     });
   }
 
+  // Generalizations are the opposite of specializations: the tree parent is the
+  // generalization (linkId), and nodeId is added under it as the child.
+  if (property === 'generalizations') {
+    return treeData.map(node => {
+      if (node.nodeId === linkId) {
+        const childExists = node.children?.some(child =>
+          child.nodeId === nodeId || child.id === nodeId
+        );
+        if (childExists) {
+          return node;
+        }
+
+        const linkedNode = relatedNodes?.[nodeId];
+        const newChild: TreeData = {
+          id: nodeId,
+          nodeId: nodeId,
+          name: linkedNode?.title || nodeId,
+          nodeType: linkedNode?.nodeType || '',
+          children: []
+        };
+        return {
+          ...node,
+          children: [...(node.children || []), newChild]
+        };
+      }
+
+      if (node.children) {
+        return {
+          ...node,
+          children: addLinkToNode(node.children, nodeId, linkId, property, collectionName, relatedNodes, nodeTitle, nodeType)
+        };
+      }
+      return node;
+    });
+  }
+
   // For other properties (parts, etc.), just trigger refresh
   return [...treeData];
 };
@@ -466,6 +502,27 @@ export const removeLinkFromNode = (
         return {
           ...node,
           children: (node.children || []).filter(child => child.nodeId !== linkId)
+        };
+      }
+
+      if (node.children) {
+        return {
+          ...node,
+          children: removeLinkFromNode(node.children, nodeId, linkId, property, collectionIndex)
+        };
+      }
+      return node;
+    });
+  }
+
+  // Generalizations are the opposite of specializations: the tree parent is the
+  // generalization (linkId), and nodeId is removed from under it.
+  if (property === 'generalizations') {
+    return treeData.map(node => {
+      if (node.nodeId === linkId) {
+        return {
+          ...node,
+          children: (node.children || []).filter(child => child.nodeId !== nodeId)
         };
       }
 

--- a/src/lib/utils/instantTreeUpdate.ts
+++ b/src/lib/utils/instantTreeUpdate.ts
@@ -495,13 +495,21 @@ export const removeLinkFromNode = (
   collectionIndex: number
 ): TreeData[] => {
 
-  // For specializations: remove child from the parent node
+  // For specializations: remove child from the parent node. The child can be a
+  // direct child (main collection) or nested under a category node (a named
+  // collection), so strip it from both.
   if (property === 'specializations') {
     return treeData.map(node => {
       if (node.nodeId === nodeId) {
         return {
           ...node,
-          children: (node.children || []).filter(child => child.nodeId !== linkId)
+          children: (node.children || [])
+            .filter(child => child.nodeId !== linkId)
+            .map(child =>
+              child.category && child.children
+                ? { ...child, children: child.children.filter(c => c.nodeId !== linkId) }
+                : child
+            )
         };
       }
 
@@ -516,13 +524,20 @@ export const removeLinkFromNode = (
   }
 
   // Generalizations are the opposite of specializations: the tree parent is the
-  // generalization (linkId), and nodeId is removed from under it.
+  // generalization (linkId), and nodeId is removed from under it — direct child
+  // or nested under a category node (named collection).
   if (property === 'generalizations') {
     return treeData.map(node => {
       if (node.nodeId === linkId) {
         return {
           ...node,
-          children: (node.children || []).filter(child => child.nodeId !== nodeId)
+          children: (node.children || [])
+            .filter(child => child.nodeId !== nodeId)
+            .map(child =>
+              child.category && child.children
+                ? { ...child, children: child.children.filter(c => c.nodeId !== nodeId) }
+                : child
+            )
         };
       }
 

--- a/src/pages/Ontology.tsx
+++ b/src/pages/Ontology.tsx
@@ -695,7 +695,6 @@ const Ontology = ({
     setNewOnes(new Set());
     setCheckedItems(new Set());
     setClonedNodesQueue({});
-    setLoadingIds(new Set());
     setEditableProperty([]);
   };
 

--- a/src/pages/Ontology.tsx
+++ b/src/pages/Ontology.tsx
@@ -380,17 +380,17 @@ const Ontology = ({
 
   // Memoized fetchNode helper to fetch nodes not in cache and add to relatedNodes
   const fetchNode = useCallback(
-    async (nodeId: string): Promise<INode | null> => {
-      // Skip if already in cache
-      if (relatedNodes[nodeId]) {
+    async (nodeId: string, force = false): Promise<INode | null> => {
+      // Use the cache unless a fresh read is forced
+      if (!force && relatedNodes[nodeId]) {
         return relatedNodes[nodeId];
       }
       const node = await fetchSingleNode(db, nodeId);
       if (node) {
-        setRelatedNodes((prev) => {
-          if (prev[nodeId]) return prev;
-          return { ...prev, [nodeId]: node };
-        });
+        // On a forced read, overwrite the cache
+        setRelatedNodes((prev) =>
+          !force && prev[nodeId] ? prev : { ...prev, [nodeId]: node },
+        );
       }
       return node;
     },
@@ -474,6 +474,10 @@ const Ontology = ({
           } as TreeData;
         });
 
+      // An instant tree update may have landed while we were fetching
+      if (hasInstantUpdateRef.current) {
+        return;
+      }
       const tree = [...pathTree, ...otherRoots];
       const filtered = filterTreeForTargetNode(tree, focused.id);
       setCurrentNodeTreeData((prev) => mergePreservedSubtrees(filtered, prev));

--- a/src/pages/Ontology.tsx
+++ b/src/pages/Ontology.tsx
@@ -2345,6 +2345,8 @@ const Ontology = ({
                     setSnackbarMessage={setSnackbarMessage}
                     treeRef={treeRef}
                     currentVisibleNode={currentVisibleNode}
+                    setCurrentVisibleNode={setCurrentVisibleNode}
+                    fetchNode={fetchNode}
                     nodes={relatedNodes}
                     onOpenNodesTree={(nodeId: string) => {
                       onOpenNodesTree(nodeId);
@@ -2775,6 +2777,8 @@ const Ontology = ({
                       setSnackbarMessage={setSnackbarMessage}
                       treeRef={treeRef}
                       currentVisibleNode={currentVisibleNode}
+                      setCurrentVisibleNode={setCurrentVisibleNode}
+                      fetchNode={fetchNode}
                       nodes={relatedNodes}
                       onOpenNodesTree={onOpenNodesTree}
                       appName={appName}

--- a/src/pages/api/nodes/hierarchy/cloning.ts
+++ b/src/pages/api/nodes/hierarchy/cloning.ts
@@ -112,12 +112,14 @@ async function applyClone(ctx: {
     appName,
   );
   if (targetProperty === "generalizations") {
-    newNode.specializations[0].nodes.push({
+    // when the clone source is the current node, buildSpecializationNode
+    // already seeded the opposite side with it.
+    addToMain(newNode.specializations, {
       id: currentNodeId,
       title: currentNode.title ?? "",
     });
   } else if (targetProperty === "specializations") {
-    newNode.generalizations[0].nodes.push({
+    addToMain(newNode.generalizations, {
       id: currentNodeId,
       title: currentNode.title ?? "",
     });

--- a/src/pages/api/nodes/hierarchy/cloning.ts
+++ b/src/pages/api/nodes/hierarchy/cloning.ts
@@ -6,11 +6,12 @@ import { ICollection, INode, NodeChange } from "@components/types/INode";
 import { updateDerivedPaths } from "@components/lib/server/updateDerivedPaths";
 import {
   HttpError,
-  Side,
   NodeCache,
+  hasOwn,
   asCollections,
   addToMain,
   addToCollection,
+  walkSpecializations,
   buildSpecializationNode,
   removeFromUnclassified,
   recomputeInheritance,
@@ -18,18 +19,68 @@ import {
   recordLogs,
 } from "@components/lib/server/hierarchy";
 
+const SCALAR_TYPES = new Set([
+  "string",
+  "numeric",
+  "string-select",
+  "string-array",
+]);
+
+/** Adds a node to a side, into `main` or a named collection. */
+function addToSide(
+  side: ICollection[],
+  collectionName: string,
+  linkNode: { id: string; title?: string },
+) {
+  if (collectionName && collectionName !== "main") {
+    addToCollection(side, collectionName, linkNode);
+  } else {
+    addToMain(side, linkNode);
+  }
+}
+
+/**
+ * Re-points descendants that still inherit `propertyName` through `nodeId` back
+ * at `nodeId`, after it became an override. Port of the same helper in
+ * nodes/properties/update.ts.
+ */
+async function rewireInheritingDescendants(
+  nodeId: string,
+  nodeTitle: string,
+  propertyName: string,
+): Promise<void> {
+  await walkSpecializations(
+    nodeId,
+    (node) => {
+      const inh = node.inheritance?.[propertyName];
+      if (!inh || inh.inheritanceType === "neverInherit") return null;
+      const stillInherits = inh.ref !== null;
+      const rewire =
+        inh.inheritanceType === "alwaysInherit" ||
+        (inh.inheritanceType === "inheritUnlessAlreadyOverRidden" &&
+          stillInherits);
+      if (!rewire) return null;
+      return {
+        [`inheritance.${propertyName}.ref`]: nodeId,
+        [`inheritance.${propertyName}.title`]: nodeTitle,
+      };
+    },
+    { descendPastSkipped: false },
+  );
+}
+
 /**
  * Creates a new node as a child of `source`, then links that new node into the
- * current node's chosen section. Only handles the specializations and
- * generalizations sections for now; parts and other properties stay on the old
- * client path.
+ * current node's `targetProperty`. The link is built differently per target:
+ * hierarchy (spec/gen), parts (own value + reciprocal isPartOf), or a generic
+ * link property (propertyOf + inheritance override).
  */
 async function applyClone(ctx: {
   newNodeId: string;
   title: string;
-  source: INode; // the node being cloned
-  currentNode: INode; // the node being edited
-  targetProperty: Side;
+  source: INode;
+  currentNode: INode;
+  targetProperty: string;
   collectionName: string;
   uname?: string;
   appName?: string;
@@ -46,6 +97,10 @@ async function applyClone(ctx: {
   } = ctx;
   const sourceId = source.id;
   const currentNodeId = currentNode.id;
+  const isHierarchy =
+    targetProperty === "specializations" ||
+    targetProperty === "generalizations";
+  const isParts = targetProperty === "parts";
 
   // Build the new node and add the current node to its links first, so it can
   // be written once with everything already in place.
@@ -61,11 +116,23 @@ async function applyClone(ctx: {
       id: currentNodeId,
       title: currentNode.title ?? "",
     });
-  } else {
+  } else if (targetProperty === "specializations") {
     newNode.generalizations[0].nodes.push({
       id: currentNodeId,
       title: currentNode.title ?? "",
     });
+  } else if (isParts) {
+    addToMain((newNode.properties as any).isPartOf, {
+      id: currentNodeId,
+      title: currentNode.title ?? "",
+    });
+  } else {
+    (newNode as any).propertyOf = {
+      ...(newNode.propertyOf || {}),
+      [targetProperty]: [
+        { collectionName: "main", nodes: [{ id: currentNodeId }] },
+      ],
+    };
   }
 
   const cache: NodeCache = new Map([
@@ -115,21 +182,74 @@ async function applyClone(ctx: {
     } as NodeChange);
   }
 
-  // Add the new node to the section the user edited on the current node.
-  const sideBefore = asCollections(currentNode[targetProperty]);
-  const side: ICollection[] = JSON.parse(JSON.stringify(sideBefore));
-  if (collectionName && collectionName !== "main") {
-    addToCollection(side, collectionName, { id: newNodeId, title });
+  // Section link on the current node. `sideBefore`/`side` feed the parent log.
+  let sideBefore: ICollection[];
+  let side: ICollection[];
+  if (isHierarchy) {
+    sideBefore = asCollections((currentNode as any)[targetProperty]);
+    side = JSON.parse(JSON.stringify(sideBefore));
+    addToSide(side, collectionName, { id: newNodeId, title });
+    await db
+      .collection(NODES)
+      .doc(currentNodeId)
+      .update({ [targetProperty]: side });
+    cache.set(currentNodeId, {
+      ...currentNode,
+      [targetProperty]: side,
+    } as INode);
+  } else if (isParts) {
+    // Parts are a plain own value; inheritance is recomputed by a separate
+    // endpoint, so this just stores the value and the reciprocal isPartOf.
+    sideBefore = asCollections(currentNode.properties?.parts);
+    side = JSON.parse(JSON.stringify(sideBefore));
+    addToSide(side, collectionName, { id: newNodeId, title });
+    await db
+      .collection(NODES)
+      .doc(currentNodeId)
+      .update({ [`properties.parts`]: side });
+    cache.set(currentNodeId, {
+      ...currentNode,
+      properties: { ...currentNode.properties, parts: side },
+    });
   } else {
-    addToMain(side, { id: newNodeId, title });
+    // Generic link property: resolve the value the user saw (through the
+    // inheritance ref while inheriting), add the new node, and override if it was
+    // inherited.
+    const inheritedRef = currentNode.inheritance?.[targetProperty]?.ref;
+    let refData: INode | undefined;
+    if (inheritedRef) {
+      refData = (
+        await db.collection(NODES).doc(inheritedRef).get()
+      ).data() as INode | undefined;
+    }
+    const base =
+      refData && hasOwn(refData.properties, targetProperty)
+        ? refData.properties[targetProperty]
+        : (currentNode.properties as any)?.[targetProperty];
+    sideBefore = asCollections(base);
+    side = JSON.parse(JSON.stringify(sideBefore));
+    addToSide(side, collectionName, { id: newNodeId, title });
+    const updates: Record<string, any> = {
+      [`properties.${targetProperty}`]: side,
+    };
+    if (inheritedRef) {
+      updates[`inheritance.${targetProperty}.ref`] = null;
+      updates[`inheritance.${targetProperty}.title`] = "";
+      if (refData?.textValue && hasOwn(refData.textValue, targetProperty)) {
+        updates[`textValue.${targetProperty}`] = refData.textValue[targetProperty];
+      }
+    }
+    await db.collection(NODES).doc(currentNodeId).update(updates);
+    if (inheritedRef) {
+      await rewireInheritingDescendants(
+        currentNodeId,
+        currentNode.title ?? "",
+        targetProperty,
+      );
+    }
   }
-  await db
-    .collection(NODES)
-    .doc(currentNodeId)
-    .update({ [targetProperty]: side });
-  cache.set(currentNodeId, { ...currentNode, [targetProperty]: side });
 
-  // Log the creation of the new node.
+  // "add node" creation log.
   if (uname) {
     childLogs.push({
       nodeId: newNodeId,
@@ -145,8 +265,9 @@ async function applyClone(ctx: {
     } as NodeChange);
   }
 
-  // A generalizations-side add can pull the current node out of unclassified;
-  // a specializations-side add gives the new node a second generalization.
+  // Inheritance recompute (hierarchy only). A generalizations add can pull the
+  // current node out of unclassified; a specializations add gives the new node
+  // a second generalization.
   if (targetProperty === "generalizations") {
     await removeFromUnclassified(
       currentNodeId,
@@ -158,7 +279,7 @@ async function applyClone(ctx: {
     );
     cache.delete(currentNodeId);
     await recomputeInheritance(currentNodeId, cache);
-  } else {
+  } else if (targetProperty === "specializations") {
     cache.delete(newNodeId);
     await recomputeInheritance(newNodeId, cache);
   }
@@ -232,15 +353,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (!targetNodeId || typeof targetNodeId !== "string") {
     return fail(res, 400, "targetNodeId is required");
   }
-  if (
-    targetProperty !== "specializations" &&
-    targetProperty !== "generalizations"
-  ) {
-    return fail(
-      res,
-      400,
-      `cloning into "${targetProperty}" is not supported yet`,
-    );
+  if (!targetProperty || typeof targetProperty !== "string") {
+    return fail(res, 400, "targetProperty is required");
+  }
+  if (targetProperty === "isPartOf") {
+    return fail(res, 400, "cannot clone into isPartOf");
   }
 
   try {
@@ -258,6 +375,20 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     }
     if (appName && source.appName && source.appName !== appName) {
       return fail(res, 403, "Source node does not belong to this app");
+    }
+
+    // A generic property target must exist on the node and be link-typed.
+    const isHierarchy =
+      targetProperty === "specializations" ||
+      targetProperty === "generalizations";
+    if (!isHierarchy && targetProperty !== "parts") {
+      if (!hasOwn(currentNode.properties, targetProperty)) {
+        return fail(res, 404, `Property "${targetProperty}" not found`);
+      }
+      const propertyType = (currentNode.propertyType as any)?.[targetProperty];
+      if (!propertyType || SCALAR_TYPES.has(propertyType)) {
+        return fail(res, 400, `Property "${targetProperty}" is not link-typed`);
+      }
     }
 
     const result = await applyClone({

--- a/src/pages/api/nodes/hierarchy/cloning.ts
+++ b/src/pages/api/nodes/hierarchy/cloning.ts
@@ -1,0 +1,294 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import fbAuth from "@components/middlewares/fbAuth";
+import { db } from "@components/lib/firestoreServer/admin";
+import { NODES, NODES_LOGS } from "@components/lib/firestoreClient/collections";
+import { ICollection, INode, NodeChange } from "@components/types/INode";
+import { updateDerivedPaths } from "@components/lib/server/updateDerivedPaths";
+import {
+  HttpError,
+  Side,
+  NodeCache,
+  asCollections,
+  addToMain,
+  addToCollection,
+  buildSpecializationNode,
+  removeFromUnclassified,
+  recomputeInheritance,
+  writeChangeLog,
+  recordLogs,
+} from "@components/lib/server/hierarchy";
+
+/**
+ * Creates a new node as a child of `source`, then links that new node into the
+ * current node's chosen section. Only handles the specializations and
+ * generalizations sections for now; parts and other properties stay on the old
+ * client path.
+ */
+async function applyClone(ctx: {
+  newNodeId: string;
+  title: string;
+  source: INode; // the node being cloned
+  currentNode: INode; // the node being edited
+  targetProperty: Side;
+  collectionName: string;
+  uname?: string;
+  appName?: string;
+}): Promise<{ ok: true; nodeId: string }> {
+  const {
+    newNodeId,
+    title,
+    source,
+    currentNode,
+    targetProperty,
+    collectionName,
+    uname,
+    appName,
+  } = ctx;
+  const sourceId = source.id;
+  const currentNodeId = currentNode.id;
+
+  // Build the new node and add the current node to its links first, so it can
+  // be written once with everything already in place.
+  const newNode = buildSpecializationNode(
+    source,
+    newNodeId,
+    title,
+    uname ?? "",
+    appName,
+  );
+  if (targetProperty === "generalizations") {
+    newNode.specializations[0].nodes.push({
+      id: currentNodeId,
+      title: currentNode.title ?? "",
+    });
+  } else {
+    newNode.generalizations[0].nodes.push({
+      id: currentNodeId,
+      title: currentNode.title ?? "",
+    });
+  }
+
+  const cache: NodeCache = new Map([
+    [newNodeId, newNode],
+    [sourceId, source],
+    [currentNodeId, currentNode],
+  ]);
+
+  const parentLogId = db.collection(NODES_LOGS).doc().id;
+  const parentLog = {
+    logId: parentLogId,
+    nodeId: currentNodeId,
+    nodeTitle: currentNode.title ?? "",
+    changeType: "modify elements" as const,
+  };
+  const childLogs: NodeChange[] = [];
+
+  // Write the new node.
+  await db
+    .collection(NODES)
+    .doc(newNodeId)
+    .set({ ...newNode, createdAt: new Date() });
+
+  // Link the new node under the node it was cloned from.
+  const sourceSpecsBefore = asCollections(source.specializations);
+  const sourceSpecs: ICollection[] = JSON.parse(
+    JSON.stringify(sourceSpecsBefore),
+  );
+  addToMain(sourceSpecs, { id: newNodeId, title });
+  await db
+    .collection(NODES)
+    .doc(sourceId)
+    .update({ specializations: sourceSpecs });
+  cache.set(sourceId, { ...source, specializations: sourceSpecs });
+  if (uname) {
+    childLogs.push({
+      nodeId: sourceId,
+      modifiedBy: uname,
+      modifiedProperty: "specializations",
+      previousValue: sourceSpecsBefore,
+      newValue: sourceSpecs,
+      modifiedAt: new Date(),
+      changeType: "add element",
+      fullNode: source,
+      triggeredBy: parentLog,
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+
+  // Add the new node to the section the user edited on the current node.
+  const sideBefore = asCollections(currentNode[targetProperty]);
+  const side: ICollection[] = JSON.parse(JSON.stringify(sideBefore));
+  if (collectionName && collectionName !== "main") {
+    addToCollection(side, collectionName, { id: newNodeId, title });
+  } else {
+    addToMain(side, { id: newNodeId, title });
+  }
+  await db
+    .collection(NODES)
+    .doc(currentNodeId)
+    .update({ [targetProperty]: side });
+  cache.set(currentNodeId, { ...currentNode, [targetProperty]: side });
+
+  // Log the creation of the new node.
+  if (uname) {
+    childLogs.push({
+      nodeId: newNodeId,
+      modifiedBy: uname,
+      modifiedProperty: "",
+      previousValue: null,
+      newValue: null,
+      modifiedAt: new Date(),
+      changeType: "add node",
+      fullNode: newNode,
+      triggeredBy: parentLog,
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+
+  // A generalizations-side add can pull the current node out of unclassified;
+  // a specializations-side add gives the new node a second generalization.
+  if (targetProperty === "generalizations") {
+    await removeFromUnclassified(
+      currentNodeId,
+      cache,
+      parentLog,
+      uname,
+      appName,
+      childLogs,
+    );
+    cache.delete(currentNodeId);
+    await recomputeInheritance(currentNodeId, cache);
+  } else {
+    cache.delete(newNodeId);
+    await recomputeInheritance(newNodeId, cache);
+  }
+
+  await updateDerivedPaths({
+    db,
+    changedNodeIds:
+      targetProperty === "generalizations"
+        ? [newNodeId, currentNodeId]
+        : [newNodeId],
+  });
+
+  if (uname) {
+    await writeChangeLog(
+      {
+        nodeId: currentNodeId,
+        modifiedBy: uname,
+        modifiedProperty: targetProperty,
+        previousValue: sideBefore,
+        newValue: side,
+        modifiedAt: new Date(),
+        changeType: "modify elements",
+        fullNode: currentNode,
+        ...(appName ? { appName } : {}),
+      } as NodeChange,
+      parentLogId,
+    );
+  }
+  for (const log of childLogs) await writeChangeLog(log);
+
+  return { ok: true, nodeId: newNodeId };
+}
+
+function fail(res: NextApiResponse, status: number, msg: string) {
+  return res.status(status).json({ error: msg, message: msg });
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "POST") return fail(res, 405, "Method not allowed");
+  const data = req.body.data;
+  const {
+    newNodeId,
+    title,
+    generalizationId,
+    targetNodeId,
+    targetProperty,
+    collectionName,
+    appName,
+    user,
+  } = data as {
+    newNodeId?: string;
+    title?: string;
+    generalizationId?: string;
+    targetNodeId?: string;
+    targetProperty?: string;
+    collectionName?: string;
+    appName?: string;
+    user?: any;
+  };
+  const { uname } = user?.userData || {};
+
+  if (!newNodeId || typeof newNodeId !== "string") {
+    return fail(res, 400, "newNodeId is required");
+  }
+  if (!title || typeof title !== "string") {
+    return fail(res, 400, "title is required");
+  }
+  if (!generalizationId || typeof generalizationId !== "string") {
+    return fail(res, 400, "generalizationId is required");
+  }
+  if (!targetNodeId || typeof targetNodeId !== "string") {
+    return fail(res, 400, "targetNodeId is required");
+  }
+  if (
+    targetProperty !== "specializations" &&
+    targetProperty !== "generalizations"
+  ) {
+    return fail(
+      res,
+      400,
+      `cloning into "${targetProperty}" is not supported yet`,
+    );
+  }
+
+  try {
+    const [sourceSnap, currentSnap, newSnap] = await Promise.all([
+      db.collection(NODES).doc(generalizationId).get(),
+      db.collection(NODES).doc(targetNodeId).get(),
+      db.collection(NODES).doc(newNodeId).get(),
+    ]);
+    if (newSnap.exists) return fail(res, 409, "newNodeId already exists");
+    const source = sourceSnap.data() as INode | undefined;
+    const currentNode = currentSnap.data() as INode | undefined;
+    if (!source || source.deleted) return fail(res, 404, "Source node not found");
+    if (!currentNode || currentNode.deleted) {
+      return fail(res, 404, "Target node not found");
+    }
+    if (appName && source.appName && source.appName !== appName) {
+      return fail(res, 403, "Source node does not belong to this app");
+    }
+
+    const result = await applyClone({
+      newNodeId,
+      title,
+      source: { ...source, id: generalizationId },
+      currentNode: { ...currentNode, id: targetNodeId },
+      targetProperty,
+      collectionName: collectionName || "main",
+      uname,
+      appName,
+    });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    if (error instanceof HttpError) return fail(res, error.status, error.message);
+    console.error("nodes/hierarchy/cloning error", error);
+    recordLogs(
+      {
+        type: "error",
+        error: JSON.stringify({
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        }),
+        at: "nodes/hierarchy/cloning",
+      },
+      uname,
+    );
+    const message = error?.message || "Internal error";
+    return res.status(500).json({ error: message, message });
+  }
+};
+
+export default fbAuth(handler);

--- a/src/pages/api/nodes/hierarchy/collection.ts
+++ b/src/pages/api/nodes/hierarchy/collection.ts
@@ -1,0 +1,189 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import fbAuth from "@components/middlewares/fbAuth";
+import { db } from "@components/lib/firestoreServer/admin";
+import { NODES } from "@components/lib/firestoreClient/collections";
+import { ICollection, INode, NodeChange } from "@components/types/INode";
+import {
+  HttpError,
+  Side,
+  asCollections,
+  writeSideOrder,
+  writeChangeLog,
+  recordLogs,
+} from "@components/lib/server/hierarchy";
+
+/**
+ * Adds, renames, or deletes a named collection on a node's specializations or
+ * generalizations. The nodes themselves don't move between parents, so there's
+ * no reciprocity, inheritance, cycle, or derived-paths work — just rewrite the
+ * side and log it. Deleting a collection merges its nodes back into `main`.
+ */
+
+type CollectionAction = "add" | "rename" | "delete";
+
+async function applyCollection(ctx: {
+  nodeId: string;
+  nodeData: INode;
+  side: Side;
+  action: CollectionAction;
+  collectionName: string;
+  newName?: string;
+  uname?: string;
+  appName?: string;
+}): Promise<{ ok: true }> {
+  const { nodeId, nodeData, side, action, collectionName, newName, uname, appName } =
+    ctx;
+
+  const previousValue = asCollections(nodeData[side]);
+  const collections: ICollection[] = JSON.parse(JSON.stringify(previousValue));
+
+  let changeType: NodeChange["changeType"];
+  let changeDetails: Record<string, any>;
+
+  if (action === "add") {
+    if (collectionName === "main") {
+      throw new HttpError(400, '"main" is a reserved collection');
+    }
+    if (collections.some((c) => c.collectionName === collectionName)) {
+      throw new HttpError(409, `Collection "${collectionName}" already exists`);
+    }
+    collections.unshift({ collectionName, nodes: [] });
+    changeType = "add collection";
+    changeDetails = { addedCollection: collectionName };
+  } else if (action === "rename") {
+    if (!newName) throw new HttpError(400, "newName is required");
+    if (collectionName === "main" || newName === "main") {
+      throw new HttpError(400, '"main" is a reserved collection');
+    }
+    if (collections.some((c) => c.collectionName === newName)) {
+      throw new HttpError(409, `Collection "${newName}" already exists`);
+    }
+    const target = collections.find((c) => c.collectionName === collectionName);
+    if (!target) {
+      throw new HttpError(404, `Collection "${collectionName}" not found`);
+    }
+    target.collectionName = newName;
+    changeType = "edit collection";
+    changeDetails = { modifiedCollection: collectionName, newValue: newName };
+  } else {
+    if (collectionName === "main") {
+      throw new HttpError(400, '"main" cannot be deleted');
+    }
+    const target = collections.find((c) => c.collectionName === collectionName);
+    if (!target) {
+      throw new HttpError(404, `Collection "${collectionName}" not found`);
+    }
+    let main = collections.find((c) => c.collectionName === "main");
+    if (!main) {
+      main = { collectionName: "main", nodes: [] };
+      collections.unshift(main);
+    }
+    const existing = new Set(main.nodes.map((n) => n.id));
+    for (const node of target.nodes) {
+      if (existing.has(node.id)) continue;
+      main.nodes.push(node);
+      existing.add(node.id);
+    }
+    collections.splice(
+      collections.findIndex((c) => c.collectionName === collectionName),
+      1,
+    );
+    changeType = "delete collection";
+    changeDetails = { deletedCollection: collectionName };
+  }
+
+  await writeSideOrder(nodeId, side, collections);
+
+  if (uname) {
+    await writeChangeLog({
+      nodeId,
+      modifiedBy: uname,
+      modifiedProperty: side,
+      previousValue,
+      newValue: collections,
+      modifiedAt: new Date(),
+      changeType,
+      changeDetails,
+      fullNode: nodeData,
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+
+  return { ok: true };
+}
+
+function fail(res: NextApiResponse, status: number, msg: string) {
+  return res.status(status).json({ error: msg, message: msg });
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "POST") return fail(res, 405, "Method not allowed");
+  const data = req.body.data;
+  const { nodeId, side, action, collectionName, newName, appName, user } = data as {
+    nodeId?: string;
+    side?: Side;
+    action?: CollectionAction;
+    collectionName?: string;
+    newName?: string;
+    appName?: string;
+    user?: any;
+  };
+  const { uname } = user?.userData || {};
+
+  if (!nodeId || typeof nodeId !== "string") {
+    return fail(res, 400, "nodeId is required");
+  }
+  if (side !== "specializations" && side !== "generalizations") {
+    return fail(res, 400, "side must be 'specializations' or 'generalizations'");
+  }
+  if (action !== "add" && action !== "rename" && action !== "delete") {
+    return fail(res, 400, "action must be 'add', 'rename' or 'delete'");
+  }
+  if (!collectionName || typeof collectionName !== "string") {
+    return fail(res, 400, "collectionName is required");
+  }
+  if (action === "rename" && (!newName || typeof newName !== "string")) {
+    return fail(res, 400, "newName is required");
+  }
+
+  try {
+    const nodeData = (await db.collection(NODES).doc(nodeId).get()).data() as
+      | INode
+      | undefined;
+    if (!nodeData || nodeData.deleted) return fail(res, 404, "Node not found");
+    if (appName && nodeData.appName && nodeData.appName !== appName) {
+      return fail(res, 403, "Node does not belong to this app");
+    }
+
+    const result = await applyCollection({
+      nodeId,
+      nodeData,
+      side,
+      action,
+      collectionName,
+      newName,
+      uname,
+      appName,
+    });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    if (error instanceof HttpError) return fail(res, error.status, error.message);
+    console.error("nodes/hierarchy/collection error", error);
+    recordLogs(
+      {
+        type: "error",
+        error: JSON.stringify({
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        }),
+        at: "nodes/hierarchy/collection",
+      },
+      uname,
+    );
+    const message = error?.message || "Internal error";
+    return res.status(500).json({ error: message, message });
+  }
+};
+
+export default fbAuth(handler);

--- a/src/pages/api/nodes/hierarchy/link.ts
+++ b/src/pages/api/nodes/hierarchy/link.ts
@@ -18,6 +18,7 @@ import {
   applyReciprocityAdd,
   applyReciprocityRemove,
   reparentToUnclassified,
+  removeFromUnclassified,
   recomputeInheritance,
   writeChangeLog,
   recordLogs,
@@ -94,6 +95,32 @@ async function applyLink(ctx: ChangeCtx): Promise<{ ok: true }> {
       appName,
       childLogs,
     );
+  }
+
+  // The inverse of reparenting: a node that just gained a real generalization
+  // leaves its root's unclassified collection.
+  if (side === "generalizations") {
+    if (added.length > 0) {
+      await removeFromUnclassified(
+        nodeId,
+        cache,
+        parentLog,
+        uname,
+        appName,
+        childLogs,
+      );
+    }
+  } else {
+    for (const id of added) {
+      await removeFromUnclassified(
+        id,
+        cache,
+        parentLog,
+        uname,
+        appName,
+        childLogs,
+      );
+    }
   }
 
   // Editing generalizations recomputes this node; editing specializations

--- a/src/pages/api/nodes/hierarchy/link.ts
+++ b/src/pages/api/nodes/hierarchy/link.ts
@@ -1,0 +1,203 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import fbAuth from "@components/middlewares/fbAuth";
+import { db } from "@components/lib/firestoreServer/admin";
+import { NODES, NODES_LOGS } from "@components/lib/firestoreClient/collections";
+import { INode, NodeChange } from "@components/types/INode";
+import { updateDerivedPaths } from "@components/lib/server/updateDerivedPaths";
+import {
+  HttpError,
+  Side,
+  ChangeCtx,
+  NodeCache,
+  oppositeOf,
+  asCollections,
+  sanitizeCollections,
+  diffSides,
+  assertNoCycle,
+  collectOrphanReparents,
+  applyReciprocityAdd,
+  applyReciprocityRemove,
+  reparentToUnclassified,
+  recomputeInheritance,
+  writeChangeLog,
+  recordLogs,
+} from "@components/lib/server/hierarchy";
+
+/**
+ * Saves a node's specializations or generalizations. This is the full editor:
+ * the client sends the complete new value for the side, so one save can both
+ * add and remove links.
+ */
+async function applyLink(ctx: ChangeCtx): Promise<{ ok: true }> {
+  const { nodeId, nodeData, side, value, uname, appName } = ctx;
+  const opposite = oppositeOf(side);
+  const cache: NodeCache = new Map([[nodeId, nodeData]]);
+
+  const previousValue = asCollections(nodeData[side]);
+  const { added, removed, newIds } = diffSides(previousValue, value);
+  if (added.length === 0 && removed.length === 0) return { ok: true };
+
+  await assertNoCycle(side, nodeId, added);
+
+  // Work out orphan moves first, so a missing root fails before any write.
+  const reparents = await collectOrphanReparents(
+    side,
+    nodeId,
+    nodeData,
+    removed,
+    newIds,
+    cache,
+  );
+
+  const parentLogId = db.collection(NODES_LOGS).doc().id;
+  const parentLog = {
+    logId: parentLogId,
+    nodeId,
+    nodeTitle: nodeData.title ?? "",
+    changeType: "modify elements" as const,
+  };
+
+  await db.collection(NODES).doc(nodeId).update({ [side]: value });
+
+  const childLogs: NodeChange[] = [];
+  await applyReciprocityRemove(
+    nodeId,
+    opposite,
+    removed,
+    cache,
+    parentLog,
+    uname,
+    appName,
+    childLogs,
+  );
+  await applyReciprocityAdd(
+    nodeId,
+    nodeData.title ?? "",
+    opposite,
+    added,
+    cache,
+    parentLog,
+    uname,
+    appName,
+    childLogs,
+  );
+
+  // Move orphans before recomputing inheritance, so the recompute sees the
+  // root as the new generalization.
+  for (const { orphanId, rootId } of reparents) {
+    await reparentToUnclassified(
+      orphanId,
+      rootId,
+      cache,
+      parentLog,
+      uname,
+      appName,
+      childLogs,
+    );
+  }
+
+  // Editing generalizations recomputes this node; editing specializations
+  // recomputes each child whose generalizations changed.
+  if (side === "generalizations") {
+    cache.delete(nodeId); // re-read so we see the generalizations we just saved
+    await recomputeInheritance(nodeId, cache);
+  } else {
+    for (const id of [...added, ...removed]) {
+      cache.delete(id);
+      await recomputeInheritance(id, cache);
+    }
+  }
+
+  // Only nodes whose generalizations changed need their paths recomputed: this
+  // node when editing generalizations, the added/removed children when editing
+  // specializations. Linked parents and the reparent root keep their own paths.
+  await updateDerivedPaths({
+    db,
+    changedNodeIds:
+      side === "generalizations" ? [nodeId] : [...added, ...removed],
+  });
+
+  if (uname) {
+    await writeChangeLog(
+      {
+        nodeId,
+        modifiedBy: uname,
+        modifiedProperty: side,
+        previousValue,
+        newValue: value,
+        modifiedAt: new Date(),
+        changeType: "modify elements",
+        fullNode: nodeData,
+        ...(appName ? { appName } : {}),
+      } as NodeChange,
+      parentLogId,
+    );
+  }
+  for (const log of childLogs) await writeChangeLog(log);
+
+  return { ok: true };
+}
+
+function fail(res: NextApiResponse, status: number, msg: string) {
+  return res.status(status).json({ error: msg, message: msg });
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "POST") return fail(res, 405, "Method not allowed");
+  const data = req.body.data;
+  const { nodeId, side, appName, user } = data as {
+    nodeId?: string;
+    side?: Side;
+    appName?: string;
+    user?: any;
+  };
+  const { uname } = user?.userData || {};
+
+  if (!nodeId || typeof nodeId !== "string") {
+    return fail(res, 400, "nodeId is required");
+  }
+  if (side !== "specializations" && side !== "generalizations") {
+    return fail(res, 400, "side must be 'specializations' or 'generalizations'");
+  }
+  const value = sanitizeCollections(data.value, nodeId);
+  if (!value) return fail(res, 400, "value must be an array of collections");
+
+  try {
+    const nodeData = (await db.collection(NODES).doc(nodeId).get()).data() as
+      | INode
+      | undefined;
+    if (!nodeData || nodeData.deleted) return fail(res, 404, "Node not found");
+    if (appName && nodeData.appName && nodeData.appName !== appName) {
+      return fail(res, 403, "Node does not belong to this app");
+    }
+
+    const result = await applyLink({
+      nodeId,
+      nodeData,
+      side,
+      value,
+      uname,
+      appName,
+    });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    if (error instanceof HttpError) return fail(res, error.status, error.message);
+    console.error("nodes/hierarchy/link error", error);
+    recordLogs(
+      {
+        type: "error",
+        error: JSON.stringify({
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        }),
+        at: "nodes/hierarchy/link",
+      },
+      uname,
+    );
+    const message = error?.message || "Internal error";
+    return res.status(500).json({ error: message, message });
+  }
+};
+
+export default fbAuth(handler);

--- a/src/pages/api/nodes/hierarchy/move.ts
+++ b/src/pages/api/nodes/hierarchy/move.ts
@@ -1,0 +1,206 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import fbAuth from "@components/middlewares/fbAuth";
+import { db } from "@components/lib/firestoreServer/admin";
+import { NODES, NODES_LOGS } from "@components/lib/firestoreClient/collections";
+import { INode, ICollection, NodeChange } from "@components/types/INode";
+import { updateDerivedPaths } from "@components/lib/server/updateDerivedPaths";
+import {
+  HttpError,
+  NodeCache,
+  asCollections,
+  generalizationIds,
+  assertNoCycle,
+  applyReciprocityAdd,
+  applyReciprocityRemove,
+  removeFromUnclassified,
+  recomputeInheritance,
+  writeChangeLog,
+  recordLogs,
+} from "@components/lib/server/hierarchy";
+
+/**
+ * Relocates a node to a new parent: drops `fromParentId` from its
+ * generalizations and adds `toParentId` (in `toCollectionName` of the new
+ * parent's specializations). Cross-parent only — same-parent reordering and
+ * re-bucketing go through the sort endpoint.
+ */
+async function applyMove(ctx: {
+  nodeId: string;
+  nodeData: INode;
+  fromParentId: string;
+  toParentId: string;
+  toCollectionName: string;
+  uname?: string;
+  appName?: string;
+}): Promise<{ ok: true }> {
+  const {
+    nodeId,
+    nodeData,
+    fromParentId,
+    toParentId,
+    toCollectionName,
+    uname,
+    appName,
+  } = ctx;
+
+  if (fromParentId === toParentId) return { ok: true };
+
+  const previousValue = asCollections(nodeData.generalizations);
+  const currentGens = generalizationIds(nodeData);
+  if (!currentGens.includes(fromParentId)) {
+    throw new HttpError(400, "Node is not a specialization of the source parent");
+  }
+  if (currentGens.includes(toParentId)) {
+    throw new HttpError(409, "Node is already a specialization of the target parent");
+  }
+
+  await assertNoCycle("generalizations", nodeId, [toParentId]);
+
+  // Drop the old parent and add the new one (generalizations are single-collection).
+  const newGens: ICollection[] = previousValue.map((c) => ({
+    ...c,
+    nodes: (c.nodes || []).filter((n) => n.id !== fromParentId),
+  }));
+  let main = newGens.find((c) => c.collectionName === "main");
+  if (!main) {
+    main = { collectionName: "main", nodes: [] };
+    newGens.unshift(main);
+  }
+  main.nodes.push({ id: toParentId, title: "" });
+
+  const cache: NodeCache = new Map([[nodeId, nodeData]]);
+
+  const parentLogId = db.collection(NODES_LOGS).doc().id;
+  const parentLog = {
+    logId: parentLogId,
+    nodeId,
+    nodeTitle: nodeData.title ?? "",
+    changeType: "modify elements" as const,
+  };
+
+  await db.collection(NODES).doc(nodeId).update({ generalizations: newGens });
+
+  const childLogs: NodeChange[] = [];
+  await applyReciprocityRemove(
+    nodeId,
+    "specializations",
+    [fromParentId],
+    cache,
+    parentLog,
+    uname,
+    appName,
+    childLogs,
+  );
+  await applyReciprocityAdd(
+    nodeId,
+    nodeData.title ?? "",
+    "specializations",
+    [toParentId],
+    cache,
+    parentLog,
+    uname,
+    appName,
+    childLogs,
+    toCollectionName,
+  );
+
+  await removeFromUnclassified(nodeId, cache, parentLog, uname, appName, childLogs);
+
+  cache.delete(nodeId); // re-read so recompute sees the new generalizations
+  await recomputeInheritance(nodeId, cache);
+
+  await updateDerivedPaths({ db, changedNodeIds: [nodeId] });
+
+  if (uname) {
+    await writeChangeLog(
+      {
+        nodeId,
+        modifiedBy: uname,
+        modifiedProperty: "generalizations",
+        previousValue,
+        newValue: newGens,
+        modifiedAt: new Date(),
+        changeType: "modify elements",
+        changeDetails: { action: "move", fromParentId, toParentId },
+        fullNode: nodeData,
+        ...(appName ? { appName } : {}),
+      } as NodeChange,
+      parentLogId,
+    );
+  }
+  for (const log of childLogs) await writeChangeLog(log);
+
+  return { ok: true };
+}
+
+function fail(res: NextApiResponse, status: number, msg: string) {
+  return res.status(status).json({ error: msg, message: msg });
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "POST") return fail(res, 405, "Method not allowed");
+  console.log("MOVE STARTED");
+  const data = req.body.data;
+  const { nodeId, fromParentId, toParentId, toCollectionName, appName, user } =
+    data as {
+      nodeId?: string;
+      fromParentId?: string;
+      toParentId?: string;
+      toCollectionName?: string;
+      appName?: string;
+      user?: any;
+    };
+  const { uname } = user?.userData || {};
+
+  if (!nodeId || typeof nodeId !== "string") {
+    return fail(res, 400, "nodeId is required");
+  }
+  if (!fromParentId || typeof fromParentId !== "string") {
+    return fail(res, 400, "fromParentId is required");
+  }
+  if (!toParentId || typeof toParentId !== "string") {
+    return fail(res, 400, "toParentId is required");
+  }
+
+  try {
+    const nodeData = (await db.collection(NODES).doc(nodeId).get()).data() as
+      | INode
+      | undefined;
+    if (!nodeData || nodeData.deleted) return fail(res, 404, "Node not found");
+    if (appName && nodeData.appName && nodeData.appName !== appName) {
+      return fail(res, 403, "Node does not belong to this app");
+    }
+
+    const result = await applyMove({
+      nodeId,
+      nodeData,
+      fromParentId,
+      toParentId,
+      toCollectionName:
+        typeof toCollectionName === "string" ? toCollectionName : "main",
+      uname,
+      appName,
+    });
+    console.log("FINISHED MOVE");
+    return res.status(200).json(result);
+  } catch (error: any) {
+    if (error instanceof HttpError) return fail(res, error.status, error.message);
+    console.error("nodes/hierarchy/move error", error);
+    recordLogs(
+      {
+        type: "error",
+        error: JSON.stringify({
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        }),
+        at: "nodes/hierarchy/move",
+      },
+      uname,
+    );
+    const message = error?.message || "Internal error";
+    return res.status(500).json({ error: message, message });
+  }
+};
+
+export default fbAuth(handler);

--- a/src/pages/api/nodes/hierarchy/move.ts
+++ b/src/pages/api/nodes/hierarchy/move.ts
@@ -139,7 +139,6 @@ function fail(res: NextApiResponse, status: number, msg: string) {
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method !== "POST") return fail(res, 405, "Method not allowed");
-  console.log("MOVE STARTED");
   const data = req.body.data;
   const { nodeId, fromParentId, toParentId, toCollectionName, appName, user } =
     data as {
@@ -181,7 +180,6 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       uname,
       appName,
     });
-    console.log("FINISHED MOVE");
     return res.status(200).json(result);
   } catch (error: any) {
     if (error instanceof HttpError) return fail(res, error.status, error.message);

--- a/src/pages/api/nodes/hierarchy/sort.ts
+++ b/src/pages/api/nodes/hierarchy/sort.ts
@@ -1,0 +1,139 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import fbAuth from "@components/middlewares/fbAuth";
+import { db } from "@components/lib/firestoreServer/admin";
+import { NODES } from "@components/lib/firestoreClient/collections";
+import { ICollection, INode, NodeChange } from "@components/types/INode";
+import {
+  HttpError,
+  Side,
+  asCollections,
+  sanitizeCollections,
+  isSameMembership,
+  writeSideOrder,
+  writeChangeLog,
+  recordLogs,
+} from "@components/lib/server/hierarchy";
+
+/**
+ * Reorders a node's specializations or generalizations: moving nodes within or
+ * between collections, or reordering the collections themselves. The same nodes
+ * stay linked, so it only saves the new order and logs it (no reciprocity,
+ * inheritance, cycle, or derived-paths work).
+ */
+
+type SortType = "elements" | "collections";
+
+/** Builds a string of the current order, used to skip when nothing changed. */
+const orderSignature = (collections: ICollection[]): string =>
+  collections
+    .map((c) => `${c.collectionName}:${c.nodes.map((n) => n.id).join(",")}`)
+    .join("|");
+
+async function applySort(ctx: {
+  nodeId: string;
+  nodeData: INode;
+  side: Side;
+  value: ICollection[];
+  sortType: SortType;
+  changeDetails?: Record<string, any>;
+  uname?: string;
+  appName?: string;
+}): Promise<{ ok: true }> {
+  const { nodeId, nodeData, side, value, sortType, changeDetails, uname, appName } =
+    ctx;
+
+  const previousValue = asCollections(nodeData[side]);
+  if (!isSameMembership(previousValue, value)) {
+    throw new HttpError(400, "Sort can only reorder links, not add or remove them");
+  }
+  if (orderSignature(previousValue) === orderSignature(value)) return { ok: true };
+
+  await writeSideOrder(nodeId, side, value);
+
+  if (uname) {
+    await writeChangeLog({
+      nodeId,
+      modifiedBy: uname,
+      modifiedProperty: side,
+      previousValue,
+      newValue: value,
+      modifiedAt: new Date(),
+      changeType: sortType === "collections" ? "sort collections" : "sort elements",
+      ...(changeDetails ? { changeDetails } : {}),
+      fullNode: nodeData,
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+
+  return { ok: true };
+}
+
+function fail(res: NextApiResponse, status: number, msg: string) {
+  return res.status(status).json({ error: msg, message: msg });
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "POST") return fail(res, 405, "Method not allowed");
+  const data = req.body.data;
+  const { nodeId, side, sortType, appName, user } = data as {
+    nodeId?: string;
+    side?: Side;
+    sortType?: SortType;
+    appName?: string;
+    user?: any;
+  };
+  const { uname } = user?.userData || {};
+
+  if (!nodeId || typeof nodeId !== "string") {
+    return fail(res, 400, "nodeId is required");
+  }
+  if (side !== "specializations" && side !== "generalizations") {
+    return fail(res, 400, "side must be 'specializations' or 'generalizations'");
+  }
+  const value = sanitizeCollections(data.value, nodeId);
+  if (!value) return fail(res, 400, "value must be an array of collections");
+
+  try {
+    const nodeData = (await db.collection(NODES).doc(nodeId).get()).data() as
+      | INode
+      | undefined;
+    if (!nodeData || nodeData.deleted) return fail(res, 404, "Node not found");
+    if (appName && nodeData.appName && nodeData.appName !== appName) {
+      return fail(res, 403, "Node does not belong to this app");
+    }
+
+    const result = await applySort({
+      nodeId,
+      nodeData,
+      side,
+      value,
+      sortType: sortType === "collections" ? "collections" : "elements",
+      changeDetails:
+        data.changeDetails && typeof data.changeDetails === "object"
+          ? data.changeDetails
+          : undefined,
+      uname,
+      appName,
+    });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    if (error instanceof HttpError) return fail(res, error.status, error.message);
+    console.error("nodes/hierarchy/sort error", error);
+    recordLogs(
+      {
+        type: "error",
+        error: JSON.stringify({
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        }),
+        at: "nodes/hierarchy/sort",
+      },
+      uname,
+    );
+    const message = error?.message || "Internal error";
+    return res.status(500).json({ error: message, message });
+  }
+};
+
+export default fbAuth(handler);

--- a/src/pages/api/nodes/hierarchy/unlink.ts
+++ b/src/pages/api/nodes/hierarchy/unlink.ts
@@ -1,0 +1,218 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import fbAuth from "@components/middlewares/fbAuth";
+import { db } from "@components/lib/firestoreServer/admin";
+import { NODES, NODES_LOGS } from "@components/lib/firestoreClient/collections";
+import { ICollection, INode, NodeChange } from "@components/types/INode";
+import { updateDerivedPaths } from "@components/lib/server/updateDerivedPaths";
+import {
+  HttpError,
+  Side,
+  NodeCache,
+  oppositeOf,
+  asCollections,
+  idsOf,
+  collectOrphanReparents,
+  applyReciprocityRemove,
+  reparentToUnclassified,
+  recomputeInheritance,
+  writeChangeLog,
+  recordLogs,
+} from "@components/lib/server/hierarchy";
+
+/**
+ * Removes one or more specialization/generalization links. The client sends
+ * only the ids to remove, so this endpoint can only remove, and concurrent
+ * unlinks are safe in any order. The server handles the rest: reverse links,
+ * moving orphans under their root, inheritance, derived paths, and logs.
+ */
+async function applyUnlink(ctx: {
+  nodeId: string;
+  nodeData: INode;
+  side: Side;
+  removeIds: string[];
+  uname?: string;
+  appName?: string;
+}): Promise<{ ok: true }> {
+  const { nodeId, nodeData, side, removeIds, uname, appName } = ctx;
+  const opposite = oppositeOf(side);
+  const cache: NodeCache = new Map([[nodeId, nodeData]]);
+
+  const previousValue = asCollections(nodeData[side]);
+  const toRemove = new Set(removeIds);
+  const removed: string[] = [];
+  const value: ICollection[] = previousValue.map((c) => ({
+    ...c,
+    nodes: (c.nodes || []).filter((n) => {
+      if (toRemove.has(n.id)) {
+        removed.push(n.id);
+        return false;
+      }
+      return true;
+    }),
+  }));
+  if (removed.length === 0) return { ok: true };
+
+  const newIds = idsOf(value);
+
+  // Work out orphan moves first, so a missing root fails before any write.
+  const reparents = await collectOrphanReparents(
+    side,
+    nodeId,
+    nodeData,
+    removed,
+    newIds,
+    cache,
+  );
+
+  const parentLogId = db.collection(NODES_LOGS).doc().id;
+  const parentLog = {
+    logId: parentLogId,
+    nodeId,
+    nodeTitle: nodeData.title ?? "",
+    changeType: "modify elements" as const,
+  };
+
+  await db.collection(NODES).doc(nodeId).update({ [side]: value });
+
+  const childLogs: NodeChange[] = [];
+  await applyReciprocityRemove(
+    nodeId,
+    opposite,
+    removed,
+    cache,
+    parentLog,
+    uname,
+    appName,
+    childLogs,
+  );
+
+  // Move orphans before recomputing inheritance, so the recompute sees the
+  // root as the new generalization.
+  for (const { orphanId, rootId } of reparents) {
+    await reparentToUnclassified(
+      orphanId,
+      rootId,
+      cache,
+      parentLog,
+      uname,
+      appName,
+      childLogs,
+    );
+  }
+
+  // Editing generalizations recomputes this node; editing specializations
+  // recomputes each removed child whose generalizations changed.
+  if (side === "generalizations") {
+    cache.delete(nodeId);
+    await recomputeInheritance(nodeId, cache);
+  } else {
+    for (const id of removed) {
+      cache.delete(id);
+      await recomputeInheritance(id, cache);
+    }
+  }
+
+  // Only nodes whose generalizations changed need their paths recomputed: this
+  // node when editing generalizations, the removed children when editing
+  // specializations. The old parent and the reparent root keep their own paths.
+  await updateDerivedPaths({
+    db,
+    changedNodeIds: side === "generalizations" ? [nodeId] : removed,
+  });
+
+  if (uname) {
+    await writeChangeLog(
+      {
+        nodeId,
+        modifiedBy: uname,
+        modifiedProperty: side,
+        previousValue,
+        newValue: value,
+        modifiedAt: new Date(),
+        changeType: "modify elements",
+        fullNode: nodeData,
+        ...(appName ? { appName } : {}),
+      } as NodeChange,
+      parentLogId,
+    );
+  }
+  for (const log of childLogs) await writeChangeLog(log);
+
+  return { ok: true };
+}
+
+function fail(res: NextApiResponse, status: number, msg: string) {
+  return res.status(status).json({ error: msg, message: msg });
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "POST") return fail(res, 405, "Method not allowed");
+  const data = req.body.data;
+  const { nodeId, side, appName, user } = data as {
+    nodeId?: string;
+    side?: Side;
+    appName?: string;
+    user?: any;
+  };
+  const { uname } = user?.userData || {};
+
+  if (!nodeId || typeof nodeId !== "string") {
+    return fail(res, 400, "nodeId is required");
+  }
+  if (side !== "specializations" && side !== "generalizations") {
+    return fail(res, 400, "side must be 'specializations' or 'generalizations'");
+  }
+  const rawIds: any[] | null = Array.isArray(data.removeIds)
+    ? data.removeIds
+    : typeof data.removeId === "string"
+      ? [data.removeId]
+      : null;
+  if (!rawIds || !rawIds.length || !rawIds.every((id) => typeof id === "string")) {
+    return fail(res, 400, "removeIds must be a non-empty array of node ids");
+  }
+  const removeIds: string[] = [
+    ...new Set(rawIds.filter((id) => id !== nodeId) as string[]),
+  ];
+  if (removeIds.length === 0) {
+    return fail(res, 400, "removeIds must reference other nodes");
+  }
+
+  try {
+    const nodeData = (await db.collection(NODES).doc(nodeId).get()).data() as
+      | INode
+      | undefined;
+    if (!nodeData || nodeData.deleted) return fail(res, 404, "Node not found");
+    if (appName && nodeData.appName && nodeData.appName !== appName) {
+      return fail(res, 403, "Node does not belong to this app");
+    }
+
+    const result = await applyUnlink({
+      nodeId,
+      nodeData,
+      side,
+      removeIds,
+      uname,
+      appName,
+    });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    if (error instanceof HttpError) return fail(res, error.status, error.message);
+    console.error("nodes/hierarchy/unlink error", error);
+    recordLogs(
+      {
+        type: "error",
+        error: JSON.stringify({
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        }),
+        at: "nodes/hierarchy/unlink",
+      },
+      uname,
+    );
+    const message = error?.message || "Internal error";
+    return res.status(500).json({ error: message, message });
+  }
+};
+
+export default fbAuth(handler);

--- a/src/pages/api/nodes/properties/update.ts
+++ b/src/pages/api/nodes/properties/update.ts
@@ -17,10 +17,17 @@ import { ICollection, INode, NodeChange } from "@components/types/INode";
 
 /**
  * Single endpoint for generic node-property operations — add / delete /
- * rename / change / change-links — selected by `action` in the request body.
+ * rename / change / change-links / sort-links — selected by `action` in the
+ * request body.
  */
 
-type PropertyAction = "add" | "delete" | "rename" | "change" | "change-links";
+type PropertyAction =
+  | "add"
+  | "delete"
+  | "rename"
+  | "change"
+  | "change-links"
+  | "sort-links";
 
 type OperationContext = {
   nodeId: string;
@@ -736,12 +743,154 @@ async function changeLinks(
   return { ok: true, changedProperty: cleanName };
 }
 
+/** Validates incoming collections; returns null if malformed. */
+function sanitizeLinkCollections(
+  value: any,
+  selfId: string,
+): ICollection[] | null {
+  if (!Array.isArray(value)) return null;
+  const seen = new Set<string>();
+  const out: ICollection[] = [];
+  for (const c of value) {
+    if (!c || typeof c.collectionName !== "string" || !Array.isArray(c.nodes)) {
+      return null;
+    }
+    const nodes = [];
+    for (const n of c.nodes) {
+      if (!n || typeof n.id !== "string") return null;
+      if (n.id === selfId || seen.has(n.id)) continue; // skip self-links and dupes
+      seen.add(n.id);
+      nodes.push({
+        id: n.id,
+        title: typeof n.title === "string" ? n.title : "",
+      });
+    }
+    out.push({ collectionName: c.collectionName, nodes });
+  }
+  return out;
+}
+
+/** Every node id across all collections. */
+function idsOf(collections: ICollection[]): Set<string> {
+  return new Set(collections.flatMap((c) => c.nodes.map((n) => n.id)));
+}
+
+/** Builds a string of the current order, used to skip when nothing changed. */
+function orderSignature(collections: ICollection[]): string {
+  return collections
+    .map((c) => `${c.collectionName}:${c.nodes.map((n) => n.id).join(",")}`)
+    .join("|");
+}
+
+/**
+ * Reorders the nodes of a link-typed property. The same nodes stay linked, so
+ * back-links are untouched. If the value was inherited, reordering it becomes an
+ * override (a child can't reorder a value stored on its parent), so the ref is
+ * broken and inheriting descendants re-point here.
+ */
+async function sortLinks(
+  ctx: OperationContext,
+): Promise<{ ok: true; changedProperty: string }> {
+  const { nodeId, nodeData, data, uname, appName } = ctx;
+
+  const nameError = validatePropertyName(data?.propertyName);
+  if (nameError) throw new HttpError(400, nameError);
+  const cleanName = (data.propertyName as string).trim();
+
+  if (!hasOwn(nodeData.properties, cleanName)) {
+    throw new HttpError(404, `Property "${cleanName}" not found on this node`);
+  }
+  const propertyType = (nodeData.propertyType as any)?.[cleanName];
+  if (propertyType === "string" || CHANGE_TYPES.has(propertyType)) {
+    throw new HttpError(
+      400,
+      `Property "${cleanName}" (type "${propertyType ?? "unknown"}") is not link-typed`,
+    );
+  }
+
+  // Reorder the value the user saw: while inheriting, that lives on the
+  // referenced node, not this node's own (stale) copy.
+  const inheritedRef = nodeData.inheritance?.[cleanName]?.ref;
+  let refData: INode | undefined;
+  if (inheritedRef) {
+    refData = (await db.collection(NODES).doc(inheritedRef).get()).data() as
+      | INode
+      | undefined;
+  }
+  let baseRaw: any =
+    refData && hasOwn(refData.properties, cleanName)
+      ? refData.properties[cleanName]
+      : nodeData.properties[cleanName];
+  if (!Array.isArray(baseRaw) || baseRaw.length === 0) {
+    baseRaw = [{ collectionName: "main", nodes: [] }];
+  }
+  const previousValue: ICollection[] = JSON.parse(JSON.stringify(baseRaw));
+
+  const value = sanitizeLinkCollections(data.value, nodeId);
+  if (!value) throw new HttpError(400, "value must be an array of collections");
+
+  // A sort may only reorder; it must not add or remove links.
+  const prevIds = idsOf(previousValue);
+  const nextIds = idsOf(value);
+  const sameMembership =
+    prevIds.size === nextIds.size && [...prevIds].every((id) => nextIds.has(id));
+  if (!sameMembership) {
+    throw new HttpError(400, "Sort can only reorder links, not add or remove them");
+  }
+  if (orderSignature(previousValue) === orderSignature(value)) {
+    return { ok: true, changedProperty: cleanName };
+  }
+
+  const wasInheriting = !!inheritedRef;
+  const nodeUpdates: Record<string, any> = {
+    [`properties.${cleanName}`]: value,
+  };
+  if (wasInheriting) {
+    nodeUpdates[`inheritance.${cleanName}.ref`] = null;
+    nodeUpdates[`inheritance.${cleanName}.title`] = "";
+    if (refData?.textValue && hasOwn(refData.textValue, cleanName)) {
+      nodeUpdates[`textValue.${cleanName}`] = refData.textValue[cleanName];
+    }
+  }
+  if (uname && uname !== "ouhrac") {
+    nodeUpdates.contributors = FieldValue.arrayUnion(uname);
+    nodeUpdates[`contributorsByProperty.${cleanName}`] =
+      FieldValue.arrayUnion(uname);
+  }
+  await db.collection(NODES).doc(nodeId).update(nodeUpdates);
+
+  // When newly overriding, re-point inheriting descendants at this node.
+  if (wasInheriting) {
+    await rewireInheritingDescendants(nodeId, nodeData.title ?? "", cleanName);
+  }
+
+  if (uname) {
+    await writeChangeLog({
+      nodeId,
+      modifiedBy: uname,
+      modifiedProperty: cleanName,
+      previousValue,
+      newValue: value,
+      modifiedAt: new Date(),
+      changeType: "sort elements",
+      ...(data.changeDetails && typeof data.changeDetails === "object"
+        ? { changeDetails: data.changeDetails }
+        : {}),
+      fullNode: nodeData,
+      ...(appName ? { appName } : {}),
+    } as NodeChange);
+  }
+
+  return { ok: true, changedProperty: cleanName };
+}
+
 const ACTIONS: PropertyAction[] = [
   "add",
   "delete",
   "rename",
   "change",
   "change-links",
+  "sort-links",
 ];
 
 function fail(res: NextApiResponse, status: number, msg: string) {
@@ -794,6 +943,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         break;
       case "change-links":
         result = await changeLinks(ctx);
+        break;
+      case "sort-links":
+        result = await sortLinks(ctx);
         break;
     }
 


### PR DESCRIPTION
Hi @samadouhra

This PR moves specializations and generalizations editing from client-side Firestore writes to backend endpoints.

Changes include:

* Added hierarchy endpoints under `/nodes/hierarchy/` for each editing action:
    * `link`
    * `unlink`
    * `cloning`
    * `sort`
    * `collection`
    * `move`
* Added shared server logic in `src/lib/server/hierarchy.ts` to handle the common hierarchy work, including:
    * keeping reverse links in sync
    * recomputing inheritance
    * preventing cycles
    * reparenting orphaned nodes
    * logging changes
* Routed all specialization/generalization editing actions through these endpoints instead of direct Firestore writes:
    * selection modal add/remove links → `link` / `unlink`
    * per-chip removal (under `CollectionStructure`) → `unlink`
    * “Add Specialization” cloning and linking flow → `cloning`
    * drag-reordering nodes and collections → `sort`
    * dragging a node between collections under the same parent → `sort`
    * adding, renaming, and deleting a collection → `collection`
    * dragging and nesting a node under a new parent in the detail panel → `move`
    * dragging nodes across parents in the tree → `move`
    * tree reordering, moving across collections, collection reordering, and cross-parent moves → `sort` / `move`
    
Notes

* Moved the heavier hierarchy work to the server so the browser no longer needs to run recursive cross-node writes for these edits.
* When a node loses its last generalization, it is now moved under its type’s root in an unclassified collection instead of being dropped.
* Kept instant local UI updates, with revert and error handling if the backend update fails.
* Prevented incoming snapshots from overwriting edits that are still in progress.
* Dragging a node under one of its own descendants is now rejected and the outline reverts, instead of creating a cycle.
* Reordering generic link properties, such as actor, now goes through `/nodes/properties/update` using a new sort-links action.