### PR TITLE
Fix cloning: place new nodes in the root's unclassified collection

### DIFF
--- a/src/components/OntologyComponents/Node.tsx
+++ b/src/components/OntologyComponents/Node.tsx
@@ -572,7 +572,11 @@ const Node = ({
     return [];
   }, [searchValue, selectedProperty, currentVisibleNode, searchWithFuse]);
 
-  const addACloneNodeQueue = async (nodeId: string, title?: string) => {
+  const addACloneNodeQueue = async (
+    nodeId: string,
+    title?: string,
+    sourceCollection?: string,
+  ) => {
     let node: INode | null = relatedNodes[nodeId] || null;
     if (!node) {
       const fetchedNode = await fetchNode(nodeId);
@@ -586,10 +590,20 @@ const Node = ({
     const newTitle = title ? title : `New ${node.title}`;
     setClonedNodesQueue(
       (prev: {
-        [nodeId: string]: { title: string; id: string; property: string };
+        [nodeId: string]: {
+          title: string;
+          id: string;
+          property: string;
+          sourceCollection?: string;
+        };
       }) => ({
         ...prev,
-        [newId]: { title: newTitle, id: nodeId, property: selectedProperty },
+        [newId]: {
+          title: newTitle,
+          id: nodeId,
+          property: selectedProperty,
+          ...(sourceCollection ? { sourceCollection } : {}),
+        },
       }),
     );
     setNewOnes((newOnes: any) => {

--- a/src/components/StructuredProperty/StructuredProperty.tsx
+++ b/src/components/StructuredProperty/StructuredProperty.tsx
@@ -618,6 +618,7 @@ const StructuredProperty = ({
           targetNodeId: targetId,
           targetProperty: property,
           collectionName,
+          sourceCollectionName: (queued as any).sourceCollection || "main",
           ...(appName ? { appName } : {}),
         });
         await Post("/triggerChroma", { nodeId: nId, update: true });

--- a/src/components/StructuredProperty/StructuredPropertySelector.tsx
+++ b/src/components/StructuredProperty/StructuredPropertySelector.tsx
@@ -22,7 +22,7 @@ import Text from "../OntologyComponents/Text";
 import {
   SCROLL_BAR_STYLE,
   DISPLAY,
-  UNCLASSIFIED,
+  UNCLASSIFIED_COLLECTION,
   development,
 } from "@components/lib/CONSTANTS";
 import { capitalizeFirstLetter } from "@components/lib/utils/string.utils";
@@ -122,10 +122,16 @@ const StructuredPropertySelector = ({
   addACloneNodeQueue: (
     nodeId: string,
     title?: string,
+    sourceCollection?: string,
   ) => Promise<string | null>;
   setClonedNodesQueue: Function;
   clonedNodesQueue: {
-    [nodeId: string]: { title: string; id: string; property: string };
+    [nodeId: string]: {
+      title: string;
+      id: string;
+      property: string;
+      sourceCollection?: string;
+    };
   };
   newOnes: any;
   setNewOnes: any;
@@ -492,23 +498,6 @@ const StructuredPropertySelector = ({
     );
   };
 
-  const getCreateNewButtonText = useMemo(() => {
-    let nodeType = currentVisibleNode.propertyType[selectedProperty];
-    if (
-      selectedProperty === "specializations" ||
-      selectedProperty === "generalizations" ||
-      selectedProperty === "parts" ||
-      selectedProperty === "isPartOf"
-    ) {
-      nodeType = currentVisibleNode.nodeType;
-    }
-    return UNCLASSIFIED[nodeType];
-  }, [
-    currentVisibleNode.nodeType,
-    currentVisibleNode.propertyType,
-    selectedProperty,
-  ]);
-
   const getNumOfGeneralizations = (id: string) => {
     if (!relatedNodes[id] || newOnes.has(id)) {
       return false;
@@ -740,8 +729,12 @@ const StructuredPropertySelector = ({
   //   selectedDiffNode,
   // ]) as ICollection[];
 
-  const _add = async (nodeId: string, title?: string) => {
-    const id = await addACloneNodeQueue(nodeId, title);
+  const _add = async (
+    nodeId: string,
+    title?: string,
+    sourceCollection?: string,
+  ) => {
+    const id = await addACloneNodeQueue(nodeId, title, sourceCollection);
     if (!id) {
       return null;
     }
@@ -803,20 +796,26 @@ const StructuredPropertySelector = ({
     ) {
       nodeType = currentVisibleNode.nodeType;
     }
-    const unclassifiedNodeDocs = await getDocs(
-      query(
-        collection(db, NODES),
-        where("unclassified", "==", true),
-        where("nodeType", "==", nodeType),
-      ),
-    );
-    // Pick the first non-deleted candidate.
-    const candidate = unclassifiedNodeDocs.docs.find(
-      (d) => (d.data() as any).deleted !== true,
-    );
-    if (candidate) {
-      await _add(candidate.id, searchValue);
+    // A new node with no natural parent goes under the type root's
+    // "unclassified" collection (created on the root if missing), not under a
+    // dedicated unclassified node.
+    const constraints: any[] = [
+      where("root", "==", true),
+      where("nodeType", "==", nodeType),
+      where("deleted", "==", false),
+    ];
+    if (appName) constraints.push(where("appName", "==", appName));
+    const rootDocs = await getDocs(query(collection(db, NODES), ...constraints));
+    const rootId = rootDocs.docs[0]?.id;
+    if (!rootId) {
+      confirmIt(
+        "No root node was found to place the new node under.",
+        "Ok",
+        "",
+      );
+      return;
     }
+    await _add(rootId, searchValue, UNCLASSIFIED_COLLECTION);
   };
 
   const approveQueuedCloneFromSource = (sourceNodeId: string) => {
@@ -1015,11 +1014,11 @@ const StructuredPropertySelector = ({
                 />
               </Box>
               <Tooltip
-                title={`Create as a new Specialization ${
-                  selectedProperty !== "specializations"
-                    ? `Under ${getCreateNewButtonText}`
-                    : ""
-                } Node`}
+                title={
+                  selectedProperty === "specializations"
+                    ? "Create a new specialization of this node"
+                    : `Create a new node under the "Unclassified" collection`
+                }
               >
                 <Button
                   onClick={async () => {

--- a/src/pages/api/nodes/hierarchy/cloning.ts
+++ b/src/pages/api/nodes/hierarchy/cloning.ts
@@ -82,6 +82,7 @@ async function applyClone(ctx: {
   currentNode: INode;
   targetProperty: string;
   collectionName: string;
+  sourceCollectionName: string;
   uname?: string;
   appName?: string;
 }): Promise<{ ok: true; nodeId: string }> {
@@ -92,6 +93,7 @@ async function applyClone(ctx: {
     currentNode,
     targetProperty,
     collectionName,
+    sourceCollectionName,
     uname,
     appName,
   } = ctx;
@@ -163,7 +165,9 @@ async function applyClone(ctx: {
   const sourceSpecs: ICollection[] = JSON.parse(
     JSON.stringify(sourceSpecsBefore),
   );
-  addToMain(sourceSpecs, { id: newNodeId, title });
+  // When the node has no parent when created from properties other than "specializations",
+  // adds it to "unclassified" collection of the root 
+  addToSide(sourceSpecs, sourceCollectionName, { id: newNodeId, title });
   await db
     .collection(NODES)
     .doc(sourceId)
@@ -329,6 +333,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     targetNodeId,
     targetProperty,
     collectionName,
+    sourceCollectionName,
     appName,
     user,
   } = data as {
@@ -338,6 +343,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     targetNodeId?: string;
     targetProperty?: string;
     collectionName?: string;
+    sourceCollectionName?: string;
     appName?: string;
     user?: any;
   };
@@ -400,6 +406,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       currentNode: { ...currentNode, id: targetNodeId },
       targetProperty,
       collectionName: collectionName || "main",
+      sourceCollectionName: sourceCollectionName || "main",
       uname,
       appName,
     });


### PR DESCRIPTION
Hi @samadouhra

This PR fixes an issue where new nodes with no natural parent (created for generalizations, parts, and generic "activity" properties) when the searched node doesn't exist are placed under the "unclassified" node instead of the "unclassified" collection of their respective roots.

Changes:

- Above nodes are now placed under the type root's "unclassified" collection (created automatically if missing), instead of under a separate "unclassified" node. 
- Updated the "Create" button tooltip to reflect the new placement and removed the unused unclassified-node label helper.