### PR TITLE
Show complete review queues and preserve revision history

### DIFF
--- a/__tests__/components/SomReview/ReviewHistorySelect.test.tsx
+++ b/__tests__/components/SomReview/ReviewHistorySelect.test.tsx
@@ -20,7 +20,7 @@ const history: SomReviewHistoryItem[] = [
   },
   {
     proposalId: "proposal-2",
-    proposalIndex: 1,
+    proposalIndex: 10,
     question: "Is the second activity misplaced?",
     decision: "disagree",
     disagreementReason: "It belongs here.",
@@ -59,7 +59,7 @@ describe("Review history selector", () => {
     );
     fireEvent.click(
       screen.getByRole("option", {
-        name: /Item 2: Is the second activity misplaced\? Current answer: Disagreed/,
+        name: /Item 11: Is the second activity misplaced\? Current answer: Disagreed/,
       }),
     );
 
@@ -75,6 +75,6 @@ describe("Review history selector", () => {
       />,
     );
 
-    expect(screen.getByText("Revising item 2")).toBeInTheDocument();
+    expect(screen.getByText("Revising item 11")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/SomReview/ReviewQueueSelector.test.tsx
+++ b/__tests__/components/SomReview/ReviewQueueSelector.test.tsx
@@ -24,6 +24,7 @@ const option = (
   stage,
   robTaskIds,
   total: 1,
+  reviewed: 0,
   pending: 1,
   waiting: 0,
   notApplicable: 0,
@@ -34,6 +35,7 @@ const option = (
 const issues: SomIssueTypeOption[] = [
   option("title-clarity", "1. Clarify unclear titles", "content", [1], {
     total: 47,
+    reviewed: 10,
     pending: 37,
     activeSession: { cursor: 3, total: 10 },
   }),
@@ -119,9 +121,13 @@ describe("Society of Mind review queue selector", () => {
     expect(screen.getByText("Movement outside Sell")).toBeInTheDocument();
     expect(screen.getByText("Exact actions")).toBeInTheDocument();
     expect(screen.getByText("Additional quality checks")).toBeInTheDocument();
-    expect(screen.getByText("In progress: item 4 of 10")).toBeInTheDocument();
     expect(
-      screen.getByText("In progress: item 4 of 10").closest(".MuiChip-root"),
+      screen.getByText("In progress: 10 of 47 reviewed"),
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getByText("In progress: 10 of 47 reviewed")
+        .closest(".MuiChip-root"),
     ).toHaveClass("MuiChip-outlined");
     expect(
       screen.getByText("16 ready to review").closest(".MuiChip-root"),

--- a/__tests__/components/SomReview/ReviewQueueSelector.test.tsx
+++ b/__tests__/components/SomReview/ReviewQueueSelector.test.tsx
@@ -119,9 +119,9 @@ describe("Society of Mind review queue selector", () => {
     expect(screen.getByText("Movement outside Sell")).toBeInTheDocument();
     expect(screen.getByText("Exact actions")).toBeInTheDocument();
     expect(screen.getByText("Additional quality checks")).toBeInTheDocument();
-    expect(screen.getByText("In progress: 4 of 10")).toBeInTheDocument();
+    expect(screen.getByText("In progress: item 4 of 10")).toBeInTheDocument();
     expect(
-      screen.getByText("In progress: 4 of 10").closest(".MuiChip-root"),
+      screen.getByText("In progress: item 4 of 10").closest(".MuiChip-root"),
     ).toHaveClass("MuiChip-outlined");
     expect(
       screen.getByText("16 ready to review").closest(".MuiChip-root"),

--- a/__tests__/lib/somReview/dataset.test.ts
+++ b/__tests__/lib/somReview/dataset.test.ts
@@ -1,8 +1,6 @@
 import path from "path";
 
 import {
-  DEFAULT_SESSION_SIZE,
-  MAX_SESSION_SIZE,
   SUPPORTED_ISSUE_TYPES,
   compileResponseValidator,
   isIssueTypeEnabled,
@@ -307,11 +305,6 @@ describe("Society of Mind review dataset", () => {
     } else {
       process.env.SOM_REVIEW_DISABLED_ISSUE_TYPES = previous;
     }
-  });
-
-  it("keeps review sessions small", () => {
-    expect(DEFAULT_SESSION_SIZE).toBe(10);
-    expect(MAX_SESSION_SIZE).toBe(15);
   });
 
   it("rejects unbounded reviewer text", () => {

--- a/__tests__/lib/somReview/reviewHistory.test.ts
+++ b/__tests__/lib/somReview/reviewHistory.test.ts
@@ -1,0 +1,39 @@
+import { orderedReviewEntries } from "../../../src/lib/somReview/reviewHistory";
+
+describe("Society of Mind review history", () => {
+  it("keeps responses from earlier and later sessions in stable issue order", () => {
+    const orderedProposalIds = Array.from(
+      { length: 15 },
+      (_, index) => `proposal-${index + 1}`,
+    );
+    const responses = new Map([
+      ["proposal-2", { decision: "agree" }],
+      ["proposal-10", { decision: "disagree" }],
+      ["proposal-11", { decision: "agree" }],
+      ["proposal-15", { decision: "agree" }],
+    ]);
+
+    expect(orderedReviewEntries(orderedProposalIds, responses)).toEqual([
+      {
+        proposalId: "proposal-2",
+        proposalIndex: 1,
+        response: { decision: "agree" },
+      },
+      {
+        proposalId: "proposal-10",
+        proposalIndex: 9,
+        response: { decision: "disagree" },
+      },
+      {
+        proposalId: "proposal-11",
+        proposalIndex: 10,
+        response: { decision: "agree" },
+      },
+      {
+        proposalId: "proposal-15",
+        proposalIndex: 14,
+        response: { decision: "agree" },
+      },
+    ]);
+  });
+});

--- a/__tests__/lib/somReview/sessionState.test.ts
+++ b/__tests__/lib/somReview/sessionState.test.ts
@@ -1,5 +1,6 @@
 import {
   isResumableSession,
+  mergeReadyProposalIds,
   planResponseTransition,
   planUndoTransition,
   reviewedProposalIndex,
@@ -12,6 +13,17 @@ const session = {
 };
 
 describe("Society of Mind session transitions", () => {
+  it("includes the complete ready queue and expands older capped sessions", () => {
+    const completeQueue = Array.from(
+      { length: 47 },
+      (_, index) => `proposal-${index + 1}`,
+    );
+    expect(mergeReadyProposalIds([], completeQueue)).toEqual(completeQueue);
+    expect(
+      mergeReadyProposalIds(completeQueue.slice(0, 10), completeQueue),
+    ).toEqual(completeQueue);
+  });
+
   it("advances the current item and completes the final item", () => {
     expect(planResponseTransition(session, "a", false)).toEqual({
       cursor: 1,

--- a/src/components/SomReview/ReviewQueueSelector.tsx
+++ b/src/components/SomReview/ReviewQueueSelector.tsx
@@ -118,7 +118,7 @@ const QueueStatus = ({ issue }: { issue: SomIssueTypeOption }) => {
   if (issue.activeSession) {
     return (
       <Chip
-        label={`In progress: ${issue.activeSession.cursor + 1} of ${issue.activeSession.total}`}
+        label={`In progress: item ${issue.activeSession.cursor + 1} of ${issue.activeSession.total}`}
         size="small"
         variant="outlined"
         sx={activeQueueStatusSx}

--- a/src/components/SomReview/ReviewQueueSelector.tsx
+++ b/src/components/SomReview/ReviewQueueSelector.tsx
@@ -116,9 +116,10 @@ const QueueStatus = ({ issue }: { issue: SomIssueTypeOption }) => {
     );
   }
   if (issue.activeSession) {
+    const availableTotal = issue.reviewed + issue.pending;
     return (
       <Chip
-        label={`In progress: item ${issue.activeSession.cursor + 1} of ${issue.activeSession.total}`}
+        label={`In progress: ${issue.reviewed} of ${availableTotal} reviewed`}
         size="small"
         variant="outlined"
         sx={activeQueueStatusSx}

--- a/src/lib/somReview/dataset.ts
+++ b/src/lib/somReview/dataset.ts
@@ -48,9 +48,6 @@ export const proposalAvailability = (
   return "ready";
 };
 
-export const DEFAULT_SESSION_SIZE = 10;
-export const MAX_SESSION_SIZE = 15;
-
 export interface SomDataset {
   datasetVersion: string;
   manifest: any;

--- a/src/lib/somReview/reviewHistory.ts
+++ b/src/lib/somReview/reviewHistory.ts
@@ -1,0 +1,17 @@
+export interface IndexedReviewEntry<T> {
+  proposalId: string;
+  proposalIndex: number;
+  response: T;
+}
+
+/** Returns all saved responses in the issue type's stable proposal order. */
+export const orderedReviewEntries = <T>(
+  orderedProposalIds: string[],
+  responses: Map<string, T>,
+): IndexedReviewEntry<T>[] =>
+  orderedProposalIds.flatMap((proposalId, proposalIndex) => {
+    const response = responses.get(proposalId);
+    return response === undefined
+      ? []
+      : [{ proposalId, proposalIndex, response }];
+  });

--- a/src/lib/somReview/sessionState.ts
+++ b/src/lib/somReview/sessionState.ts
@@ -18,6 +18,24 @@ export const isResumableSession = (
   session.cursor < session.proposalIds.length;
 
 /**
+ * Keeps the existing session order while adding every newly available proposal.
+ * This lets an older, previously capped session grow into the complete queue.
+ */
+export const mergeReadyProposalIds = (
+  existingProposalIds: string[],
+  readyProposalIds: string[],
+): string[] => {
+  const included = new Set(existingProposalIds);
+  const merged = [...existingProposalIds];
+  for (const proposalId of readyProposalIds) {
+    if (included.has(proposalId)) continue;
+    included.add(proposalId);
+    merged.push(proposalId);
+  }
+  return merged;
+};
+
+/**
  * Plans a response write while allowing a lost-network-response retry to be a
  * no-op. Stale changed responses and future-card responses are rejected.
  */

--- a/src/lib/somReview/store.ts
+++ b/src/lib/somReview/store.ts
@@ -13,7 +13,6 @@ import {
   mergeReadyProposalIds,
   planResponseTransition,
   planUndoTransition,
-  reviewedProposalIndex,
 } from "./sessionState";
 
 export interface SessionDoc {
@@ -92,6 +91,7 @@ const reviewerDecisions = async (
 };
 
 export interface PendingSummary {
+  reviewed: number;
   pending: number;
   waiting: number;
   notApplicable: number;
@@ -108,12 +108,16 @@ export const pendingSummary = async (
     reviewerDecisions(dataset.datasetVersion, reviewerId),
   ]);
   const summary: PendingSummary = {
+    reviewed: 0,
     pending: 0,
     waiting: 0,
     notApplicable: 0,
   };
   for (const id of all) {
-    if (answered.has(id)) continue;
+    if (answered.has(id)) {
+      summary.reviewed += 1;
+      continue;
+    }
     const availability = proposalAvailability(
       dataset.recordsById.get(id),
       decisions,
@@ -369,66 +373,53 @@ export const saveResponse = async (
   });
 };
 
-/** Returns current responses for proposals in this session, keyed by ID. */
-export const sessionResponses = async (
-  session: StoredSession,
+/** Returns every current response for one reviewer and issue type, keyed by ID. */
+export const issueResponses = async (
+  datasetVersion: string,
+  issueType: SomIssueType,
+  reviewerId: string,
 ): Promise<Map<string, ResponsePayload>> => {
-  const proposalIds = new Set(session.proposalIds);
   const snapshot = await db
     .collection(SOM_REVIEW_RESPONSES)
-    .where("datasetVersion", "==", session.datasetVersion)
-    .where("issueType", "==", session.issueType)
-    .where("reviewerId", "==", session.reviewerId)
+    .where("datasetVersion", "==", datasetVersion)
+    .where("issueType", "==", issueType)
+    .where("reviewerId", "==", reviewerId)
     .where("status", "==", "current")
     .get();
   return new Map(
     snapshot.docs
       .map((doc) => doc.data() as StoredResponseDoc)
-      .filter(
-        (record) =>
-          proposalIds.has(record.proposalId) && Boolean(record.response),
-      )
+      .filter((record) => Boolean(record.response))
       .map((record) => [record.proposalId, record.response]),
   );
 };
 
 /**
- * Replaces one prior answer in place, appends an audit revision, and leaves
- * the reviewer's current queue position unchanged.
+ * Replaces any prior answer for this reviewer and issue type and appends an
+ * audit revision. Revisions are intentionally independent of review sessions
+ * so judgments from completed sessions remain editable.
  */
 export const reviseResponse = async (
-  sessionId: string,
   issueType: SomIssueType,
   payload: ResponsePayload,
 ): Promise<{ changed: boolean }> => {
   return db.runTransaction(async (transaction) => {
-    const sessionRef = db.collection(SOM_REVIEW_SESSIONS).doc(sessionId);
-    const [responseSnap, sessionSnap] = await Promise.all([
-      transaction.get(
-        currentResponseQuery(
-          payload.datasetVersion,
-          payload.proposalId,
-          payload.reviewerId,
-        ),
+    const responseSnap = await transaction.get(
+      currentResponseQuery(
+        payload.datasetVersion,
+        payload.proposalId,
+        payload.reviewerId,
       ),
-      transaction.get(sessionRef),
-    ]);
-    if (!sessionSnap.exists) throw new Error("Review session was not found");
-    const session = sessionSnap.data() as SessionDoc;
-    if (
-      session.datasetVersion !== payload.datasetVersion ||
-      session.issueType !== issueType ||
-      session.reviewerId !== payload.reviewerId
-    ) {
-      throw new Error("Review session does not match this response");
-    }
-    reviewedProposalIndex(session, payload.proposalId);
+    );
     if (responseSnap.empty) {
       throw new Error("The prior response could not be found");
     }
 
     const responseDoc = responseSnap.docs[0];
     const existing = responseDoc.data() as StoredResponseDoc;
+    if (existing.issueType !== issueType) {
+      throw new Error("The prior response belongs to another issue type");
+    }
     const identical =
       existing.response.decision === payload.decision &&
       (existing.response.disagreementReason || "") ===
@@ -453,7 +444,6 @@ export const reviseResponse = async (
       response: payload,
       createdAt: now,
     });
-    transaction.update(sessionRef, { updatedAt: now });
     return { changed: true };
   });
 };

--- a/src/lib/somReview/store.ts
+++ b/src/lib/somReview/store.ts
@@ -7,14 +7,10 @@ import {
   SOM_REVIEW_SESSIONS,
 } from "../firestoreClient/collections";
 import { SomIssueType } from "../../types/ISomReview";
-import {
-  DEFAULT_SESSION_SIZE,
-  MAX_SESSION_SIZE,
-  SomDataset,
-  proposalAvailability,
-} from "./dataset";
+import { SomDataset, proposalAvailability } from "./dataset";
 import {
   isResumableSession,
+  mergeReadyProposalIds,
   planResponseTransition,
   planUndoTransition,
   reviewedProposalIndex,
@@ -138,26 +134,38 @@ export const pendingCount = async (
 };
 
 export const activeSessionProgress = async (
-  datasetVersion: string,
+  dataset: SomDataset,
   issueType: SomIssueType,
   reviewerId: string,
 ): Promise<{ cursor: number; total: number } | null> => {
   const snapshot = await activeSessionQuery(
-    datasetVersion,
+    dataset.datasetVersion,
     issueType,
     reviewerId,
   ).get();
   if (snapshot.empty) return null;
   const session = snapshot.docs[0].data() as SessionDoc;
   if (!isResumableSession(session)) return null;
-  return { cursor: session.cursor, total: session.proposalIds.length };
+
+  const [answered, decisions] = await Promise.all([
+    answeredProposalIds(dataset.datasetVersion, issueType, reviewerId),
+    reviewerDecisions(dataset.datasetVersion, reviewerId),
+  ]);
+  const ready = (dataset.orderedIdsByIssue.get(issueType) || []).filter(
+    (proposalId) =>
+      !answered.has(proposalId) &&
+      proposalAvailability(dataset.recordsById.get(proposalId), decisions) ===
+        "ready",
+  );
+  const proposalIds = mergeReadyProposalIds(session.proposalIds, ready);
+  return { cursor: session.cursor, total: proposalIds.length };
 };
 
 /**
  * Returns the reviewer's unfinished session for this issue type, or builds a
- * new one of up to DEFAULT_SESSION_SIZE unanswered records (hard cap 15,
- * single issue type, deterministic order from the dataset). Completed
- * sessions are kept as history; only "active" sessions are resumed.
+ * new one containing every currently ready unanswered record for that issue
+ * type, in deterministic dataset order. Completed sessions are kept as
+ * history; only "active" sessions are resumed.
  */
 export const getOrCreateSession = async (
   dataset: SomDataset,
@@ -183,7 +191,28 @@ export const getOrCreateSession = async (
           ) === "ready",
       );
     if (isResumableSession(session) && remainingReady) {
-      return { ...session, id: existingDoc.id };
+      const all = dataset.orderedIdsByIssue.get(issueType) || [];
+      const answered = await answeredProposalIds(
+        dataset.datasetVersion,
+        issueType,
+        reviewerId,
+      );
+      const ready = all.filter(
+        (proposalId) =>
+          !answered.has(proposalId) &&
+          proposalAvailability(
+            dataset.recordsById.get(proposalId),
+            decisions,
+          ) === "ready",
+      );
+      const proposalIds = mergeReadyProposalIds(session.proposalIds, ready);
+      if (proposalIds.length !== session.proposalIds.length) {
+        await existingDoc.ref.update({
+          proposalIds,
+          updatedAt: Timestamp.now(),
+        });
+      }
+      return { ...session, proposalIds, id: existingDoc.id };
     }
     if (session.status === "active") {
       await existingDoc.ref.update({
@@ -206,13 +235,12 @@ export const getOrCreateSession = async (
   );
   if (ready.length === 0) return null;
 
-  const size = Math.min(DEFAULT_SESSION_SIZE, MAX_SESSION_SIZE, ready.length);
   const now = Timestamp.now();
   const session: SessionDoc = {
     datasetVersion: dataset.datasetVersion,
     issueType,
     reviewerId,
-    proposalIds: ready.slice(0, size),
+    proposalIds: mergeReadyProposalIds([], ready),
     cursor: 0,
     status: "active",
     createdAt: now,

--- a/src/pages/api/som-review/overview.ts
+++ b/src/pages/api/som-review/overview.ts
@@ -27,7 +27,7 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
               pendingSummary(dataset, issueType, reviewerId),
               activeSessionProgress(dataset, issueType, reviewerId),
             ])
-          : [{ pending: 0, waiting: 0, notApplicable: 0 }, null];
+          : [{ reviewed: 0, pending: 0, waiting: 0, notApplicable: 0 }, null];
         return {
           id: issueType,
           label: issue.label,

--- a/src/pages/api/som-review/overview.ts
+++ b/src/pages/api/som-review/overview.ts
@@ -25,11 +25,7 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
         const [summary, activeSession] = enabled
           ? await Promise.all([
               pendingSummary(dataset, issueType, reviewerId),
-              activeSessionProgress(
-                dataset.datasetVersion,
-                issueType,
-                reviewerId,
-              ),
+              activeSessionProgress(dataset, issueType, reviewerId),
             ])
           : [{ pending: 0, waiting: 0, notApplicable: 0 }, null];
         return {

--- a/src/pages/api/som-review/revise.ts
+++ b/src/pages/api/som-review/revise.ts
@@ -20,8 +20,6 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
     const dataset = getDataset();
     const data = reviewRequestData(req.body);
     const payload = data.response as ResponsePayload;
-    const sessionId = typeof data.sessionId === "string" ? data.sessionId : "";
-    if (!sessionId) return res.status(400).json({ error: "Missing sessionId" });
     if (!payload)
       return res.status(400).json({ error: "Missing response payload" });
 
@@ -54,11 +52,7 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
         .json({ error: "Disagree requires a non-whitespace reason" });
     }
 
-    const { changed } = await reviseResponse(
-      sessionId,
-      record.issueType,
-      payload,
-    );
+    const { changed } = await reviseResponse(record.issueType, payload);
     const body: SomReviseResult = { ok: true, changed };
     return res.status(200).json(body);
   } catch (error: any) {

--- a/src/pages/api/som-review/session.ts
+++ b/src/pages/api/som-review/session.ts
@@ -4,10 +4,11 @@ import fbAuth, { CustomNextApiRequest } from "../../../middlewares/fbAuth";
 import { getDataset, isIssueTypeEnabled } from "../../../lib/somReview/dataset";
 import {
   getOrCreateSession,
-  sessionResponses,
+  issueResponses,
 } from "../../../lib/somReview/store";
 import { toReviewerCard } from "../../../lib/somReview/sanitize";
 import { reviewRequestData } from "../../../lib/somReview/request";
+import { orderedReviewEntries } from "../../../lib/somReview/reviewHistory";
 import { SomIssueType, SomSessionResponse } from "../../../types/ISomReview";
 
 const handler = async (request: NextApiRequest, res: NextApiResponse) => {
@@ -28,15 +29,47 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
     }
 
     const session = await getOrCreateSession(dataset, issueType, req.user.uid);
+    const orderedProposalIds = dataset.orderedIdsByIssue.get(issueType) || [];
+    const proposalIndexes = new Map(
+      orderedProposalIds.map((proposalId, index) => [proposalId, index]),
+    );
+    const responses = await issueResponses(
+      dataset.datasetVersion,
+      issueType,
+      req.user.uid,
+    );
+    const history = orderedReviewEntries(orderedProposalIds, responses).flatMap(
+      ({ proposalId, proposalIndex, response }) => {
+        const record = dataset.recordsById.get(proposalId);
+        if (!record) return [];
+        const card = toReviewerCard(record);
+        return [
+          {
+            proposalId,
+            proposalIndex,
+            question: card.reviewerView.question,
+            decision: response.decision,
+            disagreementReason: response.disagreementReason || "",
+            suggestedCorrection: response.suggestedCorrection || "",
+            reviewedAt: response.reviewedAt,
+          },
+        ];
+      },
+    );
+    const historyCards = history.map((item) => ({
+      ...toReviewerCard(dataset.recordsById.get(item.proposalId)),
+      proposalIndex: item.proposalIndex,
+    }));
+
     if (!session) {
-      const body: SomSessionResponse = { done: true };
+      const body: SomSessionResponse = { done: true, history, historyCards };
       return res.status(200).json(body);
     }
 
-    const cards = session.proposalIds.map((id) =>
-      toReviewerCard(dataset.recordsById.get(id)),
-    );
-    const responses = await sessionResponses(session);
+    const cards = session.proposalIds.map((id) => ({
+      ...toReviewerCard(dataset.recordsById.get(id)),
+      proposalIndex: proposalIndexes.get(id),
+    }));
     const body: SomSessionResponse = {
       session: {
         id: session.id,
@@ -46,24 +79,8 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
         total: session.proposalIds.length,
       },
       cards,
-      history: session.proposalIds
-        .slice(0, session.cursor)
-        .flatMap((proposalId, proposalIndex) => {
-          const response = responses.get(proposalId);
-          const card = cards[proposalIndex];
-          if (!response || !card) return [];
-          return [
-            {
-              proposalId,
-              proposalIndex,
-              question: card.reviewerView.question,
-              decision: response.decision,
-              disagreementReason: response.disagreementReason || "",
-              suggestedCorrection: response.suggestedCorrection || "",
-              reviewedAt: response.reviewedAt,
-            },
-          ];
-        }),
+      history,
+      historyCards,
     };
     return res.status(200).json(body);
   } catch (error: any) {

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -522,7 +522,7 @@ export const ReviewPage = () => {
                     component="h1"
                     sx={{ fontWeight: 800 }}
                   >
-                    Review set complete
+                    Review type complete
                   </Typography>
                   <Typography sx={{ mt: 0.75, color: "text.secondary" }}>
                     {cards.length} {cards.length === 1 ? "item" : "items"}{" "}
@@ -555,7 +555,7 @@ export const ReviewPage = () => {
                       onClick={() => startSession(issueType)}
                       sx={{ minHeight: 50, fontWeight: 750 }}
                     >
-                      Review another set
+                      Check for new proposals
                     </Button>
                   )}
                 </Stack>

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -49,6 +49,7 @@ export const ReviewPage = () => {
   const [cards, setCards] = useState<SomReviewCard[]>([]);
   const [cursor, setCursor] = useState(0);
   const [history, setHistory] = useState<SomReviewHistoryItem[]>([]);
+  const [historyCards, setHistoryCards] = useState<SomReviewCard[]>([]);
   const [revisionProposalId, setRevisionProposalId] = useState("");
   const [loadError, setLoadError] = useState("");
   const [canDeliberate, setCanDeliberate] = useState(false);
@@ -86,20 +87,19 @@ export const ReviewPage = () => {
         issueType: issue,
       });
       setIssueType(issue);
+      setHistory(result.history || []);
+      setHistoryCards(result.historyCards || []);
+      setRevisionProposalId("");
       if (result.done || !result.session || !result.cards?.length) {
         setSessionId("");
         setCards([]);
         setCursor(0);
-        setHistory([]);
-        setRevisionProposalId("");
         setPhase("empty");
         return;
       }
       setSessionId(result.session.id);
       setCards(result.cards);
       setCursor(result.session.cursor);
-      setHistory(result.history || []);
-      setRevisionProposalId("");
       setPhase(
         result.session.cursor >= result.cards.length ? "complete" : "session",
       );
@@ -185,9 +185,11 @@ export const ReviewPage = () => {
           ),
           {
             proposalId: card.proposalId,
-            proposalIndex: cards.findIndex(
-              (candidate) => candidate.proposalId === card.proposalId,
-            ),
+            proposalIndex:
+              card.proposalIndex ??
+              cards.findIndex(
+                (candidate) => candidate.proposalId === card.proposalId,
+              ),
             question: card.reviewerView.question,
             decision: submission.decision,
             disagreementReason: submission.disagreementReason,
@@ -195,6 +197,16 @@ export const ReviewPage = () => {
             reviewedAt,
           },
         ].sort((left, right) => left.proposalIndex - right.proposalIndex),
+      );
+      setHistoryCards((currentCards) =>
+        currentCards.some(
+          (historyCard) => historyCard.proposalId === card.proposalId,
+        )
+          ? currentCards
+          : [...currentCards, card].sort(
+              (left, right) =>
+                (left.proposalIndex ?? 0) - (right.proposalIndex ?? 0),
+            ),
       );
       setCursor(result.cursor);
       if (result.completed) setPhase("complete");
@@ -206,7 +218,7 @@ export const ReviewPage = () => {
     (item) => item.proposalId === revisionProposalId,
   );
   const revisionCard = revisionItem
-    ? cards.find((card) => card.proposalId === revisionItem.proposalId)
+    ? historyCards.find((card) => card.proposalId === revisionItem.proposalId)
     : undefined;
 
   const submitRevision = useCallback(
@@ -215,9 +227,11 @@ export const ReviewPage = () => {
         (candidate) => candidate.proposalId === revisionProposalId,
       );
       const card = item
-        ? cards.find((candidate) => candidate.proposalId === item.proposalId)
+        ? historyCards.find(
+            (candidate) => candidate.proposalId === item.proposalId,
+          )
         : undefined;
-      if (!item || !card || !sessionId || !user?.userId) {
+      if (!item || !card || !user?.userId) {
         throw new Error("The earlier review is unavailable");
       }
 
@@ -225,7 +239,6 @@ export const ReviewPage = () => {
       const result = await Post<SomReviseResult>(
         "/som-review/revise",
         {
-          sessionId,
           response: {
             schemaVersion: "som-review-v1",
             datasetVersion: card.datasetVersion,
@@ -255,11 +268,30 @@ export const ReviewPage = () => {
               : historyItem,
           ),
         );
+        if (issueType) {
+          await startSession(issueType);
+          return;
+        }
       }
       setRevisionProposalId("");
-      setPhase(cursor >= cards.length ? "complete" : "session");
+      setPhase(
+        cards.length === 0
+          ? "empty"
+          : cursor >= cards.length
+            ? "complete"
+            : "session",
+      );
     },
-    [cards, cursor, history, revisionProposalId, sessionId, user?.userId],
+    [
+      cards.length,
+      cursor,
+      history,
+      historyCards,
+      issueType,
+      revisionProposalId,
+      startSession,
+      user?.userId,
+    ],
   );
 
   const selectRevision = useCallback(
@@ -274,7 +306,13 @@ export const ReviewPage = () => {
 
   const cancelRevision = useCallback(() => {
     setRevisionProposalId("");
-    setPhase(cursor >= cards.length ? "complete" : "session");
+    setPhase(
+      cards.length === 0
+        ? "empty"
+        : cursor >= cards.length
+          ? "complete"
+          : "session",
+    );
   }, [cards.length, cursor]);
 
   const exitToSelector = useCallback(() => {
@@ -283,6 +321,7 @@ export const ReviewPage = () => {
     setCards([]);
     setCursor(0);
     setHistory([]);
+    setHistoryCards([]);
     setRevisionProposalId("");
     setRetryIssueType(null);
     loadOverview();
@@ -292,6 +331,9 @@ export const ReviewPage = () => {
   const activeCard = revisionCard || currentCard;
   const selectedIssue = issueTypes.find((issue) => issue.id === issueType);
   const issueLabel = selectedIssue?.label || "Proposal review";
+  const issueTotal = selectedIssue?.total || cards.length;
+  const availableReviewTotal =
+    history.length + Math.max(0, cards.length - cursor);
 
   return (
     <>
@@ -426,19 +468,28 @@ export const ReviewPage = () => {
                     {revisionItem ? (
                       <>
                         Revising item {revisionItem.proposalIndex + 1} of{" "}
-                        {cards.length}
+                        {issueTotal}
                       </>
                     ) : (
                       <>
-                        Item {cursor + 1} of {cards.length}
+                        Item {(currentCard?.proposalIndex ?? cursor) + 1} of{" "}
+                        {issueTotal}
                       </>
                     )}
                   </Typography>
                 </Stack>
                 <LinearProgress
                   variant="determinate"
-                  value={(cursor / cards.length) * 100}
-                  aria-label={`${cursor} of ${cards.length} items completed`}
+                  value={
+                    availableReviewTotal === 0
+                      ? 100
+                      : (history.length / availableReviewTotal) * 100
+                  }
+                  aria-label={
+                    availableReviewTotal === 0
+                      ? "All available items completed"
+                      : `${history.length} of ${availableReviewTotal} items completed`
+                  }
                   sx={{ height: 8, borderRadius: 1 }}
                 />
               </Stack>
@@ -462,9 +513,10 @@ export const ReviewPage = () => {
                   <strong>
                     {revisionItem.decision === "agree" ? "Agreed" : "Disagreed"}
                   </strong>
-                  . No change is made until you submit a revised answer. Your
-                  progress remains at {cursor} of {cards.length} items
-                  completed.
+                  . No change is made until you submit a revised answer.{" "}
+                  {cards.length === 0
+                    ? "All currently available proposals remain reviewed."
+                    : `Your progress remains at ${history.length} of ${availableReviewTotal} items completed.`}
                 </Alert>
               )}
               <ReviewCard
@@ -525,8 +577,9 @@ export const ReviewPage = () => {
                     Review type complete
                   </Typography>
                   <Typography sx={{ mt: 0.75, color: "text.secondary" }}>
-                    {cards.length} {cards.length === 1 ? "item" : "items"}{" "}
-                    reviewed
+                    {history.length}{" "}
+                    {history.length === 1 ? "judgment" : "judgments"} available
+                    to revise
                   </Typography>
                 </Box>
                 <ReviewHistorySelect
@@ -579,8 +632,20 @@ export const ReviewPage = () => {
                   component="h1"
                   sx={{ fontWeight: 800 }}
                 >
-                  Nothing left in this review type
+                  All available proposals reviewed
                 </Typography>
+                <Typography sx={{ color: "text.secondary" }}>
+                  {history.length > 0
+                    ? `You can revise any of your ${history.length} saved ${
+                        history.length === 1 ? "judgment" : "judgments"
+                      } below.`
+                    : "No proposals are currently available for this review type."}
+                </Typography>
+                <ReviewHistorySelect
+                  history={history}
+                  selectedProposalId={revisionProposalId}
+                  onSelect={selectRevision}
+                />
                 <Button
                   disableElevation
                   variant="outlined"

--- a/src/types/ISomReview.ts
+++ b/src/types/ISomReview.ts
@@ -179,6 +179,8 @@ export interface SomReviewCard {
   proposalId: string;
   datasetVersion: string;
   issueType: SomIssueType;
+  /** Zero-based position within the complete issue-type queue. */
+  proposalIndex?: number;
   reviewerView: {
     question: string;
     currentState: string;
@@ -195,6 +197,7 @@ export interface SomIssueTypeOption {
   label: string;
   stage: SomReviewStage;
   robTaskIds: number[];
+  reviewed: number;
   pending: number;
   waiting: number;
   notApplicable: number;
@@ -219,6 +222,7 @@ export interface SomSessionResponse {
   session?: SomSessionState;
   cards?: SomReviewCard[];
   history?: SomReviewHistoryItem[];
+  historyCards?: SomReviewCard[];
 }
 
 export interface SomReviewHistoryItem {


### PR DESCRIPTION
## Summary
- remove the hidden 10-item review-session cap
- expand existing capped sessions to every currently ready proposal
- load saved judgments across all completed and active sessions for an issue type
- allow any prior judgment to be revised, including after the queue is complete
- preserve issue-wide numbering and refresh dependent proposals after revisions
- show overall reviewed-versus-ready progress instead of session-local progress

## Verification
- `npx jest --runInBand __tests__/lib/somReview __tests__/components/SomReview` (18 suites, 90 tests)
- targeted ESLint on every changed file
- no TypeScript errors in changed production files
- local `/review` returns HTTP 200