### PR TITLE
Improve linked follow-up and revision workflows

### DIFF
--- a/__tests__/components/SomReview/ReviewFollowUpPanel.test.tsx
+++ b/__tests__/components/SomReview/ReviewFollowUpPanel.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import ReviewFollowUpPanel from "../../../src/components/SomReview/ReviewFollowUpPanel";
+import { SomLinkedFollowUp } from "../../../src/types/ISomReview";
+
+const followUp: SomLinkedFollowUp = {
+  proposalId: "relocation-1",
+  issueType: "relocation",
+  issueLabel: "Apply approved relocations",
+  question: 'Should "Sell Contract" move to "Sign Contract"?',
+  sources: [
+    {
+      proposalId: "placement-1",
+      issueType: "placement",
+      issueLabel: "11. Wrong place within Sell",
+      question: 'Is "Sell Contract" misplaced under "Sell"?',
+    },
+  ],
+};
+
+describe("linked follow-up panel", () => {
+  it("opens the exact related proposal from the persistent overview", () => {
+    const onReview = jest.fn();
+    render(<ReviewFollowUpPanel followUps={[followUp]} onReview={onReview} />);
+
+    expect(screen.getByText("Ready related decisions")).toBeInTheDocument();
+    expect(screen.getByText(followUp.question)).toBeInTheDocument();
+    expect(
+      screen.getByText("Follows 11. Wrong place within Sell"),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: `Review this next: ${followUp.question}`,
+      }),
+    );
+    expect(onReview).toHaveBeenCalledWith(followUp);
+  });
+
+  it("lets a reviewer deliberately continue the original queue", () => {
+    const onContinue = jest.fn();
+    render(
+      <ReviewFollowUpPanel
+        variant="handoff"
+        sourceLabel="11. Wrong place within Sell"
+        followUps={[followUp]}
+        onReview={jest.fn()}
+        onContinue={onContinue}
+        continueLabel="Continue 11. Wrong place within Sell"
+      />,
+    );
+
+    expect(
+      screen.getByText("Continue with the related decision"),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Continue 11. Wrong place within Sell",
+      }),
+    );
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
+++ b/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { Post } from "../../../src/lib/utils/Post";
+import { ReviewPage } from "../../../src/pages/review";
+import {
+  SomLinkedFollowUp,
+  SomReviewCard,
+} from "../../../src/types/ISomReview";
+
+jest.mock("../../../src/lib/utils/Post", () => ({
+  Post: jest.fn(),
+}));
+
+jest.mock("../../../src/components/context/AuthContext", () => {
+  const authState = { user: { userId: "reviewer-1" } };
+  return { useAuth: () => [authState] };
+});
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("../../../src/components/hoc/withAuthUser", () => ({
+  __esModule: true,
+  default: () => (Component: React.ComponentType) => Component,
+}));
+
+jest.mock("../../../src/components/SomReview/ThemeModeToggle", () => ({
+  __esModule: true,
+  default: () => <button type="button">Theme</button>,
+}));
+
+jest.mock("../../../src/components/SomReview/ReviewHistorySelect", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("../../../src/components/SomReview/ReviewCard", () => ({
+  __esModule: true,
+  default: ({ card, onSubmit }: any) => (
+    <button
+      type="button"
+      onClick={() =>
+        onSubmit({
+          decision: "agree",
+          disagreementReason: "",
+          suggestedCorrection: "",
+          elapsedMs: 100,
+        })
+      }
+    >
+      Submit {card.proposalId}
+    </button>
+  ),
+}));
+
+const card = (
+  proposalId: string,
+  issueType: "placement" | "relocation",
+  question: string,
+): SomReviewCard => ({
+  proposalId,
+  datasetVersion: "dataset-1",
+  issueType,
+  proposalIndex: 0,
+  reviewerView: {
+    question,
+    currentState: "Current",
+    proposedState: "Proposed",
+    reasoning: "Reason",
+    context:
+      issueType === "placement"
+        ? {
+            type: "placement-comparison",
+            nodeTitle: "Sell Contract",
+            currentParentTitle: "Sell",
+            placementIssue: "wrong-parent",
+          }
+        : {
+            type: "relocation-action",
+            nodeTitle: "Sell Contract",
+            currentParentTitle: "Sell",
+            currentCollection: "main",
+            proposedParentTitle: "Sign Contract",
+            proposedCollection: "main",
+            childTitles: [],
+          },
+    agreeLabel: "Agree",
+    disagreeLabel: "Disagree",
+  },
+});
+
+const diagnosis = card(
+  "placement-1",
+  "placement",
+  'Is "Sell Contract" misplaced under "Sell"?',
+);
+const action = card(
+  "relocation-1",
+  "relocation",
+  'Should "Sell Contract" move from "Sell" to "Sign Contract"?',
+);
+const followUp: SomLinkedFollowUp = {
+  proposalId: action.proposalId,
+  issueType: "relocation",
+  issueLabel: "Apply approved relocations",
+  question: action.reviewerView.question,
+  sources: [
+    {
+      proposalId: diagnosis.proposalId,
+      issueType: "placement",
+      issueLabel: "11. Wrong place within Sell",
+      question: diagnosis.reviewerView.question,
+    },
+  ],
+};
+
+describe("linked proposal review journey", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.setItem(
+      "som-review-task-intro-dataset-1-placement",
+      "seen",
+    );
+  });
+
+  it("opens the exact follow-up and returns to the preserved source queue", async () => {
+    const postMock = Post as jest.Mock;
+    postMock.mockImplementation((url: string, body: any) => {
+      if (url === "/som-review/overview") {
+        return Promise.resolve({
+          datasetVersion: "dataset-1",
+          canDeliberate: false,
+          readyFollowUps: [],
+          issueTypes: [
+            {
+              id: "placement",
+              label: "11. Wrong place within Sell",
+              stage: "within-branch",
+              robTaskIds: [11],
+              reviewed: 0,
+              pending: 1,
+              waiting: 0,
+              notApplicable: 0,
+              total: 1,
+              enabled: true,
+            },
+            {
+              id: "relocation",
+              label: "Apply approved relocations",
+              stage: "final-action",
+              robTaskIds: [11],
+              reviewed: 0,
+              pending: 0,
+              waiting: 1,
+              notApplicable: 0,
+              total: 1,
+              enabled: true,
+            },
+          ],
+        });
+      }
+      if (url === "/som-review/session" && body.issueType === "placement") {
+        return Promise.resolve({
+          session: {
+            id: "placement-session",
+            issueType: "placement",
+            datasetVersion: "dataset-1",
+            cursor: 0,
+            total: 1,
+          },
+          cards: [diagnosis],
+          history: [],
+          historyCards: [],
+        });
+      }
+      if (url === "/som-review/session" && body.issueType === "relocation") {
+        return Promise.resolve({
+          focusedProposalId: "relocation-1",
+          session: {
+            id: "relocation-session",
+            issueType: "relocation",
+            datasetVersion: "dataset-1",
+            cursor: 0,
+            total: 1,
+          },
+          cards: [action],
+          history: [],
+          historyCards: [],
+        });
+      }
+      if (
+        url === "/som-review/respond" &&
+        body.response.proposalId === "placement-1"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          cursor: 1,
+          completed: true,
+          followUps: [followUp],
+        });
+      }
+      if (
+        url === "/som-review/respond" &&
+        body.response.proposalId === "relocation-1"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          cursor: 1,
+          completed: true,
+          followUps: [],
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    render(<ReviewPage />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Start 11. Wrong place within Sell review, 1 remaining",
+      }),
+    );
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/som-review/session", {
+        issueType: "placement",
+      }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Submit placement-1" }),
+    );
+
+    expect(
+      await screen.findByText("Continue with the related decision"),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: `Review this next: ${followUp.question}`,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/som-review/session", {
+        issueType: "relocation",
+        preferredProposalId: "relocation-1",
+      }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Submit relocation-1" }),
+    );
+
+    expect(
+      await screen.findByText("Related decisions completed"),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Return to 11. Wrong place within Sell",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenLastCalledWith("/som-review/session", {
+        issueType: "placement",
+      }),
+    );
+  });
+});

--- a/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
+++ b/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
@@ -37,7 +37,21 @@ jest.mock("../../../src/components/SomReview/ThemeModeToggle", () => ({
 
 jest.mock("../../../src/components/SomReview/ReviewHistorySelect", () => ({
   __esModule: true,
-  default: () => null,
+  default: ({ history, onSelect, selectedProposalId }: any) => {
+    if (!history.length) return null;
+    const item = history[1] || history[0];
+    return (
+      <button
+        type="button"
+        aria-label={`Open saved answer ${item.proposalIndex + 1}`}
+        onClick={() => onSelect(item.proposalId)}
+      >
+        {selectedProposalId
+          ? `Revising item ${item.proposalIndex + 1}`
+          : "Open a saved answer"}
+      </button>
+    );
+  },
 }));
 
 jest.mock("../../../src/components/SomReview/ReviewCard", () => ({
@@ -63,11 +77,12 @@ const card = (
   proposalId: string,
   issueType: "placement" | "relocation",
   question: string,
+  proposalIndex = 0,
 ): SomReviewCard => ({
   proposalId,
   datasetVersion: "dataset-1",
   issueType,
-  proposalIndex: 0,
+  proposalIndex,
   reviewerView: {
     question,
     currentState: "Current",
@@ -268,5 +283,98 @@ describe("linked proposal review journey", () => {
         issueType: "placement",
       }),
     );
+  });
+
+  it("replaces queue progress with an unambiguous saved-answer status while revising", async () => {
+    const postMock = Post as jest.Mock;
+    const queueCards = Array.from({ length: 47 }, (_, index) =>
+      card(
+        `placement-${index + 1}`,
+        "placement",
+        `Is proposal ${index + 1} misplaced?`,
+        index,
+      ),
+    );
+    const savedHistory = queueCards.slice(0, 30).map((savedCard, index) => ({
+      proposalId: savedCard.proposalId,
+      proposalIndex: index,
+      question: savedCard.reviewerView.question,
+      decision: "agree" as const,
+      disagreementReason: "",
+      suggestedCorrection: "",
+      reviewedAt: `2026-07-16T10:${String(index).padStart(2, "0")}:00.000Z`,
+    }));
+
+    postMock.mockImplementation((url: string, body: any) => {
+      if (url === "/som-review/overview") {
+        return Promise.resolve({
+          datasetVersion: "dataset-1",
+          canDeliberate: false,
+          readyFollowUps: [],
+          issueTypes: [
+            {
+              id: "placement",
+              label: "11. Wrong place within Sell",
+              stage: "within-branch",
+              robTaskIds: [11],
+              reviewed: 30,
+              pending: 17,
+              waiting: 0,
+              notApplicable: 0,
+              total: 47,
+              enabled: true,
+              activeSession: { cursor: 30, total: 47 },
+            },
+          ],
+        });
+      }
+      if (url === "/som-review/session" && body.issueType === "placement") {
+        return Promise.resolve({
+          session: {
+            id: "placement-session",
+            issueType: "placement",
+            datasetVersion: "dataset-1",
+            cursor: 30,
+            total: 47,
+          },
+          cards: queueCards,
+          history: savedHistory,
+          historyCards: queueCards.slice(0, 30),
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    render(<ReviewPage />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Resume 11. Wrong place within Sell review, 17 remaining",
+      }),
+    );
+
+    expect(
+      await screen.findByRole("progressbar", {
+        name: "30 of 47 items completed",
+      }),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open saved answer 2" }),
+    );
+
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    expect(screen.getByText("Saved item 2 of 47")).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", {
+        name: "Reviewing saved item 2 of 47. Queue progress remains 30 of 47 reviewed.",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Reviewing a saved answer")).toBeInTheDocument();
+    expect(
+      screen.getByText("Queue remains 30 of 47 reviewed"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Keep saved answer" }),
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/components/SomReview/ReviewQueueSelector.test.tsx
+++ b/__tests__/components/SomReview/ReviewQueueSelector.test.tsx
@@ -9,6 +9,7 @@ import ReviewQueueSelector from "../../../src/components/SomReview/ReviewQueueSe
 import {
   SomIssueType,
   SomIssueTypeOption,
+  SomLinkedFollowUp,
   SomReviewStage,
 } from "../../../src/types/ISomReview";
 
@@ -110,6 +111,21 @@ const issues: SomIssueTypeOption[] = [
   }),
 ];
 
+const readyFollowUp: SomLinkedFollowUp = {
+  proposalId: "relocation-1",
+  issueType: "relocation",
+  issueLabel: "Apply approved relocations",
+  question: 'Should "Sell Contract" move to "Sign Contract"?',
+  sources: [
+    {
+      proposalId: "placement-1",
+      issueType: "placement",
+      issueLabel: "11. Wrong place within Sell",
+      question: 'Is "Sell Contract" misplaced under "Sell"?',
+    },
+  ],
+};
+
 describe("Society of Mind review queue selector", () => {
   it("shows every task and action queue in its workflow stage", () => {
     render(<ReviewQueueSelector issueTypes={issues} onStart={jest.fn()} />);
@@ -157,6 +173,25 @@ describe("Society of Mind review queue selector", () => {
         name: "Apply approved node merges; review its related diagnosis first",
       }),
     ).toBeDisabled();
+  });
+
+  it("keeps postponed linked actions directly accessible", () => {
+    const onStartFollowUp = jest.fn();
+    render(
+      <ReviewQueueSelector
+        issueTypes={issues}
+        onStart={jest.fn()}
+        readyFollowUps={[readyFollowUp]}
+        onStartFollowUp={onStartFollowUp}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: `Review this next: ${readyFollowUp.question}`,
+      }),
+    );
+    expect(onStartFollowUp).toHaveBeenCalledWith(readyFollowUp);
   });
 
   it("shows the deliberation entry only for authorized reviewers", () => {

--- a/__tests__/lib/somReview/followUps.test.ts
+++ b/__tests__/lib/somReview/followUps.test.ts
@@ -1,0 +1,74 @@
+import path from "path";
+
+import { loadDataset } from "../../../src/lib/somReview/dataset";
+import {
+  readyDependentRecords,
+  toLinkedFollowUps,
+} from "../../../src/lib/somReview/followUps";
+
+describe("Society of Mind linked follow-ups", () => {
+  const dataset = loadDataset(
+    path.join(
+      process.cwd(),
+      "Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15",
+      "review-datasets",
+    ),
+  );
+  const relocation = [...dataset.recordsById.values()].find(
+    (record) => record.issueType === "relocation",
+  );
+  const sourceProposalId = relocation.workflow.dependsOnProposalIds[0];
+
+  it("returns the exact action unlocked by an agreed diagnosis", () => {
+    const records = readyDependentRecords(
+      dataset,
+      new Map([[sourceProposalId, "agree"]]),
+      sourceProposalId,
+    );
+
+    expect(records.map((record) => record.proposalId)).toEqual([
+      relocation.proposalId,
+    ]);
+  });
+
+  it("excludes rejected, unanswered, and already reviewed actions", () => {
+    expect(
+      readyDependentRecords(
+        dataset,
+        new Map([[sourceProposalId, "disagree"]]),
+        sourceProposalId,
+      ),
+    ).toEqual([]);
+    expect(readyDependentRecords(dataset, new Map(), sourceProposalId)).toEqual(
+      [],
+    );
+    expect(
+      readyDependentRecords(
+        dataset,
+        new Map([
+          [sourceProposalId, "agree"],
+          [relocation.proposalId, "agree"],
+        ]),
+        sourceProposalId,
+      ),
+    ).toEqual([]);
+  });
+
+  it("serves reviewer-safe questions and both queue labels", () => {
+    const [summary] = toLinkedFollowUps(dataset, [relocation]);
+
+    expect(summary).toMatchObject({
+      proposalId: relocation.proposalId,
+      issueType: "relocation",
+      issueLabel: "Apply approved relocations",
+      question: expect.stringContaining("move from"),
+      sources: [
+        {
+          proposalId: sourceProposalId,
+          issueLabel: expect.stringMatching(/^1[12]\./),
+          question: expect.any(String),
+        },
+      ],
+    });
+  });
+});

--- a/__tests__/lib/somReview/sessionState.test.ts
+++ b/__tests__/lib/somReview/sessionState.test.ts
@@ -1,6 +1,7 @@
 import {
   isResumableSession,
   mergeReadyProposalIds,
+  prioritizeProposalAtCursor,
   planResponseTransition,
   planUndoTransition,
   reviewedProposalIndex,
@@ -22,6 +23,29 @@ describe("Society of Mind session transitions", () => {
     expect(
       mergeReadyProposalIds(completeQueue.slice(0, 10), completeQueue),
     ).toEqual(completeQueue);
+  });
+
+  it("focuses an exact follow-up without changing completed work", () => {
+    expect(
+      prioritizeProposalAtCursor(
+        ["done", "next", "target", "later"],
+        1,
+        "target",
+      ),
+    ).toEqual(["done", "target", "next", "later"]);
+  });
+
+  it("leaves missing and already reviewed follow-ups unchanged", () => {
+    const ids = ["done", "next", "later"];
+    expect(prioritizeProposalAtCursor(ids, 1, "done")).toBe(ids);
+    expect(prioritizeProposalAtCursor(ids, 1, "missing")).toBe(ids);
+    expect(prioritizeProposalAtCursor(ids, 1)).toBe(ids);
+  });
+
+  it("rejects an invalid cursor before reordering a follow-up", () => {
+    expect(() => prioritizeProposalAtCursor(["a"], 2, "a")).toThrow(
+      "Session cursor is invalid",
+    );
   });
 
   it("advances the current item and completes the final item", () => {

--- a/src/components/SomReview/ReviewFollowUpPanel.tsx
+++ b/src/components/SomReview/ReviewFollowUpPanel.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import { Box, Button, Chip, Divider, Stack, Typography } from "@mui/material";
+import AltRouteOutlinedIcon from "@mui/icons-material/AltRouteOutlined";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+
+import { SomLinkedFollowUp } from "../../types/ISomReview";
+import { reviewIconColor } from "./reviewStyles";
+
+const ReviewFollowUpPanel = ({
+  followUps,
+  onReview,
+  variant = "overview",
+  sourceLabel,
+  onContinue,
+  continueLabel,
+}: {
+  followUps: SomLinkedFollowUp[];
+  onReview: (followUp: SomLinkedFollowUp) => void;
+  variant?: "overview" | "handoff";
+  sourceLabel?: string;
+  onContinue?: () => void;
+  continueLabel?: string;
+}) => {
+  if (followUps.length === 0) return null;
+  const isHandoff = variant === "handoff";
+
+  return (
+    <Box
+      component="section"
+      aria-labelledby={`${variant}-follow-up-heading`}
+      sx={{
+        py: isHandoff ? { xs: 2, sm: 3 } : 0,
+        mb: isHandoff ? 0 : 4,
+      }}
+    >
+      <Stack direction="row" alignItems="flex-start" spacing={1.5}>
+        <Box
+          sx={{
+            display: "grid",
+            placeItems: "center",
+            flex: "0 0 auto",
+            width: 44,
+            height: 44,
+            borderRadius: 1.5,
+            color: reviewIconColor,
+            backgroundColor: "action.hover",
+          }}
+        >
+          <AltRouteOutlinedIcon aria-hidden="true" />
+        </Box>
+        <Box>
+          <Typography
+            id={`${variant}-follow-up-heading`}
+            component={isHandoff ? "h1" : "h2"}
+            sx={{
+              fontSize: isHandoff ? "1.5rem" : "1.2rem",
+              fontWeight: 800,
+              lineHeight: 1.3,
+            }}
+          >
+            {isHandoff
+              ? "Continue with the related decision"
+              : "Ready related decisions"}
+          </Typography>
+          <Typography
+            sx={{ mt: 0.5, color: "text.secondary", lineHeight: 1.5 }}
+          >
+            {isHandoff
+              ? "Your answer unlocked a separate follow-up. Review it now while this activity is fresh in mind."
+              : "These actions became available after earlier diagnoses. Open the exact follow-up directly instead of searching its queue."}
+          </Typography>
+          {sourceLabel && (
+            <Typography sx={{ mt: 0.75, fontWeight: 700 }}>
+              Earlier review: {sourceLabel}
+            </Typography>
+          )}
+        </Box>
+      </Stack>
+
+      <Stack spacing={1.5} sx={{ mt: 2.5 }}>
+        {followUps.map((followUp) => (
+          <Box
+            key={followUp.proposalId}
+            sx={{
+              border: 1,
+              borderColor: "divider",
+              borderRadius: 2,
+              p: { xs: 1.75, sm: 2 },
+              backgroundColor: "background.paper",
+            }}
+          >
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              alignItems={{ xs: "stretch", sm: "center" }}
+              justifyContent="space-between"
+              gap={1.5}
+            >
+              <Box sx={{ minWidth: 0 }}>
+                <Chip
+                  label={followUp.issueLabel}
+                  size="small"
+                  variant="outlined"
+                  sx={{ mb: 1, maxWidth: "100%", fontWeight: 700 }}
+                />
+                <Typography sx={{ fontSize: "1.05rem", fontWeight: 750 }}>
+                  {followUp.question}
+                </Typography>
+                {!isHandoff && followUp.sources.length > 0 && (
+                  <Typography
+                    sx={{
+                      mt: 0.65,
+                      color: "text.secondary",
+                      fontSize: "0.9rem",
+                    }}
+                  >
+                    Follows{" "}
+                    {followUp.sources
+                      .map((source) => source.issueLabel)
+                      .join(", ")}
+                  </Typography>
+                )}
+              </Box>
+              <Button
+                disableElevation
+                variant="contained"
+                endIcon={<ArrowForwardIcon />}
+                onClick={() => onReview(followUp)}
+                aria-label={`Review this next: ${followUp.question}`}
+                sx={{
+                  flex: "0 0 auto",
+                  minHeight: 48,
+                  fontWeight: 750,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                Review this next
+              </Button>
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+
+      {isHandoff && onContinue && continueLabel && (
+        <>
+          <Divider sx={{ my: 2.5 }} />
+          <Button
+            disableElevation
+            variant="outlined"
+            onClick={onContinue}
+            sx={{ minHeight: 48, fontWeight: 700 }}
+          >
+            {continueLabel}
+          </Button>
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default ReviewFollowUpPanel;

--- a/src/components/SomReview/ReviewQueueSelector.tsx
+++ b/src/components/SomReview/ReviewQueueSelector.tsx
@@ -28,10 +28,12 @@ import SwapHorizOutlinedIcon from "@mui/icons-material/SwapHorizOutlined";
 import {
   SomIssueType,
   SomIssueTypeOption,
+  SomLinkedFollowUp,
   SomReviewStage,
 } from "../../types/ISomReview";
 import { ISSUE_DESCRIPTIONS } from "./reviewCopy";
 import { reviewAccentColor, reviewIconColor } from "./reviewStyles";
+import ReviewFollowUpPanel from "./ReviewFollowUpPanel";
 
 const activeQueueStatusSx: SxProps<Theme> = {
   backgroundColor: (theme) =>
@@ -178,12 +180,16 @@ const ReviewQueueSelector = ({
   canDeliberate = false,
   onOpenDeliberation,
   headerAction,
+  readyFollowUps = [],
+  onStartFollowUp,
 }: {
   issueTypes: SomIssueTypeOption[];
   onStart: (issueType: SomIssueType) => void;
   canDeliberate?: boolean;
   onOpenDeliberation?: () => void;
   headerAction?: React.ReactNode;
+  readyFollowUps?: SomLinkedFollowUp[];
+  onStartFollowUp?: (followUp: SomLinkedFollowUp) => void;
 }) => (
   <Box>
     <Stack
@@ -219,6 +225,13 @@ const ReviewQueueSelector = ({
       Reviews are recorded separately from ontology changes. Choose one type of
       issue to review.
     </Typography>
+
+    {onStartFollowUp && (
+      <ReviewFollowUpPanel
+        followUps={readyFollowUps}
+        onReview={onStartFollowUp}
+      />
+    )}
 
     <Stack spacing={4}>
       {REVIEW_STAGES.map((stage) => {

--- a/src/lib/somReview/followUps.ts
+++ b/src/lib/somReview/followUps.ts
@@ -1,0 +1,61 @@
+import { SomIssueType, SomLinkedFollowUp } from "../../types/ISomReview";
+import {
+  isIssueTypeEnabled,
+  proposalAvailability,
+  SomDataset,
+} from "./dataset";
+import { toReviewerCard } from "./sanitize";
+
+type ReviewerDecisions = Map<string, "agree" | "disagree">;
+
+const orderedProposalIds = (dataset: SomDataset): string[] =>
+  (dataset.manifest.issueTypes || []).flatMap(
+    (issue: any) =>
+      dataset.orderedIdsByIssue.get(issue.id as SomIssueType) || [],
+  );
+
+/**
+ * Finds unanswered dependent proposals whose prerequisites are all approved.
+ * A source ID narrows the result to actions directly unlocked by that answer.
+ */
+export const readyDependentRecords = (
+  dataset: SomDataset,
+  decisions: ReviewerDecisions,
+  sourceProposalId?: string,
+): any[] =>
+  orderedProposalIds(dataset).flatMap((proposalId) => {
+    if (decisions.has(proposalId)) return [];
+    const record = dataset.recordsById.get(proposalId);
+    const dependencies: string[] = record?.workflow?.dependsOnProposalIds || [];
+    if (dependencies.length === 0) return [];
+    if (sourceProposalId && !dependencies.includes(sourceProposalId)) return [];
+    if (!isIssueTypeEnabled(record.issueType)) return [];
+    return proposalAvailability(record, decisions) === "ready" ? [record] : [];
+  });
+
+export const toLinkedFollowUps = (
+  dataset: SomDataset,
+  records: any[],
+): SomLinkedFollowUp[] =>
+  records.map((record) => ({
+    proposalId: record.proposalId,
+    issueType: record.issueType,
+    issueLabel:
+      dataset.issueLabels.get(record.issueType) || "Related follow-up",
+    question: toReviewerCard(record).reviewerView.question,
+    sources: (record.workflow.dependsOnProposalIds || []).flatMap(
+      (sourceProposalId: string) => {
+        const source = dataset.recordsById.get(sourceProposalId);
+        if (!source) return [];
+        return [
+          {
+            proposalId: source.proposalId,
+            issueType: source.issueType,
+            issueLabel:
+              dataset.issueLabels.get(source.issueType) || "Earlier review",
+            question: toReviewerCard(source).reviewerView.question,
+          },
+        ];
+      },
+    ),
+  }));

--- a/src/lib/somReview/sessionState.ts
+++ b/src/lib/somReview/sessionState.ts
@@ -36,6 +36,32 @@ export const mergeReadyProposalIds = (
 };
 
 /**
+ * Moves an exact linked proposal to the current cursor without changing the
+ * completed prefix or dropping any other proposal from the session.
+ */
+export const prioritizeProposalAtCursor = (
+  proposalIds: string[],
+  cursor: number,
+  preferredProposalId?: string,
+): string[] => {
+  if (cursor < 0 || cursor > proposalIds.length) {
+    throw new Error("Session cursor is invalid");
+  }
+  if (!preferredProposalId) return proposalIds;
+
+  const preferredIndex = proposalIds.indexOf(preferredProposalId);
+  if (preferredIndex < cursor || preferredIndex < 0) return proposalIds;
+  if (preferredIndex === cursor) return proposalIds;
+
+  return [
+    ...proposalIds.slice(0, cursor),
+    preferredProposalId,
+    ...proposalIds.slice(cursor, preferredIndex),
+    ...proposalIds.slice(preferredIndex + 1),
+  ];
+};
+
+/**
  * Plans a response write while allowing a lost-network-response retry to be a
  * no-op. Stale changed responses and future-card responses are rejected.
  */

--- a/src/lib/somReview/store.ts
+++ b/src/lib/somReview/store.ts
@@ -11,9 +11,11 @@ import { SomDataset, proposalAvailability } from "./dataset";
 import {
   isResumableSession,
   mergeReadyProposalIds,
+  prioritizeProposalAtCursor,
   planResponseTransition,
   planUndoTransition,
 } from "./sessionState";
+import { readyDependentRecords } from "./followUps";
 
 export interface SessionDoc {
   datasetVersion: string;
@@ -137,6 +139,15 @@ export const pendingCount = async (
   return (await pendingSummary(dataset, issueType, reviewerId)).pending;
 };
 
+export const reviewerReadyDependentRecords = async (
+  dataset: SomDataset,
+  reviewerId: string,
+  sourceProposalId?: string,
+): Promise<any[]> => {
+  const decisions = await reviewerDecisions(dataset.datasetVersion, reviewerId);
+  return readyDependentRecords(dataset, decisions, sourceProposalId);
+};
+
 export const activeSessionProgress = async (
   dataset: SomDataset,
   issueType: SomIssueType,
@@ -175,6 +186,7 @@ export const getOrCreateSession = async (
   dataset: SomDataset,
   issueType: SomIssueType,
   reviewerId: string,
+  preferredProposalId?: string,
 ): Promise<StoredSession | null> => {
   const decisions = await reviewerDecisions(dataset.datasetVersion, reviewerId);
   const existing = await activeSessionQuery(
@@ -209,8 +221,17 @@ export const getOrCreateSession = async (
             decisions,
           ) === "ready",
       );
-      const proposalIds = mergeReadyProposalIds(session.proposalIds, ready);
-      if (proposalIds.length !== session.proposalIds.length) {
+      const proposalIds = prioritizeProposalAtCursor(
+        mergeReadyProposalIds(session.proposalIds, ready),
+        session.cursor,
+        preferredProposalId,
+      );
+      if (
+        proposalIds.length !== session.proposalIds.length ||
+        proposalIds.some(
+          (proposalId, index) => proposalId !== session.proposalIds[index],
+        )
+      ) {
         await existingDoc.ref.update({
           proposalIds,
           updatedAt: Timestamp.now(),
@@ -244,7 +265,11 @@ export const getOrCreateSession = async (
     datasetVersion: dataset.datasetVersion,
     issueType,
     reviewerId,
-    proposalIds: mergeReadyProposalIds([], ready),
+    proposalIds: prioritizeProposalAtCursor(
+      mergeReadyProposalIds([], ready),
+      0,
+      preferredProposalId,
+    ),
     cursor: 0,
     status: "active",
     createdAt: now,

--- a/src/pages/api/som-review/overview.ts
+++ b/src/pages/api/som-review/overview.ts
@@ -5,9 +5,11 @@ import { getDataset, isIssueTypeEnabled } from "../../../lib/somReview/dataset";
 import {
   activeSessionProgress,
   pendingSummary,
+  reviewerReadyDependentRecords,
 } from "../../../lib/somReview/store";
 import { SomIssueType, SomOverviewResponse } from "../../../types/ISomReview";
 import { reviewAccessForToken } from "../../../lib/somReview/access";
+import { toLinkedFollowUps } from "../../../lib/somReview/followUps";
 
 const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   const req = request as CustomNextApiRequest;
@@ -17,33 +19,37 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
     const dataset = getDataset();
     const reviewerId = req.user.uid;
 
-    const issueTypes = await Promise.all(
-      (dataset.manifest.issueTypes || []).map(async (issue: any) => {
-        const issueType = issue.id as SomIssueType;
-        const enabled = isIssueTypeEnabled(issueType);
-        const total = (dataset.orderedIdsByIssue.get(issueType) || []).length;
-        const [summary, activeSession] = enabled
-          ? await Promise.all([
-              pendingSummary(dataset, issueType, reviewerId),
-              activeSessionProgress(dataset, issueType, reviewerId),
-            ])
-          : [{ reviewed: 0, pending: 0, waiting: 0, notApplicable: 0 }, null];
-        return {
-          id: issueType,
-          label: issue.label,
-          stage: issue.stage,
-          robTaskIds: issue.robTaskIds || [],
-          enabled,
-          total,
-          ...summary,
-          ...(activeSession ? { activeSession } : {}),
-        };
-      }),
-    );
+    const [issueTypes, readyFollowUpRecords] = await Promise.all([
+      Promise.all(
+        (dataset.manifest.issueTypes || []).map(async (issue: any) => {
+          const issueType = issue.id as SomIssueType;
+          const enabled = isIssueTypeEnabled(issueType);
+          const total = (dataset.orderedIdsByIssue.get(issueType) || []).length;
+          const [summary, activeSession] = enabled
+            ? await Promise.all([
+                pendingSummary(dataset, issueType, reviewerId),
+                activeSessionProgress(dataset, issueType, reviewerId),
+              ])
+            : [{ reviewed: 0, pending: 0, waiting: 0, notApplicable: 0 }, null];
+          return {
+            id: issueType,
+            label: issue.label,
+            stage: issue.stage,
+            robTaskIds: issue.robTaskIds || [],
+            enabled,
+            total,
+            ...summary,
+            ...(activeSession ? { activeSession } : {}),
+          };
+        }),
+      ),
+      reviewerReadyDependentRecords(dataset, reviewerId),
+    ]);
 
     const body: SomOverviewResponse = {
       datasetVersion: dataset.datasetVersion,
       issueTypes,
+      readyFollowUps: toLinkedFollowUps(dataset, readyFollowUpRecords),
       canDeliberate:
         process.env.SOM_REVIEW_DELIBERATION_ENABLED === "true" &&
         reviewAccessForToken(req.user).canDeliberate,

--- a/src/pages/api/som-review/respond.ts
+++ b/src/pages/api/som-review/respond.ts
@@ -6,9 +6,14 @@ import {
   getDataset,
   isIssueTypeEnabled,
 } from "../../../lib/somReview/dataset";
-import { ResponsePayload, saveResponse } from "../../../lib/somReview/store";
+import {
+  ResponsePayload,
+  reviewerReadyDependentRecords,
+  saveResponse,
+} from "../../../lib/somReview/store";
 import { reviewRequestData } from "../../../lib/somReview/request";
 import { SomRespondResult } from "../../../types/ISomReview";
+import { toLinkedFollowUps } from "../../../lib/somReview/followUps";
 
 let validateResponse: ReturnType<typeof compileResponseValidator> | null = null;
 
@@ -21,8 +26,7 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
     const data = reviewRequestData(req.body);
     const payload = data.response as ResponsePayload;
     const sessionId = typeof data.sessionId === "string" ? data.sessionId : "";
-    if (!sessionId)
-      return res.status(400).json({ error: "Missing sessionId" });
+    if (!sessionId) return res.status(400).json({ error: "Missing sessionId" });
     if (!payload)
       return res.status(400).json({ error: "Missing response payload" });
 
@@ -60,7 +64,20 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       record.issueType,
       payload,
     );
-    const body: SomRespondResult = { ok: true, cursor, completed };
+    const followUpRecords =
+      payload.decision === "agree"
+        ? await reviewerReadyDependentRecords(
+            dataset,
+            req.user.uid,
+            payload.proposalId,
+          )
+        : [];
+    const body: SomRespondResult = {
+      ok: true,
+      cursor,
+      completed,
+      followUps: toLinkedFollowUps(dataset, followUpRecords),
+    };
     return res.status(200).json(body);
   } catch (error: any) {
     console.error(error);

--- a/src/pages/api/som-review/revise.ts
+++ b/src/pages/api/som-review/revise.ts
@@ -6,9 +6,14 @@ import {
   getDataset,
   isIssueTypeEnabled,
 } from "../../../lib/somReview/dataset";
-import { ResponsePayload, reviseResponse } from "../../../lib/somReview/store";
+import {
+  ResponsePayload,
+  reviewerReadyDependentRecords,
+  reviseResponse,
+} from "../../../lib/somReview/store";
 import { reviewRequestData } from "../../../lib/somReview/request";
 import { SomReviseResult } from "../../../types/ISomReview";
+import { toLinkedFollowUps } from "../../../lib/somReview/followUps";
 
 let validateResponse: ReturnType<typeof compileResponseValidator> | null = null;
 
@@ -53,7 +58,19 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
     }
 
     const { changed } = await reviseResponse(record.issueType, payload);
-    const body: SomReviseResult = { ok: true, changed };
+    const followUpRecords =
+      payload.decision === "agree"
+        ? await reviewerReadyDependentRecords(
+            dataset,
+            req.user.uid,
+            payload.proposalId,
+          )
+        : [];
+    const body: SomReviseResult = {
+      ok: true,
+      changed,
+      followUps: toLinkedFollowUps(dataset, followUpRecords),
+    };
     return res.status(200).json(body);
   } catch (error: any) {
     console.error(error);

--- a/src/pages/api/som-review/session.ts
+++ b/src/pages/api/som-review/session.ts
@@ -18,6 +18,10 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   try {
     const data = reviewRequestData(req.body);
     const issueType = data.issueType as SomIssueType;
+    const preferredProposalId =
+      typeof data.preferredProposalId === "string"
+        ? data.preferredProposalId
+        : undefined;
     const dataset = getDataset();
     if (!dataset.orderedIdsByIssue.has(issueType)) {
       return res.status(400).json({ error: "Unknown issue type" });
@@ -27,8 +31,33 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
         .status(403)
         .json({ error: "This issue type is not enabled yet" });
     }
+    if (preferredProposalId) {
+      const preferredRecord = dataset.recordsById.get(preferredProposalId);
+      if (
+        !preferredRecord ||
+        preferredRecord.issueType !== issueType ||
+        !preferredRecord.workflow.dependsOnProposalIds.length
+      ) {
+        return res.status(400).json({
+          error: "The requested linked follow-up is invalid",
+        });
+      }
+    }
 
-    const session = await getOrCreateSession(dataset, issueType, req.user.uid);
+    const session = await getOrCreateSession(
+      dataset,
+      issueType,
+      req.user.uid,
+      preferredProposalId,
+    );
+    if (
+      preferredProposalId &&
+      (!session || session.proposalIds[session.cursor] !== preferredProposalId)
+    ) {
+      return res.status(409).json({
+        error: "This related follow-up is no longer available for review",
+      });
+    }
     const orderedProposalIds = dataset.orderedIdsByIssue.get(issueType) || [];
     const proposalIndexes = new Map(
       orderedProposalIds.map((proposalId, index) => [proposalId, index]),
@@ -81,6 +110,9 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       cards,
       history,
       historyCards,
+      ...(preferredProposalId
+        ? { focusedProposalId: preferredProposalId }
+        : {}),
     };
     return res.status(200).json(body);
   } catch (error: any) {

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -11,6 +11,7 @@ import {
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import HistoryOutlinedIcon from "@mui/icons-material/HistoryOutlined";
 import Head from "next/head";
 import { useRouter } from "next/router";
 
@@ -659,7 +660,7 @@ export const ReviewPage = () => {
                   >
                     {revisionItem ? (
                       <>
-                        Revising item {revisionItem.proposalIndex + 1} of{" "}
+                        Saved item {revisionItem.proposalIndex + 1} of{" "}
                         {issueTotal}
                       </>
                     ) : (
@@ -670,20 +671,59 @@ export const ReviewPage = () => {
                     )}
                   </Typography>
                 </Stack>
-                <LinearProgress
-                  variant="determinate"
-                  value={
-                    availableReviewTotal === 0
-                      ? 100
-                      : (history.length / availableReviewTotal) * 100
-                  }
-                  aria-label={
-                    availableReviewTotal === 0
-                      ? "All available items completed"
-                      : `${history.length} of ${availableReviewTotal} items completed`
-                  }
-                  sx={{ height: 8, borderRadius: 1 }}
-                />
+                {revisionItem ? (
+                  <Box
+                    role="status"
+                    aria-label={`Reviewing saved item ${
+                      revisionItem.proposalIndex + 1
+                    } of ${issueTotal}. Queue progress remains ${history.length} of ${availableReviewTotal} reviewed.`}
+                    sx={{
+                      display: "flex",
+                      flexDirection: { xs: "column", sm: "row" },
+                      alignItems: { xs: "flex-start", sm: "center" },
+                      justifyContent: "space-between",
+                      gap: 0.75,
+                      borderLeft: 4,
+                      borderColor: "info.main",
+                      borderRadius: 1,
+                      backgroundColor: "action.hover",
+                      px: 1.5,
+                      py: 1.1,
+                    }}
+                  >
+                    <Stack direction="row" alignItems="center" spacing={1}>
+                      <HistoryOutlinedIcon
+                        aria-hidden="true"
+                        color="info"
+                        sx={{ fontSize: 22 }}
+                      />
+                      <Typography sx={{ fontWeight: 750 }}>
+                        Reviewing a saved answer
+                      </Typography>
+                    </Stack>
+                    <Typography
+                      sx={{ color: "text.secondary", fontWeight: 650 }}
+                    >
+                      Queue remains {history.length} of {availableReviewTotal}{" "}
+                      reviewed
+                    </Typography>
+                  </Box>
+                ) : (
+                  <LinearProgress
+                    variant="determinate"
+                    value={
+                      availableReviewTotal === 0
+                        ? 100
+                        : (history.length / availableReviewTotal) * 100
+                    }
+                    aria-label={
+                      availableReviewTotal === 0
+                        ? "All available items completed"
+                        : `${history.length} of ${availableReviewTotal} items completed`
+                    }
+                    sx={{ height: 8, borderRadius: 1 }}
+                  />
+                )}
               </Stack>
               {revisionItem && (
                 <Alert
@@ -700,15 +740,12 @@ export const ReviewPage = () => {
                     </Button>
                   }
                 >
-                  You are revising item {revisionItem.proposalIndex + 1}. Saved
-                  answer:{" "}
+                  Saved answer:{" "}
                   <strong>
                     {revisionItem.decision === "agree" ? "Agreed" : "Disagreed"}
                   </strong>
-                  . No change is made until you submit a revised answer.{" "}
-                  {cards.length === 0
-                    ? "All currently available proposals remain reviewed."
-                    : `Your progress remains at ${history.length} of ${availableReviewTotal} items completed.`}
+                  . Submit a revised answer to replace it, or keep the saved
+                  answer to return to your current review position.
                 </Alert>
               )}
               {!revisionItem &&

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -21,6 +21,7 @@ import ReviewCard, {
   ReviewSubmission,
 } from "@components/components/SomReview/ReviewCard";
 import ReviewHistorySelect from "@components/components/SomReview/ReviewHistorySelect";
+import ReviewFollowUpPanel from "@components/components/SomReview/ReviewFollowUpPanel";
 import ReviewQueueSelector from "@components/components/SomReview/ReviewQueueSelector";
 import ReviewTaskIntro from "@components/components/SomReview/ReviewTaskIntro";
 import ThemeModeToggle from "@components/components/SomReview/ThemeModeToggle";
@@ -28,6 +29,8 @@ import { reviewInteractiveSurfaceSx } from "@components/components/SomReview/rev
 import {
   SomIssueType,
   SomIssueTypeOption,
+  SomFollowUpSource,
+  SomLinkedFollowUp,
   SomOverviewResponse,
   SomRespondResult,
   SomReviewCard,
@@ -36,7 +39,31 @@ import {
   SomSessionResponse,
 } from "@components/types/ISomReview";
 
-type Phase = "loading" | "select" | "intro" | "session" | "complete" | "empty";
+type Phase =
+  | "loading"
+  | "select"
+  | "intro"
+  | "session"
+  | "follow-up"
+  | "sequence-complete"
+  | "complete"
+  | "empty";
+
+interface LinkedReviewSequence {
+  source: SomFollowUpSource;
+  followUp: SomLinkedFollowUp;
+}
+
+interface FollowUpOffer {
+  source: SomFollowUpSource;
+  followUps: SomLinkedFollowUp[];
+  sourceQueueCompleted: boolean;
+}
+
+interface CompletedSequence {
+  sequence: LinkedReviewSequence;
+  followUpQueueCompleted: boolean;
+}
 
 export const ReviewPage = () => {
   const [{ user }] = useAuth();
@@ -44,6 +71,7 @@ export const ReviewPage = () => {
   const [phase, setPhase] = useState<Phase>("loading");
   const [datasetVersion, setDatasetVersion] = useState("");
   const [issueTypes, setIssueTypes] = useState<SomIssueTypeOption[]>([]);
+  const [readyFollowUps, setReadyFollowUps] = useState<SomLinkedFollowUp[]>([]);
   const [issueType, setIssueType] = useState<SomIssueType | null>(null);
   const [sessionId, setSessionId] = useState("");
   const [cards, setCards] = useState<SomReviewCard[]>([]);
@@ -56,6 +84,13 @@ export const ReviewPage = () => {
   const [retryIssueType, setRetryIssueType] = useState<SomIssueType | null>(
     null,
   );
+  const [followUpOffer, setFollowUpOffer] = useState<FollowUpOffer | null>(
+    null,
+  );
+  const [activeSequence, setActiveSequence] =
+    useState<LinkedReviewSequence | null>(null);
+  const [completedSequence, setCompletedSequence] =
+    useState<CompletedSequence | null>(null);
 
   const loadOverview = useCallback(async () => {
     setPhase("loading");
@@ -65,6 +100,7 @@ export const ReviewPage = () => {
       const overview = await Post<SomOverviewResponse>("/som-review/overview");
       setDatasetVersion(overview.datasetVersion);
       setIssueTypes(overview.issueTypes);
+      setReadyFollowUps(overview.readyFollowUps || []);
       setCanDeliberate(overview.canDeliberate);
       setPhase("select");
     } catch {
@@ -77,40 +113,81 @@ export const ReviewPage = () => {
     if (user) loadOverview();
   }, [user, loadOverview]);
 
-  const startSession = useCallback(async (issue: SomIssueType) => {
-    setIssueType(issue);
-    setPhase("loading");
-    setLoadError("");
-    setRetryIssueType(null);
-    try {
-      const result = await Post<SomSessionResponse>("/som-review/session", {
-        issueType: issue,
-      });
+  const startSession = useCallback(
+    async (
+      issue: SomIssueType,
+      options: {
+        preferredProposalId?: string;
+        sequence?: LinkedReviewSequence | null;
+      } = {},
+    ) => {
       setIssueType(issue);
-      setHistory(result.history || []);
-      setHistoryCards(result.historyCards || []);
-      setRevisionProposalId("");
-      if (result.done || !result.session || !result.cards?.length) {
-        setSessionId("");
-        setCards([]);
-        setCursor(0);
-        setPhase("empty");
+      setPhase("loading");
+      setLoadError("");
+      setRetryIssueType(null);
+      setFollowUpOffer(null);
+      setCompletedSequence(null);
+      setActiveSequence(options.sequence || null);
+      try {
+        const result = await Post<SomSessionResponse>("/som-review/session", {
+          issueType: issue,
+          ...(options.preferredProposalId
+            ? { preferredProposalId: options.preferredProposalId }
+            : {}),
+        });
+        if (
+          options.preferredProposalId &&
+          result.focusedProposalId !== options.preferredProposalId
+        ) {
+          throw new Error("The related follow-up could not be focused");
+        }
+        setIssueType(issue);
+        setHistory(result.history || []);
+        setHistoryCards(result.historyCards || []);
+        setRevisionProposalId("");
+        if (result.done || !result.session || !result.cards?.length) {
+          setSessionId("");
+          setCards([]);
+          setCursor(0);
+          setPhase("empty");
+          return;
+        }
+        setSessionId(result.session.id);
+        setCards(result.cards);
+        setCursor(result.session.cursor);
+        setPhase(
+          result.session.cursor >= result.cards.length ? "complete" : "session",
+        );
+      } catch {
+        setActiveSequence(null);
+        setLoadError(
+          options.preferredProposalId
+            ? "That related follow-up could not be opened. It may already have been reviewed."
+            : "The review session could not be started. Please try again.",
+        );
+        setRetryIssueType(options.preferredProposalId ? null : issue);
+        setPhase("select");
+      }
+    },
+    [],
+  );
+
+  const startLinkedFollowUp = useCallback(
+    (followUp: SomLinkedFollowUp, source?: SomFollowUpSource) => {
+      const linkedSource = source || followUp.sources[0];
+      if (!linkedSource) {
+        startSession(followUp.issueType, {
+          preferredProposalId: followUp.proposalId,
+        });
         return;
       }
-      setSessionId(result.session.id);
-      setCards(result.cards);
-      setCursor(result.session.cursor);
-      setPhase(
-        result.session.cursor >= result.cards.length ? "complete" : "session",
-      );
-    } catch {
-      setLoadError(
-        "The review session could not be started. Please try again.",
-      );
-      setRetryIssueType(issue);
-      setPhase("select");
-    }
-  }, []);
+      startSession(followUp.issueType, {
+        preferredProposalId: followUp.proposalId,
+        sequence: { source: linkedSource, followUp },
+      });
+    },
+    [startSession],
+  );
 
   const introStorageKey = useCallback(
     (issue: SomIssueType) =>
@@ -122,6 +199,9 @@ export const ReviewPage = () => {
     (issue: SomIssueType) => {
       setLoadError("");
       setRetryIssueType(null);
+      setFollowUpOffer(null);
+      setActiveSequence(null);
+      setCompletedSequence(null);
       try {
         if (window.localStorage.getItem(introStorageKey(issue)) === "seen") {
           startSession(issue);
@@ -209,9 +289,35 @@ export const ReviewPage = () => {
             ),
       );
       setCursor(result.cursor);
+      const followUps = result.followUps || [];
+      if (followUps.length > 0) {
+        const sourceIssue = issueTypes.find(
+          (candidate) => candidate.id === card.issueType,
+        );
+        setFollowUpOffer({
+          source: {
+            proposalId: card.proposalId,
+            issueType: card.issueType,
+            issueLabel: sourceIssue?.label || "Earlier review",
+            question: card.reviewerView.question,
+          },
+          followUps,
+          sourceQueueCompleted: result.completed,
+        });
+        setPhase("follow-up");
+        return;
+      }
+      if (activeSequence?.followUp.proposalId === card.proposalId) {
+        setCompletedSequence({
+          sequence: activeSequence,
+          followUpQueueCompleted: result.completed,
+        });
+        setPhase("sequence-complete");
+        return;
+      }
       if (result.completed) setPhase("complete");
     },
-    [cards, cursor, sessionId, user?.userId],
+    [activeSequence, cards, cursor, issueTypes, sessionId, user?.userId],
   );
 
   const revisionItem = history.find(
@@ -268,6 +374,29 @@ export const ReviewPage = () => {
               : historyItem,
           ),
         );
+      }
+
+      const followUps = result.followUps || [];
+      if (followUps.length > 0) {
+        const sourceIssue = issueTypes.find(
+          (candidate) => candidate.id === card.issueType,
+        );
+        setRevisionProposalId("");
+        setFollowUpOffer({
+          source: {
+            proposalId: card.proposalId,
+            issueType: card.issueType,
+            issueLabel: sourceIssue?.label || "Earlier review",
+            question: card.reviewerView.question,
+          },
+          followUps,
+          sourceQueueCompleted: cards.length === 0 || cursor >= cards.length,
+        });
+        setPhase("follow-up");
+        return;
+      }
+
+      if (result.changed) {
         if (issueType) {
           await startSession(issueType);
           return;
@@ -287,6 +416,7 @@ export const ReviewPage = () => {
       cursor,
       history,
       historyCards,
+      issueTypes,
       issueType,
       revisionProposalId,
       startSession,
@@ -324,8 +454,34 @@ export const ReviewPage = () => {
     setHistoryCards([]);
     setRevisionProposalId("");
     setRetryIssueType(null);
+    setFollowUpOffer(null);
+    setActiveSequence(null);
+    setCompletedSequence(null);
     loadOverview();
   }, [loadOverview]);
+
+  const continueOriginalQueue = useCallback(() => {
+    if (!followUpOffer) return;
+    setActiveSequence(null);
+    setFollowUpOffer(null);
+    setPhase(followUpOffer.sourceQueueCompleted ? "complete" : "session");
+  }, [followUpOffer]);
+
+  const returnToSourceQueue = useCallback(() => {
+    if (!completedSequence) return;
+    const sourceIssueType = completedSequence.sequence.source.issueType;
+    setCompletedSequence(null);
+    setActiveSequence(null);
+    startSession(sourceIssueType);
+  }, [completedSequence, startSession]);
+
+  const continueFollowUpQueue = useCallback(() => {
+    if (!completedSequence) return;
+    const followUpIssueType = completedSequence.sequence.followUp.issueType;
+    setCompletedSequence(null);
+    setActiveSequence(null);
+    startSession(followUpIssueType);
+  }, [completedSequence, startSession]);
 
   const currentCard = cards[cursor];
   const activeCard = revisionCard || currentCard;
@@ -387,10 +543,46 @@ export const ReviewPage = () => {
             <ReviewQueueSelector
               issueTypes={issueTypes}
               onStart={chooseIssueType}
+              readyFollowUps={readyFollowUps}
+              onStartFollowUp={(followUp) => startLinkedFollowUp(followUp)}
               canDeliberate={canDeliberate}
               onOpenDeliberation={() => router.push("/review/admin")}
               headerAction={<ThemeModeToggle />}
             />
+          )}
+
+          {phase === "follow-up" && followUpOffer && (
+            <Stack sx={{ py: 2 }}>
+              <Stack direction="row" justifyContent="flex-end">
+                <ThemeModeToggle />
+              </Stack>
+              <ReviewFollowUpPanel
+                variant="handoff"
+                sourceLabel={followUpOffer.source.issueLabel}
+                followUps={followUpOffer.followUps}
+                onReview={(followUp) =>
+                  startLinkedFollowUp(followUp, followUpOffer.source)
+                }
+                onContinue={continueOriginalQueue}
+                continueLabel={`${
+                  followUpOffer.sourceQueueCompleted ? "Finish" : "Continue"
+                } ${followUpOffer.source.issueLabel}`}
+              />
+            </Stack>
+          )}
+
+          {phase === "follow-up" && !followUpOffer && (
+            <Alert
+              severity="error"
+              action={
+                <Button disableElevation onClick={exitToSelector}>
+                  All review types
+                </Button>
+              }
+            >
+              The related follow-up is unavailable. Return to all review types
+              and try again.
+            </Alert>
           )}
 
           {phase === "intro" && selectedIssue && (
@@ -519,6 +711,16 @@ export const ReviewPage = () => {
                     : `Your progress remains at ${history.length} of ${availableReviewTotal} items completed.`}
                 </Alert>
               )}
+              {!revisionItem &&
+                activeSequence?.followUp.proposalId ===
+                  activeCard.proposalId && (
+                  <Alert severity="info" sx={{ mb: 2 }}>
+                    Related follow-up from{" "}
+                    <strong>{activeSequence.source.issueLabel}</strong>. This is
+                    a separate decision. After answering it, you can return to
+                    the original review queue.
+                  </Alert>
+                )}
               <ReviewCard
                 key={
                   activeCard.proposalId +
@@ -554,6 +756,106 @@ export const ReviewPage = () => {
               }
             >
               The current review item is unavailable.
+            </Alert>
+          )}
+
+          {phase === "sequence-complete" && completedSequence && (
+            <Stack sx={{ py: 2 }}>
+              <Stack direction="row" justifyContent="flex-end">
+                <ThemeModeToggle />
+              </Stack>
+              <Stack
+                alignItems="center"
+                spacing={2.5}
+                sx={{ py: { xs: 7, sm: 10 }, textAlign: "center" }}
+              >
+                <CheckCircleOutlineIcon color="success" sx={{ fontSize: 56 }} />
+                <Box>
+                  <Typography
+                    variant="h5"
+                    component="h1"
+                    sx={{ fontWeight: 800 }}
+                  >
+                    Related decisions completed
+                  </Typography>
+                  <Typography
+                    sx={{ mt: 0.75, color: "text.secondary", lineHeight: 1.55 }}
+                  >
+                    You reviewed the diagnosis and its exact follow-up as two
+                    separate decisions.
+                  </Typography>
+                </Box>
+                <Box
+                  sx={{
+                    width: "100%",
+                    borderTop: 1,
+                    borderBottom: 1,
+                    borderColor: "divider",
+                    py: 2,
+                  }}
+                >
+                  <Typography sx={{ fontWeight: 750 }}>
+                    {completedSequence.sequence.source.issueLabel}
+                  </Typography>
+                  <Typography sx={{ mt: 0.4, color: "text.secondary" }}>
+                    {completedSequence.sequence.source.question}
+                  </Typography>
+                  <Typography sx={{ mt: 1.5, fontWeight: 750 }}>
+                    {completedSequence.sequence.followUp.issueLabel}
+                  </Typography>
+                  <Typography sx={{ mt: 0.4, color: "text.secondary" }}>
+                    {completedSequence.sequence.followUp.question}
+                  </Typography>
+                </Box>
+                <Stack
+                  direction={{ xs: "column", sm: "row" }}
+                  spacing={1.5}
+                  sx={{ width: { xs: "100%", sm: "auto" } }}
+                >
+                  <Button
+                    disableElevation
+                    variant="contained"
+                    startIcon={<ArrowBackIcon />}
+                    onClick={returnToSourceQueue}
+                    sx={{ minHeight: 50, fontWeight: 750 }}
+                  >
+                    Return to {completedSequence.sequence.source.issueLabel}
+                  </Button>
+                  {completedSequence.followUpQueueCompleted ? (
+                    <Button
+                      disableElevation
+                      variant="outlined"
+                      onClick={exitToSelector}
+                      sx={{ minHeight: 50, fontWeight: 700 }}
+                    >
+                      All review types
+                    </Button>
+                  ) : (
+                    <Button
+                      disableElevation
+                      variant="outlined"
+                      onClick={continueFollowUpQueue}
+                      sx={{ minHeight: 50, fontWeight: 700 }}
+                    >
+                      Continue {completedSequence.sequence.followUp.issueLabel}
+                    </Button>
+                  )}
+                </Stack>
+              </Stack>
+            </Stack>
+          )}
+
+          {phase === "sequence-complete" && !completedSequence && (
+            <Alert
+              severity="error"
+              action={
+                <Button disableElevation onClick={exitToSelector}>
+                  All review types
+                </Button>
+              }
+            >
+              The completed review sequence is unavailable. Return to all review
+              types and try again.
             </Alert>
           )}
 

--- a/src/types/ISomReview.ts
+++ b/src/types/ISomReview.ts
@@ -223,6 +223,8 @@ export interface SomSessionResponse {
   cards?: SomReviewCard[];
   history?: SomReviewHistoryItem[];
   historyCards?: SomReviewCard[];
+  /** Present only when an exact linked proposal was requested and focused. */
+  focusedProposalId?: string;
 }
 
 export interface SomReviewHistoryItem {
@@ -235,9 +237,26 @@ export interface SomReviewHistoryItem {
   reviewedAt: string;
 }
 
+export interface SomFollowUpSource {
+  proposalId: string;
+  issueType: SomIssueType;
+  issueLabel: string;
+  question: string;
+}
+
+/** A ready action proposal connected to one or more completed diagnoses. */
+export interface SomLinkedFollowUp {
+  proposalId: string;
+  issueType: SomIssueType;
+  issueLabel: string;
+  question: string;
+  sources: SomFollowUpSource[];
+}
+
 export interface SomOverviewResponse {
   datasetVersion: string;
   issueTypes: SomIssueTypeOption[];
+  readyFollowUps: SomLinkedFollowUp[];
   canDeliberate: boolean;
 }
 
@@ -245,6 +264,7 @@ export interface SomRespondResult {
   ok: boolean;
   cursor: number;
   completed: boolean;
+  followUps: SomLinkedFollowUp[];
 }
 
 export interface SomUndoResult {
@@ -255,6 +275,7 @@ export interface SomUndoResult {
 export interface SomReviseResult {
   ok: boolean;
   changed: boolean;
+  followUps: SomLinkedFollowUp[];
 }
 
 export interface SomDeliberationRoleSummary {


### PR DESCRIPTION
## Summary
- pause after an agreed diagnosis when it unlocks a separate action proposal, and offer that exact follow-up immediately
- open linked actions by authoritative `dependsOnProposalIds` and proposal ID, while preserving the original queue and completed prefix
- let reviewers return to the diagnosis queue after the linked action, or continue the action queue
- keep postponed linked actions directly accessible on the review overview by exact question
- support the same handoff when a revised answer unlocks an action
- replace the normal completion progress bar while revisiting a saved answer with an explicit revision status and a separate unchanged queue count

## Safety and accessibility
- categories and judgments remain separate; the navigation only connects them
- the server rejects stale or invalid linked targets instead of opening a different proposal
- handoff and completion screens use explicit language, large controls, and clear return paths
- revision mode identifies the proposal as a saved item and does not visually imply that revisiting it advances or rewinds queue progress

## Tests
- `npx jest --runInBand __tests__/lib/somReview __tests__/components/SomReview` (21 suites, 101 tests)
- the page-level workflow test verifies both the linked diagnosis-to-action journey and the normal-progress-to-saved-answer transition
- changed files pass ESLint
- `git diff --check`
- local `/review` server returns HTTP 200 and recompiles cleanly

The repository-wide TypeScript check still reports pre-existing errors outside the Society of Mind review files; no new TypeScript errors are reported in this change.
