### PR TITLE
Show O*NET evidence by default in ontology reviews

### DIFF
--- a/__tests__/components/SomReview/ContextRenderer.test.tsx
+++ b/__tests__/components/SomReview/ContextRenderer.test.tsx
@@ -8,7 +8,7 @@ import "@testing-library/jest-dom";
 import ContextRenderer from "../../../src/components/SomReview/ContextRenderer";
 
 describe("Society of Mind context renderers", () => {
-  it("keeps title evidence collapsed until requested", () => {
+  it("shows title evidence by default and lets the reviewer collapse it", () => {
     render(
       <ContextRenderer
         context={{
@@ -20,11 +20,18 @@ describe("Society of Mind context renderers", () => {
       />,
     );
     expect(
-      screen.queryByText("Recommend and sell lotions or tonics."),
-    ).not.toBeInTheDocument();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Show source O*NET evidence" }),
-    );
+      screen.getByText("Recommend and sell lotions or tonics."),
+    ).toBeInTheDocument();
+    const collapseButton = screen.getByRole("button", {
+      name: "Hide source O*NET evidence",
+    });
+    expect(collapseButton).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(collapseButton);
+    const expandButton = screen.getByRole("button", {
+      name: "Show source O*NET evidence",
+    });
+    expect(expandButton).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(expandButton);
     expect(
       screen.getByText("Recommend and sell lotions or tonics."),
     ).toBeInTheDocument();
@@ -46,9 +53,6 @@ describe("Society of Mind context renderers", () => {
       />,
     );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Show source O*NET evidence" }),
-    );
     expect(screen.getAllByText("Sell products or services.")).toHaveLength(1);
   });
 
@@ -123,9 +127,7 @@ describe("Society of Mind context renderers", () => {
     expect(
       screen.getByLabelText("Proposed synonym relationship"),
     ).toHaveTextContent("Sell Products");
-    expect(
-      screen.queryByText("Sell products to customers."),
-    ).not.toBeInTheDocument();
+    expect(screen.getByText("Sell products to customers.")).toBeInTheDocument();
     expect(
       screen.queryByText(/merge|delete|downstream/i),
     ).not.toBeInTheDocument();
@@ -152,7 +154,10 @@ describe("Society of Mind context renderers", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("Rent out")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Show source O*NET evidence" }),
+      screen.getByRole("button", { name: "Hide source O*NET evidence" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Rent merchandise to customers."),
     ).toBeInTheDocument();
   });
 
@@ -304,8 +309,8 @@ describe("Society of Mind context renderers", () => {
       screen.getByText("Recorded synonyms after this change"),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText("Sell and install accessories."),
-    ).not.toBeInTheDocument();
+      screen.getByText("Sell and install accessories."),
+    ).toBeInTheDocument();
   });
 
   it("shows the two meanings in a polysemy diagnosis", () => {
@@ -346,6 +351,9 @@ describe("Society of Mind context renderers", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByText(/where each meaning belongs will be reviewed/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Selling or Influencing Others"),
     ).toBeInTheDocument();
   });
 

--- a/src/components/SomReview/ContextRenderer.tsx
+++ b/src/components/SomReview/ContextRenderer.tsx
@@ -127,13 +127,15 @@ export const DiffedTitle = ({
 const Disclosure = ({
   closedLabel,
   openLabel,
+  initiallyOpen = false,
   children,
 }: {
   closedLabel: string;
   openLabel: string;
+  initiallyOpen?: boolean;
   children: React.ReactNode;
 }) => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(initiallyOpen);
   return (
     <Box>
       <Button
@@ -171,6 +173,7 @@ const TitleComparison = ({
     <Disclosure
       closedLabel={`Show source O*NET evidence${tasks.length > 1 ? ` (${tasks.length})` : ""}`}
       openLabel="Hide source O*NET evidence"
+      initiallyOpen
     >
       <List dense disablePadding sx={{ pl: 1, pb: 1 }}>
         {tasks.map((task) => (
@@ -579,6 +582,7 @@ const SourceTasks = ({ tasks }: { tasks: string[] }) => {
     <Disclosure
       closedLabel={`Show source O*NET evidence${uniqueTasks.length > 1 ? ` (${uniqueTasks.length})` : ""}`}
       openLabel="Hide source O*NET evidence"
+      initiallyOpen
     >
       <List dense disablePadding sx={{ pl: 1, pb: 1 }}>
         {uniqueTasks.map((task) => (


### PR DESCRIPTION
## What changed

- Open source O*NET evidence lists by default across Society of Mind review contexts.
- Keep the existing control so reviewers can collapse and reopen the evidence.
- Update component tests to cover the initial expanded state, collapse/reopen behavior, deduplication, and evidence visibility across proposal types.

## Why

During the July 17 research-group review, Tom and Alok noted that reviewers need the underlying O*NET tasks to interpret some proposals. Making source evidence visible by default preserves that context while retaining reviewer control over page density.

## Validation

- `npx jest --runInBand __tests__/components/SomReview __tests__/lib/somReview` (22 suites, 107 tests)
- `npm run build`
- `git diff --check`