### PR TITLE
Allow reopening completed ontology review queues

### DIFF
--- a/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
+++ b/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
@@ -377,4 +377,76 @@ describe("linked proposal review journey", () => {
       screen.getByRole("button", { name: "Keep saved answer" }),
     ).toBeInTheDocument();
   });
+
+  it("opens a completed review type from the main menu for revision", async () => {
+    const postMock = Post as jest.Mock;
+    const completedCard = card(
+      "placement-1",
+      "placement",
+      'Is "Sell Contract" misplaced under "Sell"?',
+    );
+    const savedHistory = [
+      {
+        proposalId: completedCard.proposalId,
+        proposalIndex: 0,
+        question: completedCard.reviewerView.question,
+        decision: "agree" as const,
+        disagreementReason: "",
+        suggestedCorrection: "",
+        reviewedAt: "2026-07-20T08:00:00.000Z",
+      },
+    ];
+
+    postMock.mockImplementation((url: string, body: any) => {
+      if (url === "/som-review/overview") {
+        return Promise.resolve({
+          datasetVersion: "dataset-1",
+          canDeliberate: false,
+          readyFollowUps: [],
+          issueTypes: [
+            {
+              id: "placement",
+              label: "10. Wrong place within Sub-branch",
+              stage: "within-branch",
+              robTaskIds: [11],
+              reviewed: 1,
+              pending: 0,
+              waiting: 0,
+              notApplicable: 0,
+              total: 1,
+              enabled: true,
+            },
+          ],
+        });
+      }
+      if (url === "/som-review/session" && body.issueType === "placement") {
+        return Promise.resolve({
+          done: true,
+          history: savedHistory,
+          historyCards: [completedCard],
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    render(<ReviewPage />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Review completed items in 10. Wrong place within Sub-branch, 1 saved",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenLastCalledWith("/som-review/session", {
+        issueType: "placement",
+      }),
+    );
+    expect(
+      await screen.findByText("All available proposals reviewed"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Open saved answer 1" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/__tests__/components/SomReview/ReviewQueueSelector.test.tsx
+++ b/__tests__/components/SomReview/ReviewQueueSelector.test.tsx
@@ -56,7 +56,7 @@ const issues: SomIssueTypeOption[] = [
     "6. Repeated miscellaneous/facet nodes",
     "within-branch",
     [4],
-    { pending: 0 },
+    { total: 4, reviewed: 4, pending: 0 },
   ),
   option("mistaken-synonym", "3. Mistaken synonyms", "content", [5]),
   option("duplicate-synonym", "4. Undetected synonyms", "content", [6]),
@@ -175,7 +175,8 @@ describe("Society of Mind review queue selector", () => {
       screen.getByText("16 ready to review").closest(".MuiChip-root"),
     ).toHaveClass("MuiChip-outlined");
     expect(screen.getAllByText("No review items found")).toHaveLength(2);
-    expect(screen.getByText("Reviewed")).toBeInTheDocument();
+    expect(screen.getByText("4 reviewed")).toBeInTheDocument();
+    expect(screen.getByText("Review completed items")).toBeInTheDocument();
     expect(screen.getByText("Related review required")).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -194,9 +195,20 @@ describe("Society of Mind review queue selector", () => {
       }),
     );
     expect(onStart).toHaveBeenCalledWith("placement");
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Review completed items in 6. Repeated miscellaneous/facet nodes, 4 saved",
+      }),
+    );
+    expect(onStart).toHaveBeenCalledWith("misc-facet-duplicate");
     expect(
       screen.getByRole("button", {
         name: "13. Review approved node merges; review its related diagnosis first",
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "2. Add missing synonyms, no review items available",
       }),
     ).toBeDisabled();
   });

--- a/src/components/SomReview/ReviewQueueSelector.tsx
+++ b/src/components/SomReview/ReviewQueueSelector.tsx
@@ -349,6 +349,8 @@ const ReviewQueueSelector = ({
                           direction="row"
                           alignItems="center"
                           spacing={1}
+                          useFlexGap
+                          flexWrap="wrap"
                           sx={{
                             gridColumn: { xs: "2", sm: "3" },
                             justifySelf: { xs: "start", sm: "end" },
@@ -370,7 +372,6 @@ const ReviewQueueSelector = ({
                                 sx={{
                                   fontSize: "0.9rem",
                                   fontWeight: 750,
-                                  whiteSpace: "nowrap",
                                 }}
                               >
                                 Review completed items

--- a/src/components/SomReview/ReviewQueueSelector.tsx
+++ b/src/components/SomReview/ReviewQueueSelector.tsx
@@ -18,6 +18,7 @@ import DriveFileRenameOutlineIcon from "@mui/icons-material/DriveFileRenameOutli
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import HubOutlinedIcon from "@mui/icons-material/HubOutlined";
 import GroupsOutlinedIcon from "@mui/icons-material/GroupsOutlined";
+import HistoryOutlinedIcon from "@mui/icons-material/HistoryOutlined";
 import AltRouteOutlinedIcon from "@mui/icons-material/AltRouteOutlined";
 import CallMergeOutlinedIcon from "@mui/icons-material/CallMergeOutlined";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
@@ -92,6 +93,16 @@ const QueueStatus = ({ issue }: { issue: SomIssueTypeOption }) => {
   if (issue.total === 0) {
     return (
       <Chip label="No review items found" size="small" variant="outlined" />
+    );
+  }
+  if (issue.pending === 0 && issue.reviewed > 0) {
+    return (
+      <Chip
+        icon={<CheckCircleOutlineIcon />}
+        label={`${issue.reviewed} reviewed`}
+        size="small"
+        variant="outlined"
+      />
     );
   }
   if (issue.pending === 0 && issue.waiting > 0) {
@@ -221,7 +232,11 @@ const ReviewQueueSelector = ({
             </Typography>
             <Stack spacing={1.25}>
               {stageIssues.map((issue) => {
-                const available = issue.enabled && issue.pending > 0;
+                const hasNewItems = issue.pending > 0;
+                const hasSavedItems = issue.reviewed > 0;
+                const completedOnly = !hasNewItems && hasSavedItems;
+                const available =
+                  issue.enabled && (hasNewItems || hasSavedItems);
                 const unavailableLabel = issue.waiting
                   ? `${issue.label}; review its related diagnosis first`
                   : `${issue.label}, no review items available`;
@@ -244,9 +259,11 @@ const ReviewQueueSelector = ({
                       disabled={!available}
                       onClick={() => onStart(issue.id)}
                       aria-label={
-                        available
-                          ? `${issue.activeSession ? "Resume" : "Start"} ${issue.label} review, ${issue.pending} remaining`
-                          : unavailableLabel
+                        completedOnly
+                          ? `Review completed items in ${issue.label}, ${issue.reviewed} saved`
+                          : available
+                            ? `${issue.activeSession ? "Resume" : "Start"} ${issue.label} review, ${issue.pending} remaining`
+                            : unavailableLabel
                       }
                       sx={{ p: { xs: 1.75, sm: 2 }, minHeight: 92 }}
                     >
@@ -322,8 +339,9 @@ const ReviewQueueSelector = ({
                                 lineHeight: 1.4,
                               }}
                             >
-                              Review its related diagnosis first. If you agree,
-                              this action will become available.
+                              {hasSavedItems
+                                ? "No new items are ready. You can revisit your saved judgments; related actions require their diagnoses first."
+                                : "Review its related diagnosis first. If you agree, this action will become available."}
                             </Typography>
                           )}
                         </Box>
@@ -337,12 +355,37 @@ const ReviewQueueSelector = ({
                           }}
                         >
                           <QueueStatus issue={issue} />
-                          {available && (
+                          {completedOnly ? (
+                            <Stack
+                              direction="row"
+                              alignItems="center"
+                              spacing={0.6}
+                              sx={{ color: "text.primary" }}
+                            >
+                              <HistoryOutlinedIcon
+                                aria-hidden="true"
+                                sx={{ fontSize: 20 }}
+                              />
+                              <Typography
+                                sx={{
+                                  fontSize: "0.9rem",
+                                  fontWeight: 750,
+                                  whiteSpace: "nowrap",
+                                }}
+                              >
+                                Review completed items
+                              </Typography>
+                              <ArrowForwardIcon
+                                aria-hidden="true"
+                                sx={{ color: "text.secondary" }}
+                              />
+                            </Stack>
+                          ) : available ? (
                             <ArrowForwardIcon
                               aria-hidden="true"
                               sx={{ color: "text.secondary" }}
                             />
-                          )}
+                          ) : null}
                         </Stack>
                       </Box>
                     </CardActionArea>

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -203,6 +203,17 @@ export const ReviewPage = () => {
       setFollowUpOffer(null);
       setActiveSequence(null);
       setCompletedSequence(null);
+      const selectedQueue = issueTypes.find(
+        (candidate) => candidate.id === issue,
+      );
+      if (
+        selectedQueue &&
+        selectedQueue.pending === 0 &&
+        selectedQueue.reviewed > 0
+      ) {
+        startSession(issue);
+        return;
+      }
       try {
         if (window.localStorage.getItem(introStorageKey(issue)) === "seen") {
           startSession(issue);
@@ -214,7 +225,7 @@ export const ReviewPage = () => {
       setIssueType(issue);
       setPhase("intro");
     },
-    [introStorageKey, startSession],
+    [introStorageKey, issueTypes, startSession],
   );
 
   const continueFromIntro = useCallback(() => {


### PR DESCRIPTION
## What changed

- Keep completed review types active on the main menu instead of disabling and graying them out.
- Label completed queues with the number reviewed and an explicit “Review completed items” affordance.
- Open completed queues directly into their saved judgments so reviewers can inspect or revise any prior answer.
- Leave genuinely empty and dependency-locked queues disabled.
- Add selector and full-page workflow tests for reopening completed work.

## Why

Reviewers need to return to completed examples during meetings and revise earlier judgments. The saved-history interface already supported this, but the main-menu card became disabled once a queue had no pending items, blocking access to that history.

## Validation

- `npm test -- --runInBand __tests__/components/SomReview __tests__/lib/somReview` (22 suites, 108 tests)
- `npm run build`
- Targeted Prettier check
- `git diff --check`
- Local browser smoke test at `http://localhost:3010/review` with no console errors