### PR TITLE
Add dependency-aware ontology review workflow

### DIFF
--- a/__tests__/components/SomReview/ReviewQueueSelector.test.tsx
+++ b/__tests__/components/SomReview/ReviewQueueSelector.test.tsx
@@ -30,6 +30,8 @@ const option = (
   waiting: 0,
   notApplicable: 0,
   enabled: true,
+  prerequisiteIssueTypes: [],
+  blockedBy: [],
   ...overrides,
 });
 
@@ -211,6 +213,78 @@ describe("Society of Mind review queue selector", () => {
         name: "2. Add missing synonyms, no review items available",
       }),
     ).toBeDisabled();
+  });
+
+  it("guides reviewers to prerequisites and locks invalid later queues", () => {
+    const onStart = jest.fn();
+    const dependencyIssues = issues.map((issue) =>
+      issue.id === "placement"
+        ? {
+            ...issue,
+            prerequisiteIssueTypes: ["title-clarity" as const],
+            blockedBy: [
+              {
+                id: "title-clarity" as const,
+                label: "1. Clarify unclear titles",
+                remaining: 37,
+              },
+            ],
+          }
+        : issue,
+    );
+    render(
+      <ReviewQueueSelector issueTypes={dependencyIssues} onStart={onStart} />,
+    );
+
+    expect(screen.getByText("Guided review path")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Continue 1. Clarify unclear titles",
+      }),
+    );
+    expect(onStart).toHaveBeenCalledWith("title-clarity");
+    expect(
+      screen.getByRole("button", {
+        name: "10. Wrong place within Sub-branch; complete Phase 1: Clarify labels first",
+      }),
+    ).toBeDisabled();
+    expect(screen.getByText("Earlier phase required")).toBeInTheDocument();
+    expect(
+      screen.getByText("Complete Phase 1: Clarify labels first."),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps saved reviews accessible while locking new items in a later phase", () => {
+    const onStart = jest.fn();
+    const dependencyIssues = issues.map((issue) =>
+      issue.id === "placement"
+        ? {
+            ...issue,
+            reviewed: 3,
+            pending: 13,
+            blockedBy: [
+              {
+                id: "title-clarity" as const,
+                label: "1. Clarify unclear titles",
+                remaining: 37,
+              },
+            ],
+          }
+        : issue,
+    );
+    render(
+      <ReviewQueueSelector issueTypes={dependencyIssues} onStart={onStart} />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Review completed items in 10. Wrong place within Sub-branch, 3 saved; complete Phase 1: Clarify labels before new items",
+      }),
+    );
+    expect(onStart).toHaveBeenCalledWith("placement");
+    expect(
+      screen.getByText("3 reviewed; new items locked"),
+    ).toBeInTheDocument();
   });
 
   it("keeps postponed linked actions directly accessible", () => {

--- a/__tests__/lib/somReview/reviewDependencies.test.ts
+++ b/__tests__/lib/somReview/reviewDependencies.test.ts
@@ -1,0 +1,97 @@
+import {
+  blockingIssuePrerequisites,
+  issuePrerequisiteTypes,
+  issueReviewIsComplete,
+} from "../../../src/lib/somReview/reviewDependencies";
+import {
+  SomIssueType,
+  SomIssueTypeOption,
+  SomReviewStage,
+} from "../../../src/types/ISomReview";
+
+const option = (
+  id: SomIssueType,
+  overrides: Partial<SomIssueTypeOption> = {},
+): SomIssueTypeOption => ({
+  id,
+  label: id,
+  stage: "content" as SomReviewStage,
+  robTaskIds: [],
+  reviewed: 0,
+  pending: 1,
+  waiting: 0,
+  notApplicable: 0,
+  total: 1,
+  enabled: true,
+  prerequisiteIssueTypes: issuePrerequisiteTypes(id),
+  blockedBy: [],
+  ...overrides,
+});
+
+describe("review queue dependencies", () => {
+  it("requires title review before meaning review", () => {
+    expect(issuePrerequisiteTypes("duplicate-synonym")).toEqual([
+      "title-clarity",
+    ]);
+  });
+
+  it("requires meaning and identity review before structural review", () => {
+    expect(issuePrerequisiteTypes("flat-list-grouping")).toEqual([
+      "title-clarity",
+      "synonym-enrichment",
+      "mistaken-synonym",
+      "duplicate-synonym",
+      "polysemy",
+      "misc-facet-duplicate",
+    ]);
+  });
+
+  it("does not add queue-level gates to exact follow-up actions", () => {
+    expect(issuePrerequisiteTypes("node-merge")).toEqual([]);
+    expect(issuePrerequisiteTypes("relocation")).toEqual([]);
+    expect(issuePrerequisiteTypes("sense-relocation")).toEqual([]);
+  });
+
+  it("treats empty, disabled, and fully answered queues as complete", () => {
+    expect(issueReviewIsComplete(option("title-clarity", { total: 0 }))).toBe(
+      true,
+    );
+    expect(
+      issueReviewIsComplete(option("title-clarity", { enabled: false })),
+    ).toBe(true);
+    expect(
+      issueReviewIsComplete(
+        option("title-clarity", { reviewed: 1, pending: 0 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports each unfinished prerequisite with a remaining count", () => {
+    const issues = new Map<SomIssueType, SomIssueTypeOption>([
+      ["title-clarity", option("title-clarity", { pending: 2 })],
+      [
+        "synonym-enrichment",
+        option("synonym-enrichment", { pending: 0, reviewed: 1 }),
+      ],
+      [
+        "mistaken-synonym",
+        option("mistaken-synonym", { pending: 0, reviewed: 1 }),
+      ],
+      ["duplicate-synonym", option("duplicate-synonym", { pending: 1 })],
+      ["polysemy", option("polysemy", { pending: 0, reviewed: 1 })],
+      [
+        "misc-facet-duplicate",
+        option("misc-facet-duplicate", { pending: 0, reviewed: 1 }),
+      ],
+    ]);
+
+    expect(blockingIssuePrerequisites("flat-list-grouping", issues)).toEqual([
+      { id: "title-clarity", label: "title-clarity", remaining: 2 },
+      {
+        id: "duplicate-synonym",
+        label: "duplicate-synonym",
+        remaining: 1,
+      },
+    ]);
+  });
+});

--- a/docs/research/chi-2027-scalable-oversight-study-proposal.md
+++ b/docs/research/chi-2027-scalable-oversight-study-proposal.md
@@ -1,0 +1,825 @@
+# Oversight Without Ground Truth
+
+## A Dependency-Aware, Disagreement-Preserving System for Reviewing AI-Proposed Ontology Changes
+
+Proposed venue: ACM CHI 2027 Papers
+
+Full-paper deadline: September 10, 2026, Anywhere on Earth
+
+Protocol status: study proposal; not yet preregistered or ethics-approved
+
+Prepared: July 20, 2026
+
+## Decision summary
+
+This is a credible CHI research direction, but the current Sell pilot is not
+sufficient evidence for a CHI paper. A defensible submission requires:
+
+1. a frozen and separately validated review interface;
+2. prompt and proposal generation frozen before confirmatory data collection;
+3. held-out ontology sub-branches rather than Sell alone;
+4. independent judgments before reviewers see model rationales;
+5. a response option for insufficient evidence or legitimate unresolved cases;
+6. multiple reviewer expertise strata without treating seniority weights as
+   scientific ground truth;
+7. structured deliberation that preserves dissent; and
+8. a held-out test of a selective oversight policy, not merely agreement rates.
+
+The [CHI 2027 call](https://chi2027.acm.org/authors/papers/) sets a September 10,
+2026 deadline. This leaves roughly seven weeks. Submission is possible only with
+immediate ethics review, bounded scope, rapid recruitment, and a firm August 3
+go/no-go decision. If those conditions are not met, the scientifically correct
+choice is to continue the study for CSCW or CHI 2028 rather than submit a rushed,
+underpowered paper.
+
+## 1. Working abstract
+
+AI agents can generate proposed improvements to complex knowledge artifacts much
+faster than scarce domain stewards can inspect them. Yet scaling oversight is
+especially difficult when proposal quality has no single objective target:
+reviewers may disagree because of error, missing evidence, uneven expertise,
+ambiguous policy, or legitimately different use goals. We present a
+dependency-aware review system that decomposes AI-proposed ontology changes into
+bounded
+before/after judgments, stages model rationales after independent human decisions,
+links diagnoses to exact downstream actions, and escalates disagreement through
+structured deliberation without forcing consensus. We evaluate the system across
+held-out branches of a large ontology of work activities with reviewers at three
+expertise levels. Our study asks which proposal types can be reviewed reliably by
+lower-cost reviewers, when structured human or AI-mediated deliberation improves
+judgments, and whether a selective oversight policy can reduce expert workload
+while preserving unresolved disagreement. Rather than construct a single gold
+label for every proposal, we distinguish formally resolvable,
+expert-reference-resolvable, and legitimately plural cases. We contribute
+empirical evidence and
+design guidance for scaling human oversight of open-ended AI work when agreement
+is informative but not synonymous with correctness.
+
+## 2. Intended contribution
+
+The paper should claim four contributions:
+
+1. **A conceptual contribution:** a model of oversight without objective targets
+   that separates resolvable error from legitimate plural judgment.
+2. **A system contribution:** a dependency-aware review workflow with independent
+   judgment, evidence exposure, exact diagnosis-to-action transitions, revision,
+   deliberation, provenance, and selective escalation.
+3. **An empirical contribution:** evidence about how proposal type, reviewer
+   expertise, model rationale, and deliberation affect decisions, uncertainty,
+   disagreement, effort, and reference-panel resolution.
+4. **An operational contribution:** a held-out selective oversight policy that
+   determines which proposals need one reviewer, multiple reviewers, expert
+   adjudication, or abstention.
+
+The paper should not claim that:
+
+- majority agreement is ground truth;
+- Tom or Rob's operational authority makes their judgment objectively correct;
+- local proposal acceptance necessarily improves the complete ontology;
+- the agents are superhuman; or
+- high model confidence is enough to remove human review.
+
+## 3. Research framing
+
+### 3.1 Operational scalable oversight
+
+Classic scalable-oversight work asks how weaker supervisors can evaluate stronger
+agents. Debate, process supervision, weak-to-strong generalization, and AI feedback
+all reduce or redistribute human judgment. The 1Ontology setting is a tractable,
+real-world analogue: a Society of Mind pipeline can produce many structural
+proposals, the number of ontology stewards is small, and quality is expensive to
+judge globally.
+
+The paper should define the construct narrowly:
+
+> Operational scalable oversight is the allocation and structuring of human
+> judgment so that a high-volume AI proposal pipeline can operate at increasing
+> coverage while maintaining predeclared quality, dissent-preservation, and audit
+> requirements.
+
+### 3.2 No single gold standard
+
+Every proposal should be classified into one of three epistemic categories:
+
+1. **Formally resolvable:** a decision can be checked against an explicit
+   invariant, source record, or ontology policy.
+2. **Reference-resolvable:** an independent qualified panel reaches a reasoned
+   decision after reviewing common evidence.
+3. **Plural or unresolved:** more than one decision remains defensible because
+   policies, use goals, or interpretations differ.
+
+Only categories 1 and 2 support an accuracy-like outcome. Category 3 requires
+distributional reporting, rationale preservation, and continued human governance.
+
+### 3.3 Why dependencies are part of the research design
+
+The same node can have title, synonym, description, placement, grouping, and final
+action proposals. Review order therefore changes the information available for a
+later judgment. The app now distinguishes:
+
+- queue-level semantic prerequisites;
+- exact proposal-level diagnosis-to-action links; and
+- dataset-level snapshot dependencies requiring adjudication and regeneration.
+
+The complete dependency rationale is documented in
+`docs/research/review-workflow-dependency-spec.md`.
+
+## 4. Research questions
+
+### RQ1: Reviewability across expertise
+
+For which ontology proposal types can informed non-stewards and general reviewers
+make judgments comparable to an independent expert reference panel, and where do
+expertise gaps remain?
+
+### RQ2: Influence and deliberation
+
+How do model-rationale exposure, structured rationale exchange, and AI-mediated
+synthesis change reviewers' decisions, confidence, disagreement reasons, effort,
+and retention of minority rationales?
+
+### RQ3: Selective oversight
+
+Can observable signals identify which proposals can receive lower-cost oversight
+and which require expert review or abstention, while meeting predeclared quality
+and dissent-preservation thresholds on held-out ontology branches?
+
+### RQ4: End-to-end compositionality
+
+Does applying decisions from the proposed oversight policy produce an ontology
+snapshot that is easier to understand and navigate without increasing formal or
+expert-identified structural defects?
+
+## 5. Preregistered expectations
+
+These are candidate hypotheses. They should be revised after the formative pilot
+and frozen before confirmatory data are inspected.
+
+- **H1, expertise interaction:** expertise gaps will be smaller for title and
+  metadata judgments than for polysemy, placement, collection, and final-action
+  judgments.
+- **H2, model influence:** revealing a model rationale will change judgments
+  toward the model more often than away from it. This is an influence hypothesis,
+  not a quality hypothesis.
+- **H3, deliberation:** structured rationale exchange will improve alignment with
+  the reference panel on reference-resolvable cases relative to a no-exchange
+  reconsideration control.
+- **H4, synthesis trade-off:** AI synthesis will reduce review time relative to a
+  raw rationale board, but may omit or flatten minority arguments unless raw
+  rationales remain expandable.
+- **H5, selective coverage:** a held-out selective policy will reduce the share of
+  proposals requiring steward adjudication while meeting preregistered quality and
+  unresolved-case leakage thresholds.
+
+## 6. System under study
+
+### 6.1 Proposal pipeline
+
+The Society of Mind pipeline uses specialized detectors and judges to produce
+proposals for:
+
+- title clarity;
+- missing or mistaken synonyms;
+- missing descriptions;
+- double meanings;
+- repeated facet nodes;
+- undetected duplicates;
+- flat-list and compound-object grouping;
+- collection design;
+- within-branch placement;
+- wrong leading verbs;
+- merge, relocation, and sense-relocation actions;
+- missing activities; and
+- redundant nodes.
+
+Every proposal must carry:
+
+- ontology snapshot ID and hash;
+- subject and referenced node IDs;
+- detector and judge prompt versions;
+- issue type and epistemic category;
+- source evidence, including O\*NET tasks where applicable;
+- dependencies and conflict group;
+- current and proposed state; and
+- rationale.
+
+### 6.2 Prompt-improvement loop before confirmatory evaluation
+
+Reviewer corrections can improve the proposal agents, but automatically rewriting
+prompts from individual comments would create unstable behavior and make the
+evaluation circular. During development only, use this versioned loop:
+
+1. collect independent decisions, corrections, and disagreement codes on Sell and
+   the designated development branch;
+2. have an LLM cluster recurring failure modes and draft candidate prompt changes,
+   without editing production prompts;
+3. require a human prompt owner to accept, reject, or revise each candidate and
+   record the rationale;
+4. run the candidate against a frozen regression set containing prior failures,
+   accepted proposals, rejected proposals, and invariant checks;
+5. retain the revision only if it improves the preregistered development metrics
+   without a material regression by issue family; and
+6. archive the prompt, model, data snapshot, and test report as one immutable
+   version.
+
+No prompt may be changed after the confirmatory prompts and branches are frozen.
+Comments from held-out participants must not flow back into prompt development
+until all confirmatory analyses are locked. This separates a useful
+human-supervised engineering loop from evidence about whether the resulting
+pipeline generalizes.
+
+### 6.3 Dependency-aware review
+
+The workflow has five phases:
+
+1. clarify labels;
+2. resolve meaning and identity;
+3. review structure and placement;
+4. confirm exact linked actions; and
+5. conduct optional quality checks.
+
+Exact actions are offered immediately after agreement with their source diagnosis.
+Broader structural phases are gated until semantic prerequisites are complete.
+Previously saved judgments remain revisable.
+
+### 6.4 Study-mode additions required
+
+The operational app should be forked into a versioned study mode with:
+
+1. `Agree`, `Disagree`, and `Insufficient evidence / unresolved` responses;
+2. confidence on a 0–100 scale;
+3. independent Stage 1 judgment before model rationale exposure;
+4. model rationale shown only after Stage 1 is locked;
+5. O\*NET/source evidence visible by default in both stages;
+6. a structured rationale form separating claim, evidence, uncertainty, and
+   suggested correction;
+7. randomized or counterbalanced proposal order;
+8. no model identity, confidence, or reviewer-role status in the reviewer view;
+9. instrumentation for view, expansion, revision, and response timing; and
+10. a deliberation view that always preserves raw rationales beside any AI
+    synthesis.
+
+## 7. Study program
+
+The UI and content questions must be separated. Otherwise, disagreement could be
+caused by a bad proposal, an unclear title, or an interaction failure.
+
+## Study 0: Formative interface and dependency validation
+
+### Purpose
+
+Establish that intended users understand exactly what each card asks, how before
+and after differ, which evidence is relevant, and why some proposals follow
+others. These data develop and freeze the instrument; they are not used as the
+main evidence about agent quality.
+
+### Participants
+
+Planning target: 12 participants, four from each group:
+
+1. ontology or knowledge-organization researchers;
+2. HR, work-analysis, organizational research, or adjacent informed users; and
+3. educated general users with no ontology experience.
+
+Project prompt authors should not participate as evaluative subjects.
+
+### Procedure
+
+1. Five-minute onboarding with one example not used later.
+2. Think-aloud review of 10–12 seeded proposals covering all major card forms.
+3. At least two dependency transitions, including diagnosis to exact action.
+4. Neutral comprehension questions after each form:
+   - What decision are you making?
+   - What changes if you agree?
+   - What remains undecided?
+   - What evidence did you use?
+5. Retrospective interview about unclear terminology, missing context, and
+   perceived pressure to follow the AI.
+
+### Freeze criteria
+
+The main study should not begin until:
+
+- at least 90% of decision-scope comprehension questions are correct;
+- no participant mistakes a diagnosis judgment for an already-applied action;
+- at least 10 of 12 participants can explain the dependency path unaided;
+- all critical accessibility defects are resolved;
+- median task completion fits the planned participant burden; and
+- no new critical usability theme appears in the last three sessions.
+
+If these criteria fail, iterate the UI and repeat targeted sessions. Do not mix
+pre-freeze and post-freeze responses in the confirmatory dataset.
+
+## Study 1: Confirmatory oversight and deliberation study
+
+### 7.1 Stimulus development and held-out test
+
+Sell is the development branch. It must not be the sole confirmatory branch
+because prompts, proposal copy, and interface behavior were tuned against it.
+
+1. Use Sell and one additional branch for prompt development and variance
+   estimation.
+2. Freeze all prompts, model versions, ontology policies, and UI behavior.
+3. Select 3–5 held-out sub-branches varying in size and semantic character.
+4. Generate proposals by issue type from the frozen pipeline.
+5. Sample approximately 180 proposals with minimum representation from six
+   families: labels/metadata, identity, grouping, placement, exact actions, and
+   optional additions/removals.
+6. Include model-proposed negatives or control items where the detector rejected a
+   change; otherwise agreement can be inflated by only reviewing positive
+   proposals.
+7. Keep a branch-level held-out partition untouched until the routing policy is
+   frozen.
+
+The exact count should follow the pilot variance and power simulation. `180` is a
+planning target, not a post hoc promise.
+
+### 7.2 Dataset-level wave execution
+
+The confirmatory study cannot review every proposal from one stale snapshot in a
+single pass.
+
+For each phase:
+
+1. generate proposals from snapshot S_t;
+2. collect all independent reviews;
+3. complete the assigned deliberation condition;
+4. obtain reference-panel disposition;
+5. apply approved changes to produce S_t+1;
+6. run invariant checks; and
+7. regenerate downstream proposals from S_t+1.
+
+This prevents later judgments from referring to titles, nodes, or parent-child
+relations that earlier approved changes would remove.
+
+### 7.3 Participants
+
+Planning target: 72 independent reviewers.
+
+| Stratum                    | Target | Eligibility                                                                                       |  Planned workload |
+| -------------------------- | -----: | ------------------------------------------------------------------------------------------------- | ----------------: |
+| Ontology/knowledge experts |     12 | ontology engineering, knowledge graphs, classification, or closely related research/practice      | 30 proposals each |
+| Informed domain users      |     24 | HR, work analysis, organizational research, labor/learning research, or related professional work | 15 proposals each |
+| General reviewers          |     36 | fluent English, careful reasoning, no required ontology background                                | 10 proposals each |
+
+This yields approximately 1,080 initial reviews: six per proposal, with two from
+each stratum. Final sample size and allocation must be selected by
+simulation-based power analysis using pilot estimates and the cross-classified
+model below.
+
+Recruitment sources may include professional networks, Prolific, relevant academic
+mailing lists, and paid expert outreach. All participants should receive fair
+compensation based on pilot-measured completion time.
+
+### 7.4 Independent review stages
+
+Each proposal has two individual stages before any social information appears.
+
+#### Stage 1: evidence-only judgment
+
+Show:
+
+- current and proposed state;
+- the exact question;
+- ontology context needed for the decision; and
+- source O\*NET tasks or other source evidence, visible by default.
+
+Hide:
+
+- model rationale;
+- model identity and confidence;
+- detector/judge agreement;
+- other reviewers' responses; and
+- reviewer seniority or role.
+
+Collect decision, confidence, claim, evidence, uncertainty, and time.
+
+#### Stage 2: model-rationale judgment
+
+Reveal the model rationale, permit evidence reinspection, and collect the same
+measures again. Preserve the Stage 1 response as immutable data while allowing a
+new Stage 2 response.
+
+Decision change is an influence measure. It is only scored as beneficial or
+harmful after reference classification.
+
+### 7.5 Deliberation assignment
+
+After Stage 2, proposals with unanimous judgments finish without deliberation but
+receive a random steward audit sample. Proposals with disagreement or substantial
+uncertainty are randomized at the proposal level to one of three conditions:
+
+1. **Reconsideration control:** matched delay, original evidence, and an invitation
+   to reconsider without seeing others' rationales.
+2. **Structured human rationale board:** anonymized claim/evidence/uncertainty
+   cards from the other reviewers, randomly ordered and grouped only by stance.
+3. **AI-mediated synthesis plus raw rationales:** a structured synthesis of claims,
+   evidence, conflicts, missing context, and minority positions, with every raw
+   rationale directly expandable.
+
+The AI mediator must not recommend `Agree` or `Disagree`. It should identify the
+decision dimensions, faithfully attribute supporting evidence, and explicitly
+state any position it could not reconcile.
+
+After exposure, each reviewer independently records a final decision, confidence,
+and explanation. Reviewers are never required to reach consensus.
+
+Randomization must be stratified by issue family and initial disagreement level.
+Each participant sees only one deliberation condition for a given proposal.
+
+### 7.6 Independent reference panel
+
+Use a 3–5 person reference panel, preferably majority-external and spanning
+ontology engineering and work-activity domain knowledge. The panel should not see
+participant distributions, model confidence, or role weights before making its
+initial judgments.
+
+Panel procedure:
+
+1. independent evidence-only judgment;
+2. independent judgment after model rationale;
+3. structured adjudication against the written ontology policy and source data;
+4. disposition as `accept`, `reject`, or `unresolved/plural`;
+5. epistemic category as formal, reference-resolvable, or plural; and
+6. written rationale and any policy clarification.
+
+Tom and Rob may serve as operational stewards or panel members, but a primary
+scientific reference composed only of project leads would be circular. At least
+two independent external panelists are strongly preferred.
+
+### 7.7 Operational authority versus scientific analysis
+
+The existing admin interface can weight stewards more than researchers and
+researchers more than outside contributors for operational recommendations. That
+governance rule must not determine the scientific outcome.
+
+The paper should report:
+
+- unweighted response distributions;
+- stratum-specific distributions;
+- reference-panel disposition;
+- counterfactual outcomes under simple majority, equal-stratum vote, current
+  operational weights, and deliberation; and
+- which proposals change outcome under each policy.
+
+## 8. Measures
+
+### 8.1 Primary measures
+
+1. **Reference alignment on resolvable cases:** agreement with the panel's accept
+   or reject disposition, reported by issue family and expertise stratum.
+2. **Unresolved-case identification:** sensitivity and precision for participant
+   `insufficient evidence` responses relative to panel `unresolved/plural` cases.
+3. **Decision transition:** Stage 1 to Stage 2 and Stage 2 to post-deliberation
+   change, including direction relative to the model and reference panel.
+4. **Minority-rationale retention:** blinded coders judge whether all distinct,
+   evidence-supported positions remain represented after deliberation.
+5. **Review effort:** active time, number of evidence expansions, rationale length,
+   and estimated cost per routed decision.
+6. **Selective oversight performance:** coverage and disaggregated risk on the
+   untouched branch.
+
+### 8.2 Secondary measures
+
+- confidence and calibration on resolvable cases;
+- inter-rater agreement, reported descriptively rather than as quality itself;
+- response revision frequency;
+- comprehension-check accuracy;
+- perceived decision clarity;
+- brief workload measure;
+- perceived procedural fairness and voice;
+- model-rationale usefulness and perceived pressure;
+- deliberation contribution balance; and
+- downstream formal invariant failures.
+
+### 8.3 Disagreement coding
+
+Two blinded coders should code rationales using a preregistered codebook:
+
+1. attention/execution error;
+2. interface or question misunderstanding;
+3. missing context;
+4. contradictory evidence;
+5. lexical ambiguity;
+6. unclear ontology policy;
+7. domain expertise difference;
+8. different use goal or granularity preference; and
+9. residual disagreement.
+
+Double-code at least 25% of rationales, report code reliability, reconcile the
+codebook rather than silently forcing low-reliability categories, and preserve
+multi-label codes.
+
+## 9. Selective oversight policy
+
+### 9.1 Routing levels
+
+The learned or rule-based policy should predict the minimum acceptable oversight:
+
+- **Route A: audit-only provisional acceptance/rejection.** No routine steward
+  review, but a random audit sample remains mandatory.
+- **Route B: two independent reviewers.** Appropriate for low-risk, highly
+  reviewable proposal types.
+- **Route C: mixed-stratum panel.** Used when expertise improves resolution or
+  judgments diverge.
+- **Route D: steward deliberation or abstention.** Used for policy ambiguity,
+  unresolved disagreement, or high-impact structural actions.
+
+No proposal should be irreversibly auto-applied during the study.
+
+### 9.2 Candidate routing features
+
+Only use features available before the route is selected:
+
+- issue family and action reversibility;
+- number of referenced nodes and dependency depth;
+- amount and consistency of source evidence;
+- detector/judge disagreement;
+- model confidence, calibrated on development data;
+- prior empirical error for that frozen prompt version;
+- branch and node structural features; and
+- whether the proposal conflicts with another proposal.
+
+Do not use protected participant attributes, post hoc reference outcomes, or a
+prompt author's manual judgment as routing features.
+
+### 9.3 Predeclared safety criteria
+
+Candidate deployment thresholds, subject to stakeholder confirmation before
+preregistration:
+
+- one-sided 95% lower confidence bound of at least 0.95 reference alignment on
+  resolvable Route A cases;
+- one-sided 95% upper confidence bound of at most 0.05 for routing panel-unresolved
+  cases to Route A;
+- no formal invariant failures after applying Route A decisions in a sandbox;
+- at least 10% random audit of Route A decisions; and
+- no issue family generalized beyond the prompt version and branch distribution
+  represented in the held-out test.
+
+Report sensitivity analyses at 0.90, 0.95, and 0.98 thresholds. The goal is not to
+maximize coverage; it is to characterize the safe coverage-quality frontier.
+
+## 10. Analysis plan
+
+### 10.1 Confirmatory models
+
+Use cross-classified hierarchical models because judgments are nested in neither
+reviewers nor proposals alone.
+
+For resolvable cases, fit a Bayesian or frequentist mixed-effects logistic model:
+
+```text
+reference_alignment ~
+  expertise_stratum * issue_family * study_stage_or_condition +
+  proposal_dependency_depth +
+  (1 + study_stage_or_condition | reviewer) +
+  (1 | proposal) +
+  (1 | ontology_branch)
+```
+
+For the three-way `agree`, `disagree`, `insufficient` outcome, use a hierarchical
+multinomial model. Analyze confidence with an ordinal or bounded model rather than
+treating a 0–100 scale as unproblematic Gaussian data.
+
+Deliberation effects are estimated only among eligible disagreement cases and
+must respect proposal-level randomization. Report average effects and interactions
+with issue family and expertise.
+
+### 10.2 Distributional analysis
+
+For every proposal, retain and visualize the response distribution. Agreement
+coefficients may be reported but should not be interpreted as correctness.
+Compare counterfactual governance policies using the same raw judgments.
+
+Latent-competence models such as MACE may be included only as sensitivity analyses
+on reference-resolvable cases. Their single-latent-truth assumption is not valid
+for plural cases.
+
+### 10.3 Rationale analysis
+
+Use the preregistered disagreement codebook, blinded coding, and representative
+quotes. Test whether the AI synthesis omits minority rationale categories more
+often than the raw rationale board. Do not use an LLM as the only qualitative
+coder; an LLM may assist retrieval after human codebook validation.
+
+### 10.4 Power analysis
+
+Do not justify sample size using a generic “30 per condition” rule. Use Study 0 or
+a separate non-confirmatory pilot to estimate:
+
+- baseline reference alignment by stratum and issue family;
+- proposal and reviewer variance;
+- proportion of proposals entering deliberation;
+- within-reviewer decision-change correlation; and
+- expected attrition.
+
+Simulate the planned hierarchical analysis across candidate reviewer and proposal
+counts. Freeze sample size before confirmatory data collection.
+
+### 10.5 Missing data and exclusions
+
+Preregister exclusions for failed attention/comprehension checks, implausibly fast
+completion, duplicate participation, and technical interruption. Preserve all
+substantive disagreement. Report analyses with and without speed-based exclusions
+and reasons for missing deliberation follow-up.
+
+## 11. End-to-end compositionality check
+
+Local proposal judgments do not prove that the resulting ontology is globally
+better. Construct three blinded snapshots for held-out evaluation:
+
+1. baseline ontology;
+2. changes selected by simple majority; and
+3. changes selected by the frozen selective oversight policy.
+
+Run automated checks for cycles, dangling references, duplicate paths, and other
+formal invariants. Then recruit 18–24 HR/work-analysis participants not used in
+Study 1 for counterbalanced tasks such as:
+
+- locate the best activity for a source work task;
+- identify where a new activity belongs;
+- explain the difference between adjacent categories; and
+- detect whether two paths represent the same activity.
+
+Primary artifact outcomes are task success, time, confidence, and explanation
+quality. Include pairwise snapshot preference only as a secondary subjective
+measure. This check provides pragmatic ontology-quality evidence and tests whether
+local decisions compose.
+
+## 12. Ethics and research integrity
+
+### Human subjects
+
+- Obtain MIT ethics/IRB determination before recruitment.
+- Explain that responses evaluate the system, not employee performance.
+- Avoid recruiting direct reports where participation could feel compulsory; use
+  an independent recruiter and compensation where internal recruitment is needed.
+- Store reviewer identity separately from study responses.
+- Do not expose role weights, senior reviewers' choices, or model confidence in
+  participant views.
+- Permit withdrawal without affecting employment or collaboration.
+
+### AI-generated study materials
+
+- Freeze and archive prompts and model versions.
+- Human-review every model-generated stimulus for personally identifying or
+  confidential information.
+- Report the use of generative AI according to ACM policy.
+- Ensure AI synthesis remains traceable to raw participant rationales.
+
+### Author and evaluator separation
+
+The prompt author should not contribute primary independent labels. System authors
+may conduct engineering and analysis, but reference-panel decisions and rationale
+coding should include blinded independent researchers. Any overlap must be
+disclosed and analyzed as a sensitivity check.
+
+## 13. Reproducibility package
+
+Subject to ontology and participant-data permissions, release:
+
+- anonymized frozen app and study mode;
+- proposal schema and dependency graph;
+- prompt and model-version manifests;
+- ontology snapshots or structurally equivalent deidentified samples;
+- preregistration and power simulation;
+- task instructions and comprehension checks;
+- analysis code and synthetic test data;
+- anonymized individual decisions and confidence;
+- deliberation condition assignments;
+- disagreement codebook and coded excerpts; and
+- selective routing policy with audit thresholds.
+
+Do not release identifiable free-text rationales without a disclosure-risk review.
+
+## 14. Feasibility, budget, and schedule
+
+### Planning budget
+
+| Cost                                       |      Planning range |
+| ------------------------------------------ | ------------------: |
+| Formative pilot compensation               |         $800–$1,500 |
+| General and informed reviewer compensation |       $4,000–$7,000 |
+| Independent expert honoraria               |       $4,000–$8,000 |
+| Artifact-level validation                  |       $1,500–$3,000 |
+| LLM/API and hosting                        |         $300–$1,000 |
+| **Total**                                  | **$10,600–$20,500** |
+
+These ranges require recalculation after the timed pilot. An unfunded internal
+six-person pilot remains useful for development but is not a substitute for the
+confirmatory study.
+
+### Aggressive CHI 2027 schedule
+
+| Date                  | Deliverable                                                                        |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| July 20–23            | Freeze research questions, dependency policy, stimulus schema, and authorship plan |
+| July 21–24            | Submit IRB/ethics protocol; begin external expert recruitment                      |
+| July 24–29            | Run Study 0; repair and freeze study UI                                            |
+| July 30–August 2      | Generate pilot branch; estimate variance; run power simulation; preregister        |
+| **August 3**          | **Go/no-go decision for CHI 2027**                                                 |
+| August 4–17           | Generate held-out waves and collect Study 1 data                                   |
+| August 18–23          | Deliberation, reference adjudication, and artifact snapshots                       |
+| August 24–28          | Artifact-level validation and confirmatory analysis                                |
+| August 29–September 5 | Complete paper and supplementary materials                                         |
+| September 6–9         | Independent methods audit, anonymization, accessibility, and final revisions       |
+| September 10          | Submit before AoE deadline; do not rely on grace period                            |
+
+### Go/no-go criteria on August 3
+
+Proceed only if all are true:
+
+- ethics approval or a documented determination permits data collection;
+- Study 0 meets interface freeze criteria;
+- at least three held-out branches and all required proposal families are ready;
+- prompt/model/UI versions are frozen;
+- power simulation supports a feasible sample;
+- at least three independent reference panelists are committed;
+- participant funding and recruitment channels are confirmed; and
+- the team can preserve branch-wave dependencies rather than review one stale
+  snapshot.
+
+If any critical criterion fails, continue the pilot, collect stronger data, and
+target a later venue.
+
+## 15. Anticipated failure modes and safeguards
+
+| Failure mode                        | Consequence                                             | Safeguard                                                    |
+| ----------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------ |
+| Sell-only evaluation                | Prompt and UI overfitting masquerades as generalization | Development/held-out branch split                            |
+| UI changes during main study        | Interface and content effects become inseparable        | Study 0 freeze and version checks                            |
+| Model rationale shown first         | Automation bias destroys independent baseline           | Locked evidence-only Stage 1                                 |
+| Forced agree/disagree               | Legitimate ambiguity becomes artificial error           | Insufficient/unresolved option                               |
+| Weighted vote as truth              | Governance authority becomes circular validation        | Separate operational and scientific analyses                 |
+| Majority-only aggregation           | Minority knowledge and use goals disappear              | Raw distributions and rationale retention outcome            |
+| Stale downstream proposals          | Later judgments refer to superseded nodes               | Adjudicate, apply, and regenerate between waves              |
+| Prompt editing on test data         | Confirmatory overfitting                                | Frozen prompts and untouched branch                          |
+| AI synthesis hallucinates consensus | Deliberation becomes persuasion                         | No recommendation; expandable raw rationales; fidelity audit |
+| Unanimous errors evade review       | Selective system appears safer than it is               | Random audit of high-agreement cases and control proposals   |
+| Local gains harm global structure   | Proposal accuracy does not compose                      | Formal checks and artifact-level user tasks                  |
+| Too few genuine experts             | Expertise conclusions are unstable                      | Early recruitment and simulation-based sample decision       |
+
+## 16. Paper outline
+
+Target 7,000–8,000 words excluding references, consistent with the CHI call.
+
+1. Introduction and motivating no-ground-truth oversight problem
+2. Related work
+   - scalable oversight and weak supervision
+   - human-AI reliance and explanation
+   - disagreement, deliberation, and expertise
+   - ontology evaluation
+3. System and dependency model
+4. Study 0 and interface freeze
+5. Study 1 method
+6. Results
+   - expertise and proposal type
+   - model-rationale influence
+   - deliberation and dissent preservation
+   - selective routing and held-out coverage-risk
+7. Artifact-level compositionality check
+8. Discussion
+   - when disagreement is oversight signal
+   - limits of local decomposition
+   - governance versus scientific truth
+   - implications beyond ontologies
+9. Limitations and ethics
+10. Conclusion
+
+## 17. Immediate actions
+
+1. Ask Tom and Rob to approve the narrow framing: scalable oversight of
+   open-ended AI proposals, not a general proof of ontology correctness.
+2. Identify an MIT co-investigator responsible for human-subjects protocol and
+   submit the ethics determination immediately.
+3. Recruit at least two external ontology/knowledge-organization experts for the
+   reference panel.
+4. Freeze a written ontology policy covering titles, synonyms, polysemy,
+   grouping, placement, and acceptable unresolved cases.
+5. Implement study mode without changing the production review experience.
+6. Select development and held-out branches before inspecting their agent
+   proposals.
+7. Run the 12-person formative UI study and simulation-based power analysis.
+8. Make the August 3 go/no-go decision based on the criteria above.
+
+## 18. Core literature
+
+The accompanying review at
+`docs/research/scalable-oversight-literature-review.md` provides the detailed
+synthesis and links. The most central sources are:
+
+- [AI Safety via Debate](https://arxiv.org/abs/1805.00899)
+- [Scalable Agent Alignment via Reward Modeling](https://arxiv.org/abs/1811.07871)
+- [Debating with More Persuasive LLMs](https://proceedings.mlr.press/v235/khan24a.html)
+- [Let's Verify Step by Step](https://arxiv.org/abs/2305.20050)
+- [Weak-to-Strong Generalization](https://cdn.openai.com/papers/weak-to-strong-generalization.pdf)
+- [The “Problem” of Human Label Variation](https://aclanthology.org/2022.emnlp-main.731/)
+- [Dealing with Disagreements](https://aclanthology.org/2022.tacl-1.6/)
+- [Resolvable vs. Irresolvable Disagreement](https://edithlaw.ca/papers/ambiguity.pdf)
+- [Jury Learning](https://hci.stanford.edu/publications/2022/gordon_jury_learning_chi22.pdf)
+- [To Trust or to Think](https://arxiv.org/abs/2102.09692)
+- [Role of Human-AI Interaction in Selective Prediction](https://ojs.aaai.org/index.php/AAAI/article/view/20465)
+- [Guidelines for Human-AI Interaction](https://doi.org/10.1145/3290605.3300233)
+- [Evaluating Ontological Decisions with OntoClean](https://doi.org/10.1145/503124.503150)
+- [A Semiotic Metrics Suite for Ontology Quality](https://doi.org/10.1016/j.datak.2004.11.010)

--- a/docs/research/review-workflow-dependency-spec.md
+++ b/docs/research/review-workflow-dependency-spec.md
@@ -1,0 +1,220 @@
+# Dependency-Aware Review Workflow
+
+Status: implementation specification for the `sell-final-hierarchy-onet-2026-07-15-v4` review dataset
+
+Source meeting: MIT CCI ontology group, July 20, 2026
+
+Implementation branch: `codex/dependency-aware-review-study`
+
+## 1. Why dependencies matter
+
+The review app does not contain 17 independent lists. Several proposal types ask
+reviewers to make decisions whose interpretation depends on earlier decisions.
+The July 20 meeting identified the clearest example: an unclear activity title
+must be resolved before a reviewer can reliably judge that activity's synonyms,
+placement, or structural role.
+
+The Sell dataset confirms three distinct dependency classes:
+
+1. **Semantic prerequisites.** A later queue assumes that labels and meanings
+   have already been interpreted. These are queue-level dependencies.
+2. **Diagnosis-to-action dependencies.** A precise merge or relocation should
+   only be reviewed after its corresponding diagnosis is accepted. These are
+   proposal-level dependencies.
+3. **Snapshot dependencies.** Accepted changes in one phase may change the
+   inputs to later detectors. These are dataset-level dependencies and require
+   adjudication, application, and proposal regeneration between study waves.
+
+Treating all three as a generic “waiting” state hides what the reviewer must do,
+encourages invalid review order, and makes it difficult to reason about whether
+the resulting judgments are comparable.
+
+## 2. Evidence from the Sell dataset
+
+The same ontology nodes recur across proposal types. Examples include:
+
+| Node                   | Proposal types in the frozen dataset                       |
+| ---------------------- | ---------------------------------------------------------- |
+| Sell Service (1)       | title clarity, description, mistaken synonym, placement    |
+| Sell Good              | title clarity, description, undetected synonym, node merge |
+| Sell Contract          | title clarity, description, placement, relocation          |
+| Sell Package           | title clarity, description, placement, relocation          |
+| Market Space           | title clarity, description, wrong verb, relocation         |
+| Sell Products or Ideas | description, double meaning, sense relocation              |
+
+Every final-action proposal in the current dataset has a specific source:
+
+- 6 node merges depend on 2 repeated-facet diagnoses or 4 undetected-synonym
+  diagnoses.
+- 11 relocations depend on 6 within-sub-branch placement diagnoses or 5
+  wrong-verb diagnoses.
+- 1 sense relocation depends on the double-meaning diagnosis.
+
+These links are encoded in `workflow.dependsOnProposalIds` and should not be
+replaced by queue-level rules.
+
+## 3. Dependency policy
+
+### Phase 1: clarify labels
+
+Required queue:
+
+- `title-clarity`
+
+Rationale: title clarity is a semantic precondition for judgments about identity,
+meaning, and structure. Reviewers should not have to infer what an opaque label
+means while simultaneously evaluating a different proposed change.
+
+### Phase 2: resolve meaning and identity
+
+Queues:
+
+- `synonym-enrichment`
+- `mistaken-synonym`
+- `duplicate-synonym`
+- `polysemy`
+- `misc-facet-duplicate`
+
+Rules:
+
+- All meaning queues require Phase 1.
+- `misc-facet-duplicate` additionally requires synonym-enrichment,
+  mistaken-synonym, duplicate-synonym, and polysemy because it asks a structural
+  overlap question after node identity has been considered.
+- The first four meaning queues are otherwise parallel. The current evidence does not
+  justify an arbitrary order among them.
+
+### Phase 3: review structure and placement
+
+Queues:
+
+- `flat-list-grouping`
+- `compound-object-grouping`
+- `collection-design`
+- `placement`
+- `wrong-verb`
+
+Prerequisites:
+
+- Phase 1
+- missing synonyms
+- mistaken synonyms
+- undetected synonyms
+- double meanings
+- repeated miscellaneous/facet nodes
+
+Rationale: grouping and placement assume that reviewers know what each node
+denotes and which nodes should remain distinct.
+
+### Phase 4: confirm exact changes
+
+Queues:
+
+- `node-merge`
+- `relocation`
+- `sense-relocation`
+
+Rule: no global queue gate. Each action is unlocked only by agreement with its
+exact source diagnosis. The reviewer is offered that follow-up immediately while
+the source node and evidence remain fresh.
+
+This exception is intentional. Requiring completion of an entire diagnosis queue
+before an exact follow-up would increase memory burden without improving validity.
+
+### Phase 5: optional quality checks
+
+Queues:
+
+- `description-enrichment`
+- `missing-activity`
+- `redundant-node`
+
+Rules:
+
+- Descriptions require clarified titles.
+- Missing and redundant activity reviews require clarified identity and meaning.
+- These queues do not block restructuring and are marked optional.
+
+## 4. Reviewer-facing behavior
+
+The interface implements the following behavior:
+
+1. A **Guided review path** shows five phases, their status, and the next valid
+   queue.
+2. A blocked queue names the unfinished earlier queue or queues. It never uses an
+   unexplained “waiting” badge for a phase dependency.
+3. A reviewer cannot start unanswered items in a blocked queue through the UI or
+   by calling the session API directly.
+4. Previously saved judgments remain accessible, including judgments made before
+   phase gating was introduced.
+5. Exact diagnosis-to-action follow-ups bypass queue gates and remain available
+   immediately after agreement with their source diagnosis.
+6. “Related review required” is reserved for proposal-level action dependencies;
+   “Earlier phase required” is reserved for queue-level semantic prerequisites.
+7. The app continues to state that review responses are recorded separately from
+   ontology changes.
+
+## 5. Server enforcement
+
+Client-only disabling is insufficient because a stale client or direct request
+could create an invalid review session. The session API therefore:
+
+- calculates unfinished prerequisite queues for the current reviewer;
+- returns HTTP 409 with `PREREQUISITE_REVIEW_REQUIRED` when an unanswered blocked
+  queue is requested;
+- allows `historyOnly` access to saved judgments;
+- allows a valid `preferredProposalId` when it is an exact linked follow-up.
+
+The overview API returns both:
+
+- `prerequisiteIssueTypes`: the declared dependency graph; and
+- `blockedBy`: the currently unfinished prerequisites and remaining counts.
+
+## 6. Important scientific limitation
+
+The current implementation enforces **review order within one frozen dataset**.
+It does not apply accepted changes or regenerate downstream proposals. That is
+adequate for interface piloting, but it is not enough for a confirmatory study of
+the full pipeline.
+
+The production study must use dataset-level waves:
+
+1. Freeze ontology snapshot S0 and generate Phase 1 proposals.
+2. Collect independent Phase 1 reviews.
+3. Adjudicate and apply accepted changes to create S1.
+4. Regenerate Phase 2 proposals from S1 and preserve provenance linking S0 to S1.
+5. Repeat for structural phases.
+
+Without regeneration, a reviewer may approve a clearer title in Phase 1 but see
+the old title in a later proposal, or may judge a structure containing a node that
+an earlier decision would merge. Such observations are not independent evidence
+about pipeline quality.
+
+## 7. Non-dependencies
+
+The following should not be encoded without new evidence:
+
+- a fixed order among all queues inside the same phase;
+- a requirement to complete optional descriptions before restructuring;
+- a global requirement to finish every diagnosis before reviewing an exact
+  follow-up;
+- automatic acceptance based solely on high model confidence;
+- a scientific weighting rule that treats senior reviewers as ground truth.
+
+Tom and Rob may have greater **governance authority** in operational decisions,
+but role weights must remain separate from the study's analysis of judgments and
+disagreement.
+
+## 8. Acceptance checks
+
+- [x] The title queue is the first required phase.
+- [x] Meaning queues remain unavailable until titles are complete.
+- [x] Structural queues remain unavailable until identity questions are complete.
+- [x] Optional checks do not block restructuring.
+- [x] Exact merge and move actions retain proposal-level links.
+- [x] Saved judgments can still be reopened.
+- [x] Server and client enforce the same queue policy.
+- [x] Focused unit tests cover completion, blocking counts, saved-history access,
+      and exact follow-ups.
+- [ ] Before confirmatory data collection, implement admin-controlled wave
+      release and proposal regeneration from adjudicated ontology snapshots.

--- a/docs/research/scalable-oversight-literature-review.md
+++ b/docs/research/scalable-oversight-literature-review.md
@@ -1,0 +1,312 @@
+# Scalable Oversight Without Objective Targets
+
+## A focused literature review for AI-proposed ontology changes
+
+Review date: July 20, 2026
+
+Scope: primary research on scalable oversight, human-AI judgment, disagreement,
+deliberation, expertise, selective prediction, and ontology evaluation.
+
+## Executive synthesis
+
+The proposed ontology-review study sits at the intersection of two research
+traditions that use similar language for different problems.
+
+1. **AI alignment and scalable oversight** ask how weaker supervisors can judge
+   outputs that are too complex or costly to evaluate directly. Debate, process
+   supervision, recursive reward modeling, weak-to-strong generalization, and
+   AI-generated feedback are prominent approaches.
+2. **HCI, CSCW, and human computation** ask how people and AI should interact
+   when judgments are fallible, expertise is uneven, and disagreement may be
+   informative rather than noise.
+
+The ontology case is not yet a demonstration of oversight over a superhuman
+model. It is a defensible instance of **operational scalable oversight**: AI agents
+can generate substantially more open-ended structural proposals than a small set
+of ontology stewards can inspect, while the quality target is only partially
+specified and sometimes contestable.
+
+Five conclusions are especially important:
+
+1. Decompose complex outcomes into locally inspectable decisions, but validate
+   that local approval composes into a better global artifact.
+2. Collect an independent human judgment before exposing the model's rationale.
+   Explanations alone do not reliably prevent overreliance.
+3. Do not convert every disagreement into a majority label. First distinguish
+   mistakes, missing context, policy ambiguity, expertise differences, and
+   legitimate alternative goals.
+4. Deliberation should preserve minority rationales and permit an unresolved
+   result. Consensus is evidence only when it is reasoned and not coerced.
+5. Replace the false choice between 100% human review and autonomous execution
+   with selective oversight: use empirical evidence to decide which proposal
+   classes need one reviewer, multiple reviewers, expert adjudication, or
+   continued abstention.
+
+## 1. What “scalable oversight” means here
+
+[Leike et al.](https://arxiv.org/abs/1811.07871) frame scalable alignment as the
+problem of learning and extending a user's implicit objective when direct reward
+specification and exhaustive feedback are infeasible. [Irving, Christiano, and
+Amodei](https://arxiv.org/abs/1805.00899) propose debate so that competing agents
+surface information a weaker judge could otherwise miss. In an empirical analogue,
+[Khan et al.](https://proceedings.mlr.press/v235/khan24a.html) found that debate
+helped nonexpert model and human judges answer questions whose decisive evidence
+was held by stronger debaters.
+
+Several related approaches reduce the unit of oversight:
+
+- [Lightman et al.](https://arxiv.org/abs/2305.20050) show, in mathematical
+  reasoning, that supervision of intermediate steps can outperform outcome-only
+  supervision and can support active selection of feedback.
+- [Bai et al.](https://arxiv.org/abs/2212.08073) replace many direct human labels
+  with AI critique and preference judgments constrained by a human-written
+  constitution.
+- [Burns et al.](https://cdn.openai.com/papers/weak-to-strong-generalization.pdf)
+  study whether weak supervision can elicit capabilities from a stronger model,
+  while emphasizing that naive weak supervision remains substantially limited.
+- [Collective Constitutional AI](https://www.anthropic.com/news/collective-constitutional-ai-aligning-a-language-model-with-public-input)
+  demonstrates one process for turning public input into explicit principles,
+  although deliberative participation and training remain distinct stages.
+
+### Implication for 1Ontology
+
+The review app's before/after cards are a form of process decomposition: instead
+of asking whether a complete ontology is “good,” reviewers judge bounded proposed
+changes. That analogy is useful but must not be overstated. The agents are not
+proven to exceed expert capability, and the decomposition itself may omit global
+interactions. A rigorous paper should call this _scalable human oversight of
+high-volume, open-ended AI proposals_, not superhuman alignment.
+
+## 2. No objective target does not mean no evaluation
+
+Ontology quality is multidimensional. [Burton-Jones et al.](https://doi.org/10.1016/j.datak.2004.11.010)
+distinguish syntactic, semantic, pragmatic, and social quality. [Guarino and
+Welty's OntoClean](https://doi.org/10.1145/503124.503150) shows that some
+subsumption errors can be assessed against formal metaproperties. A review of
+biomedical ontology evaluation practices identifies four broad strategies:
+comparison with a gold standard, application-based evaluation, corpus or coverage
+analysis, and expert review against criteria ([Amith et al.](https://pmc.ncbi.nlm.nih.gov/articles/PMC5882531/)).
+NIST similarly notes the lack of community consensus about ontology quality and
+the need for empirically grounded evaluation practices
+([NIST IR 8008](https://nvlpubs.nist.gov/nistpubs/ir/2014/NIST.IR.8008.pdf)).
+
+Therefore, “there is no ground truth” should be decomposed into three cases:
+
+1. **Formally resolvable:** violations of explicit ontology rules or data
+   invariants can have objective checks.
+2. **Reference-resolvable:** qualified experts can reach a reasoned reference
+   decision after inspecting shared evidence and policy.
+3. **Plural or goal-dependent:** multiple structures remain defensible because
+   they optimize different users, granularity levels, or downstream tasks.
+
+The study should not use one metric for all three.
+
+## 3. Human disagreement is a signal to diagnose
+
+[Plank](https://aclanthology.org/2022.emnlp-main.731/) argues that label variation
+can arise from subjectivity and multiple plausible answers rather than noise.
+[Davani, Díaz, and Prabhakaran](https://aclanthology.org/2022.tacl-1.6/) show that
+majority aggregation can erase systematic annotator perspectives. [Jury
+Learning](https://hci.stanford.edu/publications/2022/gordon_jury_learning_chi22.pdf)
+demonstrates that changing who is represented in a decision rule can alter model
+outcomes, making aggregation a governance choice rather than a neutral statistic.
+
+[Schaekermann et al.](https://edithlaw.ca/papers/ambiguity.pdf) directly compare
+resolvable and irresolvable disagreement. Their findings show that resolvability
+depends on why people disagree, initial consensus, and the amount and quality of
+deliberation. In a clinical setting, [structured expert
+adjudication](https://edithlaw.ca/papers/adjudication.pdf) revealed that expert
+background, data presentation, and guideline clarity all contribute to initial
+and persistent disagreement.
+
+### Implication for 1Ontology
+
+The primary data are not only `agree` and `disagree`. The study must preserve:
+
+- initial independent decisions;
+- confidence and “insufficient information” responses;
+- evidence-linked rationales;
+- reviewer expertise and relevant experience;
+- post-deliberation decisions;
+- whether disagreement was resolved; and
+- a coded reason for disagreement.
+
+A useful disagreement taxonomy is:
+
+1. attention or execution error;
+2. misunderstood question or interface;
+3. missing or contradictory evidence;
+4. unclear title or lexical ambiguity;
+5. unclear ontology policy;
+6. domain-knowledge difference;
+7. different use goals or granularity preferences; and
+8. residual unexplained disagreement.
+
+Categories 1–6 may motivate task, interface, evidence, or prompt repair. Category
+7 should usually be preserved rather than “fixed” by majority vote.
+
+## 4. Deliberation can help, but consensus is not the objective
+
+Structured deliberation has repeatedly improved discussion quality or judgment
+in appropriate settings:
+
+- [Schaekermann et al.](https://edithlaw.ca/papers/ambiguity.pdf) found improved
+  correctness and characterized when cases remained unresolved.
+- [Kim et al.'s DebateBot](https://doi.org/10.1145/3449161) found that structured
+  discussion promoted diverse contributions and perceived deliberative quality,
+  while facilitation improved contribution equality and alignment.
+- [Ma et al.](https://arxiv.org/abs/2403.16812) use dimension-level opinion
+  elicitation and human-AI discussion rather than a single accept/reject exchange.
+- [Khan et al.](https://proceedings.mlr.press/v235/khan24a.html) show that
+  adversarial arguments can reveal otherwise unavailable evidence, but their
+  benchmark has known answers and should not be generalized directly to
+  contestable ontology design.
+
+The design implication is **deliberation with an exit**. Reviewers should be able
+to converge, revise one another, request evidence, or mark the case unresolved.
+An AI moderator may cluster claims, locate contradictions, and ensure that each
+position is represented, but should not manufacture a single recommendation.
+
+## 5. Exposure to AI rationales must be staged
+
+The current app presents an LLM-generated recommendation and rationale. This is
+useful operationally but creates a measurement problem. [Buçinca, Malaya, and
+Gajos](https://arxiv.org/abs/2102.09692) found that explanations alone did not
+prevent overreliance, while cognitive forcing reduced overreliance at a usability
+cost. [Bondi et al.](https://ojs.aaai.org/index.php/AAAI/article/view/20465) found
+that selective-prediction messaging changed human accuracy; informing people
+that the system deferred without revealing its prediction performed better in
+their task than revealing the prediction.
+
+The study should therefore collect:
+
+1. an initial judgment from the before/after evidence without model identity,
+   confidence, or rationale;
+2. a second judgment after revealing the rationale and source evidence; and
+3. deliberation only after independent judgments are locked.
+
+This design measures model influence and protects the independence needed for
+meaningful disagreement analysis. It does not assume that changing toward the
+model is good.
+
+## 6. Expertise is both a measurement variable and a governance choice
+
+Latent-truth aggregation methods such as
+[MACE](https://aclanthology.org/N13-1132/) estimate annotator competence from
+redundant labels. Such models are useful sensitivity analyses when a single truth
+is plausible, but they are poorly suited as the primary method when systematic
+disagreement may be valid. Research on expertise-aware crowdsourcing suggests
+that expertise can improve aggregation ([Merritt et al.](https://ojs.aaai.org/index.php/HCOMP/article/view/13263)),
+but expertise is not a universal scalar: a work analyst, ontology engineer, and
+intended nonexpert user may each be authoritative for different criteria.
+
+The study should separate:
+
+- **scientific analysis:** model each reviewer's expertise and report
+  stratum-specific judgment distributions; and
+- **operational governance:** allow authorized stewards to decide whose judgment
+  governs an actual ontology release.
+
+Tom and Rob's higher operational authority must not silently become a statistical
+claim that their answers are objective ground truth.
+
+## 7. Selective oversight is the appropriate scaling target
+
+Selective classification trades coverage against risk by allowing a system to
+abstain ([El-Yaniv and Wiener](https://jmlr.csail.mit.edu/papers/v11/el-yaniv10a.html)).
+Learning-to-defer work routes cases to humans when machine judgment is less
+reliable, while emphasizing that human and AI behavior are interdependent
+([Bondi et al.](https://ojs.aaai.org/index.php/AAAI/article/view/20465);
+[Wei, Cao, and Feng](https://proceedings.mlr.press/v235/wei24a.html)).
+
+For ontology review, the policy should not initially be “auto-apply or human.”
+It should have at least four routes:
+
+1. one independent reviewer plus audit;
+2. multiple independent reviewers;
+3. structured deliberation and steward adjudication; and
+4. unresolved/defer until policy or evidence improves.
+
+Coverage-risk analysis can be adapted, but “risk” must remain disaggregated:
+
+- reversal by an expert reference panel on resolvable cases;
+- failure to identify a legitimately unresolved case;
+- downstream ontology invariant violation;
+- loss of a documented minority rationale; and
+- review time and monetary cost.
+
+Collapsing these into one accuracy score would recreate the ground-truth problem
+the study is meant to address.
+
+## 8. Human-AI interaction requirements
+
+[Amershi et al.](https://doi.org/10.1145/3290605.3300233) emphasize communicating
+system capabilities, supporting correction, and preserving user control. Applied
+to the review app, the study interface should:
+
+- state exactly which decision is being requested;
+- show current and proposed states symmetrically;
+- show source evidence without hiding it behind expert-only language;
+- distinguish diagnosis from irreversible action;
+- allow revision of saved judgments;
+- expose phase and exact proposal dependencies;
+- permit uncertainty or insufficient-evidence responses;
+- preserve raw rationales next to any AI synthesis; and
+- record every prompt, model, ontology snapshot, and UI version.
+
+## 9. Literature-to-design matrix
+
+| Evidence                             | What the study contributes                                          | Design consequence                                                                             |
+| ------------------------------------ | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Irving et al., AI debate             | Stronger agents can surface evidence for weaker judges              | Compare raw rationales with structured AI synthesis, not unaided voting alone                  |
+| Khan et al., empirical debate        | Debate helped nonexpert judges on answerable tasks                  | Test whether the benefit extends to partly contestable judgments; retain an unresolved outcome |
+| Lightman et al., process supervision | Local step feedback can outperform outcome-only feedback            | Review bounded proposal steps and separately validate whole-ontology outcomes                  |
+| Burns et al., weak-to-strong         | Weak labels can elicit some strong capability but leave a large gap | Do not treat lower-expertise agreement as proof that oversight has succeeded                   |
+| Plank; Davani et al.                 | Label variation may encode perspectives                             | Store distributions and annotator-level data; do not majority-collapse the dataset             |
+| Schaekermann et al.                  | Disagreement has resolvable and irreducible causes                  | Code disagreement reasons and allow unresolved cases                                           |
+| Jury Learning                        | Aggregation composition changes outcomes                            | Make reviewer composition explicit and report counterfactual aggregation policies              |
+| Buçinca et al.                       | Explanations can induce overreliance                                | Lock an independent initial judgment before model rationale                                    |
+| Bondi et al.                         | Deferral messaging changes human performance                        | Experimentally control what the reviewer learns about the model                                |
+| Amershi et al.                       | Human-AI systems require correction and control affordances         | Preserve revision, provenance, and clear action boundaries                                     |
+| OntoClean                            | Some ontology errors are formally testable                          | Separate formal checks from preference-sensitive structural judgments                          |
+| Burton-Jones et al.                  | Ontology quality is multidimensional                                | Include pragmatic and social utility, not only structural correctness                          |
+
+## 10. Open research gap
+
+Existing scalable-oversight studies typically use tasks with externally known
+answers or formal verifiers. Disagreement research explains why consensus may be
+undesirable, but rarely connects that insight to selective automation of a
+multi-stage AI pipeline. Ontology evaluation offers formal metrics and expert
+review methods, but little evidence about how to allocate oversight across
+AI-generated proposal types and reviewer expertise levels.
+
+The strongest CHI contribution is therefore not “an LLM improves an ontology.” It
+is a dependency-aware, disagreement-preserving method for deciding **which AI
+proposals can receive less oversight, which require deliberation, and which must
+remain unresolved when quality has no single objective target**.
+
+## References
+
+- Amershi, S., et al. (2019). [Guidelines for Human-AI Interaction](https://doi.org/10.1145/3290605.3300233).
+- Amith, M., et al. (2018). [Assessing the Practice of Biomedical Ontology Evaluation](https://pmc.ncbi.nlm.nih.gov/articles/PMC5882531/).
+- Bai, Y., et al. (2022). [Constitutional AI](https://arxiv.org/abs/2212.08073).
+- Bondi, E., et al. (2022). [Role of Human-AI Interaction in Selective Prediction](https://ojs.aaai.org/index.php/AAAI/article/view/20465).
+- Burns, C., et al. (2023). [Weak-to-Strong Generalization](https://cdn.openai.com/papers/weak-to-strong-generalization.pdf).
+- Burton-Jones, A., et al. (2005). [A Semiotic Metrics Suite for Assessing the Quality of Ontologies](https://doi.org/10.1016/j.datak.2004.11.010).
+- Buçinca, Z., Malaya, M. B., & Gajos, K. Z. (2021). [To Trust or to Think](https://arxiv.org/abs/2102.09692).
+- Davani, A. M., Díaz, M., & Prabhakaran, V. (2022). [Dealing with Disagreements](https://aclanthology.org/2022.tacl-1.6/).
+- El-Yaniv, R., & Wiener, Y. (2010). [On the Foundations of Noise-free Selective Classification](https://jmlr.csail.mit.edu/papers/v11/el-yaniv10a.html).
+- Gordon, M. L., et al. (2022). [Jury Learning](https://hci.stanford.edu/publications/2022/gordon_jury_learning_chi22.pdf).
+- Guarino, N., & Welty, C. (2002). [Evaluating Ontological Decisions with OntoClean](https://doi.org/10.1145/503124.503150).
+- Hovy, D., et al. (2013). [Learning Whom to Trust with MACE](https://aclanthology.org/N13-1132/).
+- Irving, G., Christiano, P., & Amodei, D. (2018). [AI Safety via Debate](https://arxiv.org/abs/1805.00899).
+- Khan, A., et al. (2024). [Debating with More Persuasive LLMs Leads to More Truthful Answers](https://proceedings.mlr.press/v235/khan24a.html).
+- Kim, S., et al. (2021). [Moderator Chatbot for Deliberative Discussion](https://doi.org/10.1145/3449161).
+- Leike, J., et al. (2018). [Scalable Agent Alignment via Reward Modeling](https://arxiv.org/abs/1811.07871).
+- Lightman, H., et al. (2023). [Let's Verify Step by Step](https://arxiv.org/abs/2305.20050).
+- Ma, S., et al. (2024). [Towards Human-AI Deliberation](https://arxiv.org/abs/2403.16812).
+- Merritt, D., et al. (2015). [Using Expertise for Crowd-Sourcing](https://ojs.aaai.org/index.php/HCOMP/article/view/13263).
+- Plank, B. (2022). [The “Problem” of Human Label Variation](https://aclanthology.org/2022.emnlp-main.731/).
+- Schaekermann, M., et al. (2018). [Resolvable vs. Irresolvable Disagreement](https://edithlaw.ca/papers/ambiguity.pdf).
+- Schaekermann, M., et al. (2019). [Understanding Expert Disagreement through Structured Adjudication](https://edithlaw.ca/papers/adjudication.pdf).
+- Wei, Z., Cao, Y., & Feng, L. (2024). [Exploiting Human-AI Dependence for Learning to Defer](https://proceedings.mlr.press/v235/wei24a.html).

--- a/src/components/SomReview/ReviewPath.tsx
+++ b/src/components/SomReview/ReviewPath.tsx
@@ -1,0 +1,208 @@
+import React from "react";
+import { Box, Button, Chip, Stack, Typography } from "@mui/material";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+
+import { SOM_REVIEW_PATH } from "../../lib/somReview/reviewDependencies";
+import { SomIssueType, SomIssueTypeOption } from "../../types/ISomReview";
+
+type StepStatus = "complete" | "current" | "later" | "contextual" | "optional";
+
+const statusForStep = (
+  issues: SomIssueTypeOption[],
+  contextual?: boolean,
+  optional?: boolean,
+): StepStatus => {
+  if (optional) return "optional";
+  const relevant = issues.filter((issue) => issue.enabled && issue.total > 0);
+  if (
+    relevant.length === 0 ||
+    relevant.every((issue) => issue.pending === 0 && issue.waiting === 0)
+  ) {
+    return "complete";
+  }
+  if (contextual) {
+    return relevant.some((issue) => issue.pending > 0)
+      ? "current"
+      : "contextual";
+  }
+  if (
+    relevant.some(
+      (issue) => issue.pending > 0 && (issue.blockedBy || []).length === 0,
+    )
+  ) {
+    return "current";
+  }
+  return "later";
+};
+
+const StatusChip = ({ status }: { status: StepStatus }) => {
+  if (status === "complete") {
+    return (
+      <Chip
+        icon={<CheckCircleOutlineIcon />}
+        label="Complete"
+        color="success"
+        size="small"
+        variant="outlined"
+      />
+    );
+  }
+  if (status === "current") {
+    return <Chip label="Current" color="primary" size="small" />;
+  }
+  if (status === "later") {
+    return (
+      <Chip
+        icon={<LockOutlinedIcon />}
+        label="Later"
+        size="small"
+        variant="outlined"
+      />
+    );
+  }
+  return (
+    <Chip
+      label={status === "optional" ? "Optional" : "As decisions unlock it"}
+      size="small"
+      variant="outlined"
+    />
+  );
+};
+
+const ReviewPath = ({
+  issueTypes,
+  onStart,
+}: {
+  issueTypes: SomIssueTypeOption[];
+  onStart: (issueType: SomIssueType) => void;
+}) => {
+  const issuesById = new Map(issueTypes.map((issue) => [issue.id, issue]));
+  const steps = SOM_REVIEW_PATH.map((step) => {
+    const issues = step.issueTypes.flatMap((id) => {
+      const issue = issuesById.get(id);
+      return issue ? [issue] : [];
+    });
+    return {
+      ...step,
+      issues,
+      status: statusForStep(issues, step.contextual, step.optional),
+    };
+  });
+  const nextIssue = steps
+    .filter((step) => !step.contextual && !step.optional)
+    .flatMap((step) => step.issues)
+    .find(
+      (issue) =>
+        issue.enabled &&
+        issue.pending > 0 &&
+        (issue.blockedBy || []).length === 0,
+    );
+
+  return (
+    <Box
+      component="section"
+      aria-labelledby="review-path-heading"
+      sx={{
+        borderTop: 1,
+        borderBottom: 1,
+        borderColor: "divider",
+        py: 2.25,
+        mb: 3.5,
+      }}
+    >
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        justifyContent="space-between"
+        alignItems={{ xs: "stretch", sm: "flex-start" }}
+        spacing={1.5}
+        sx={{ mb: 2 }}
+      >
+        <Box>
+          <Typography
+            id="review-path-heading"
+            component="h2"
+            sx={{ fontSize: "1.15rem", fontWeight: 800 }}
+          >
+            Guided review path
+          </Typography>
+          <Typography
+            sx={{ mt: 0.35, color: "text.secondary", lineHeight: 1.5 }}
+          >
+            Complete each required phase before starting proposals that depend
+            on it.
+          </Typography>
+        </Box>
+        {nextIssue && (
+          <Button
+            disableElevation
+            variant="contained"
+            endIcon={<ArrowForwardIcon />}
+            onClick={() => onStart(nextIssue.id)}
+            sx={{ minHeight: 46, flex: "0 0 auto", fontWeight: 750 }}
+          >
+            {nextIssue.activeSession ? "Continue" : "Start"} {nextIssue.label}
+          </Button>
+        )}
+      </Stack>
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: {
+            xs: "1fr",
+            md: "repeat(2, minmax(0, 1fr))",
+            xl: "repeat(5, minmax(0, 1fr))",
+          },
+          gap: 0,
+        }}
+      >
+        {steps.map((step, index) => (
+          <Box
+            key={step.id}
+            sx={{
+              minWidth: 0,
+              py: { xs: 1.25, md: 0.5 },
+              px: { xs: 0, md: 1.5 },
+              borderTop: {
+                xs: index === 0 ? 0 : 1,
+                md: index < 2 ? 0 : 1,
+                xl: 0,
+              },
+              borderLeft: {
+                xs: 0,
+                md: index % 2 === 0 ? 0 : 1,
+                xl: index === 0 ? 0 : 1,
+              },
+              borderColor: "divider",
+            }}
+          >
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+              spacing={1}
+            >
+              <Typography sx={{ fontWeight: 800, lineHeight: 1.35 }}>
+                {step.number}. {step.title}
+              </Typography>
+              <StatusChip status={step.status} />
+            </Stack>
+            <Typography
+              sx={{
+                mt: 0.55,
+                color: "text.secondary",
+                fontSize: "0.88rem",
+                lineHeight: 1.45,
+              }}
+            >
+              {step.description}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default ReviewPath;

--- a/src/components/SomReview/ReviewQueueSelector.tsx
+++ b/src/components/SomReview/ReviewQueueSelector.tsx
@@ -32,9 +32,32 @@ import {
   SomLinkedFollowUp,
 } from "../../types/ISomReview";
 import { SOM_REVIEW_STAGES } from "../../lib/somReview/reviewTaxonomy";
+import { SOM_REVIEW_PATH } from "../../lib/somReview/reviewDependencies";
 import { ISSUE_DESCRIPTIONS } from "./reviewCopy";
 import { reviewAccentColor, reviewIconColor } from "./reviewStyles";
 import ReviewFollowUpPanel from "./ReviewFollowUpPanel";
+import ReviewPath from "./ReviewPath";
+
+const reviewPathStepByIssue = new Map(
+  SOM_REVIEW_PATH.flatMap((step) =>
+    step.issueTypes.map((issueType) => [issueType, step] as const),
+  ),
+);
+
+const blockingPhaseSummary = (
+  blockers: SomIssueTypeOption["blockedBy"],
+): string => {
+  const labels = Array.from(
+    new Set(
+      blockers.map((blocker) => {
+        const step = reviewPathStepByIssue.get(blocker.id);
+        return step ? `Phase ${step.number}: ${step.title}` : blocker.label;
+      }),
+    ),
+  );
+  if (labels.length <= 1) return labels[0] || "the earlier phase";
+  return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
+};
 
 const activeQueueStatusSx: SxProps<Theme> = {
   backgroundColor: (theme) =>
@@ -93,6 +116,20 @@ const QueueStatus = ({ issue }: { issue: SomIssueTypeOption }) => {
   if (issue.total === 0) {
     return (
       <Chip label="No review items found" size="small" variant="outlined" />
+    );
+  }
+  if ((issue.blockedBy || []).length > 0 && issue.pending > 0) {
+    return (
+      <Chip
+        icon={<LockOutlinedIcon />}
+        label={
+          issue.reviewed > 0
+            ? `${issue.reviewed} reviewed; new items locked`
+            : "Earlier phase required"
+        }
+        size="small"
+        variant="outlined"
+      />
     );
   }
   if (issue.pending === 0 && issue.reviewed > 0) {
@@ -201,6 +238,8 @@ const ReviewQueueSelector = ({
       issue to review.
     </Typography>
 
+    <ReviewPath issueTypes={issueTypes} onStart={onStart} />
+
     {onStartFollowUp && (
       <ReviewFollowUpPanel
         followUps={readyFollowUps}
@@ -234,12 +273,17 @@ const ReviewQueueSelector = ({
               {stageIssues.map((issue) => {
                 const hasNewItems = issue.pending > 0;
                 const hasSavedItems = issue.reviewed > 0;
+                const blockers = issue.blockedBy || [];
+                const blocked = blockers.length > 0 && hasNewItems;
                 const completedOnly = !hasNewItems && hasSavedItems;
                 const available =
-                  issue.enabled && (hasNewItems || hasSavedItems);
-                const unavailableLabel = issue.waiting
-                  ? `${issue.label}; review its related diagnosis first`
-                  : `${issue.label}, no review items available`;
+                  issue.enabled && (hasSavedItems || (hasNewItems && !blocked));
+                const blockerPhases = blockingPhaseSummary(blockers);
+                const unavailableLabel = blocked
+                  ? `${issue.label}; complete ${blockerPhases} first`
+                  : issue.waiting
+                    ? `${issue.label}; review its related diagnosis first`
+                    : `${issue.label}, no review items available`;
                 return (
                   <Card
                     key={issue.id}
@@ -259,11 +303,13 @@ const ReviewQueueSelector = ({
                       disabled={!available}
                       onClick={() => onStart(issue.id)}
                       aria-label={
-                        completedOnly
-                          ? `Review completed items in ${issue.label}, ${issue.reviewed} saved`
-                          : available
-                            ? `${issue.activeSession ? "Resume" : "Start"} ${issue.label} review, ${issue.pending} remaining`
-                            : unavailableLabel
+                        blocked && hasSavedItems
+                          ? `Review completed items in ${issue.label}, ${issue.reviewed} saved; complete ${blockerPhases} before new items`
+                          : completedOnly
+                            ? `Review completed items in ${issue.label}, ${issue.reviewed} saved`
+                            : available
+                              ? `${issue.activeSession ? "Resume" : "Start"} ${issue.label} review, ${issue.pending} remaining`
+                              : unavailableLabel
                       }
                       sx={{ p: { xs: 1.75, sm: 2 }, minHeight: 92 }}
                     >
@@ -342,6 +388,19 @@ const ReviewQueueSelector = ({
                               {hasSavedItems
                                 ? "No new items are ready. You can revisit your saved judgments; related actions require their diagnoses first."
                                 : "Review its related diagnosis first. If you agree, this action will become available."}
+                            </Typography>
+                          )}
+                          {blocked && (
+                            <Typography
+                              sx={{
+                                mt: 0.6,
+                                color: "text.primary",
+                                fontSize: "0.9rem",
+                                fontWeight: 650,
+                                lineHeight: 1.4,
+                              }}
+                            >
+                              Complete {blockerPhases} first.
                             </Typography>
                           )}
                         </Box>

--- a/src/lib/somReview/reviewDependencies.ts
+++ b/src/lib/somReview/reviewDependencies.ts
@@ -1,0 +1,178 @@
+import {
+  SomIssuePrerequisite,
+  SomIssueType,
+  SomIssueTypeOption,
+} from "../../types/ISomReview";
+
+/**
+ * Queue-level prerequisites capture decisions that must be made before a
+ * reviewer can interpret a later class of proposal. Exact diagnosis-to-action
+ * dependencies remain attached to individual proposals in the dataset.
+ */
+const ISSUE_PREREQUISITES: Partial<Record<SomIssueType, SomIssueType[]>> = {
+  "synonym-enrichment": ["title-clarity"],
+  "mistaken-synonym": ["title-clarity"],
+  "duplicate-synonym": ["title-clarity"],
+  polysemy: ["title-clarity"],
+  "misc-facet-duplicate": [
+    "title-clarity",
+    "synonym-enrichment",
+    "mistaken-synonym",
+    "duplicate-synonym",
+    "polysemy",
+  ],
+  "flat-list-grouping": [
+    "title-clarity",
+    "synonym-enrichment",
+    "mistaken-synonym",
+    "duplicate-synonym",
+    "polysemy",
+    "misc-facet-duplicate",
+  ],
+  "compound-object-grouping": [
+    "title-clarity",
+    "synonym-enrichment",
+    "mistaken-synonym",
+    "duplicate-synonym",
+    "polysemy",
+    "misc-facet-duplicate",
+  ],
+  "collection-design": [
+    "title-clarity",
+    "synonym-enrichment",
+    "mistaken-synonym",
+    "duplicate-synonym",
+    "polysemy",
+    "misc-facet-duplicate",
+  ],
+  placement: [
+    "title-clarity",
+    "synonym-enrichment",
+    "mistaken-synonym",
+    "duplicate-synonym",
+    "polysemy",
+    "misc-facet-duplicate",
+  ],
+  "wrong-verb": [
+    "title-clarity",
+    "synonym-enrichment",
+    "mistaken-synonym",
+    "duplicate-synonym",
+    "polysemy",
+    "misc-facet-duplicate",
+  ],
+  "description-enrichment": ["title-clarity"],
+  "missing-activity": [
+    "title-clarity",
+    "synonym-enrichment",
+    "mistaken-synonym",
+    "duplicate-synonym",
+    "polysemy",
+    "misc-facet-duplicate",
+  ],
+  "redundant-node": [
+    "title-clarity",
+    "synonym-enrichment",
+    "mistaken-synonym",
+    "duplicate-synonym",
+    "polysemy",
+    "misc-facet-duplicate",
+  ],
+};
+
+export const issuePrerequisiteTypes = (
+  issueType: SomIssueType,
+): SomIssueType[] => [...(ISSUE_PREREQUISITES[issueType] || [])];
+
+export const issueReviewIsComplete = (
+  issue: Pick<SomIssueTypeOption, "enabled" | "total" | "pending" | "waiting">,
+): boolean =>
+  !issue.enabled ||
+  issue.total === 0 ||
+  (issue.pending === 0 && issue.waiting === 0);
+
+export const blockingIssuePrerequisites = (
+  issueType: SomIssueType,
+  issues: Map<SomIssueType, SomIssueTypeOption>,
+): SomIssuePrerequisite[] =>
+  issuePrerequisiteTypes(issueType).flatMap((prerequisiteId) => {
+    const prerequisite = issues.get(prerequisiteId);
+    if (!prerequisite || issueReviewIsComplete(prerequisite)) return [];
+    return [
+      {
+        id: prerequisite.id,
+        label: prerequisite.label,
+        remaining: prerequisite.pending + prerequisite.waiting,
+      },
+    ];
+  });
+
+export interface SomReviewPathStep {
+  id: string;
+  number: number;
+  title: string;
+  description: string;
+  issueTypes: SomIssueType[];
+  contextual?: boolean;
+  optional?: boolean;
+}
+
+export const SOM_REVIEW_PATH: SomReviewPathStep[] = [
+  {
+    id: "labels",
+    number: 1,
+    title: "Clarify labels",
+    description: "Resolve unclear titles before judging meaning or structure.",
+    issueTypes: ["title-clarity"],
+  },
+  {
+    id: "meaning",
+    number: 2,
+    title: "Resolve meaning and identity",
+    description:
+      "Review synonym, double-meaning, and duplicate-structure diagnoses.",
+    issueTypes: [
+      "synonym-enrichment",
+      "mistaken-synonym",
+      "duplicate-synonym",
+      "polysemy",
+      "misc-facet-duplicate",
+    ],
+  },
+  {
+    id: "structure",
+    number: 3,
+    title: "Review structure and placement",
+    description:
+      "Judge proposed groups, collections, and movements after meanings are clear.",
+    issueTypes: [
+      "flat-list-grouping",
+      "compound-object-grouping",
+      "collection-design",
+      "placement",
+      "wrong-verb",
+    ],
+  },
+  {
+    id: "actions",
+    number: 4,
+    title: "Confirm exact changes",
+    description:
+      "Separate merge and move decisions appear as soon as their diagnoses are approved.",
+    issueTypes: ["node-merge", "relocation", "sense-relocation"],
+    contextual: true,
+  },
+  {
+    id: "optional",
+    number: 5,
+    title: "Optional quality checks",
+    description:
+      "Descriptions, missing activities, and redundant nodes do not block restructuring.",
+    issueTypes: [
+      "description-enrichment",
+      "missing-activity",
+      "redundant-node",
+    ],
+    optional: true,
+  },
+];

--- a/src/lib/somReview/store.ts
+++ b/src/lib/somReview/store.ts
@@ -6,8 +6,13 @@ import {
   SOM_REVIEW_RESPONSE_REVISIONS,
   SOM_REVIEW_SESSIONS,
 } from "../firestoreClient/collections";
-import { SomIssueType } from "../../types/ISomReview";
-import { SomDataset, proposalAvailability } from "./dataset";
+import { SomIssuePrerequisite, SomIssueType } from "../../types/ISomReview";
+import {
+  isIssueTypeEnabled,
+  SomDataset,
+  proposalAvailability,
+} from "./dataset";
+import { issuePrerequisiteTypes } from "./reviewDependencies";
 import {
   dropMissingProposalIds,
   isResumableSession,
@@ -138,6 +143,32 @@ export const pendingCount = async (
   reviewerId: string,
 ): Promise<number> => {
   return (await pendingSummary(dataset, issueType, reviewerId)).pending;
+};
+
+export const reviewerBlockingPrerequisites = async (
+  dataset: SomDataset,
+  issueType: SomIssueType,
+  reviewerId: string,
+): Promise<SomIssuePrerequisite[]> => {
+  const prerequisiteTypes =
+    issuePrerequisiteTypes(issueType).filter(isIssueTypeEnabled);
+  const summaries = await Promise.all(
+    prerequisiteTypes.map(async (prerequisiteType) => ({
+      prerequisiteType,
+      summary: await pendingSummary(dataset, prerequisiteType, reviewerId),
+    })),
+  );
+  return summaries.flatMap(({ prerequisiteType, summary }) => {
+    const remaining = summary.pending + summary.waiting;
+    if (remaining === 0) return [];
+    return [
+      {
+        id: prerequisiteType,
+        label: dataset.issueLabels.get(prerequisiteType) || prerequisiteType,
+        remaining,
+      },
+    ];
+  });
 };
 
 export const reviewerReadyDependentRecords = async (

--- a/src/pages/api/som-review/overview.ts
+++ b/src/pages/api/som-review/overview.ts
@@ -11,6 +11,10 @@ import { SomIssueType, SomOverviewResponse } from "../../../types/ISomReview";
 import { reviewAccessForToken } from "../../../lib/somReview/access";
 import { toLinkedFollowUps } from "../../../lib/somReview/followUps";
 import { numberReviewIssues } from "../../../lib/somReview/reviewTaxonomy";
+import {
+  blockingIssuePrerequisites,
+  issuePrerequisiteTypes,
+} from "../../../lib/somReview/reviewDependencies";
 
 const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   const req = request as CustomNextApiRequest;
@@ -20,7 +24,7 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
     const dataset = getDataset();
     const reviewerId = req.user.uid;
 
-    const [issueTypes, readyFollowUpRecords] = await Promise.all([
+    const [baseIssueTypes, readyFollowUpRecords] = await Promise.all([
       Promise.all(
         numberReviewIssues(dataset.manifest.issueTypes || []).map(
           async (issue: any) => {
@@ -45,6 +49,8 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
               optional: Boolean(issue.optional),
               enabled,
               total,
+              prerequisiteIssueTypes: issuePrerequisiteTypes(issueType),
+              blockedBy: [],
               ...summary,
               ...(activeSession ? { activeSession } : {}),
             };
@@ -53,6 +59,13 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       ),
       reviewerReadyDependentRecords(dataset, reviewerId),
     ]);
+    const issuesByType = new Map(
+      baseIssueTypes.map((issue) => [issue.id, issue]),
+    );
+    const issueTypes = baseIssueTypes.map((issue) => ({
+      ...issue,
+      blockedBy: blockingIssuePrerequisites(issue.id, issuesByType),
+    }));
 
     const body: SomOverviewResponse = {
       datasetVersion: dataset.datasetVersion,

--- a/src/pages/api/som-review/session.ts
+++ b/src/pages/api/som-review/session.ts
@@ -5,6 +5,7 @@ import { getDataset, isIssueTypeEnabled } from "../../../lib/somReview/dataset";
 import {
   getOrCreateSession,
   issueResponses,
+  reviewerBlockingPrerequisites,
 } from "../../../lib/somReview/store";
 import { toReviewerCard } from "../../../lib/somReview/sanitize";
 import { reviewRequestData } from "../../../lib/somReview/request";
@@ -22,6 +23,7 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       typeof data.preferredProposalId === "string"
         ? data.preferredProposalId
         : undefined;
+    const historyOnly = data.historyOnly === true;
     const dataset = getDataset();
     if (!dataset.orderedIdsByIssue.has(issueType)) {
       return res.status(400).json({ error: "Unknown issue type" });
@@ -44,12 +46,29 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       }
     }
 
-    const session = await getOrCreateSession(
-      dataset,
-      issueType,
-      req.user.uid,
-      preferredProposalId,
-    );
+    if (!preferredProposalId && !historyOnly) {
+      const blockedBy = await reviewerBlockingPrerequisites(
+        dataset,
+        issueType,
+        req.user.uid,
+      );
+      if (blockedBy.length > 0) {
+        return res.status(409).json({
+          code: "PREREQUISITE_REVIEW_REQUIRED",
+          error: "Complete the required earlier review types first",
+          blockedBy,
+        });
+      }
+    }
+
+    const session = historyOnly
+      ? null
+      : await getOrCreateSession(
+          dataset,
+          issueType,
+          req.user.uid,
+          preferredProposalId,
+        );
     if (
       preferredProposalId &&
       (!session || session.proposalIds[session.cursor] !== preferredProposalId)

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -120,6 +120,7 @@ export const ReviewPage = () => {
       options: {
         preferredProposalId?: string;
         sequence?: LinkedReviewSequence | null;
+        historyOnly?: boolean;
       } = {},
     ) => {
       setIssueType(issue);
@@ -135,6 +136,7 @@ export const ReviewPage = () => {
           ...(options.preferredProposalId
             ? { preferredProposalId: options.preferredProposalId }
             : {}),
+          ...(options.historyOnly ? { historyOnly: true } : {}),
         });
         if (
           options.preferredProposalId &&
@@ -206,6 +208,10 @@ export const ReviewPage = () => {
       const selectedQueue = issueTypes.find(
         (candidate) => candidate.id === issue,
       );
+      if (selectedQueue?.blockedBy?.length && selectedQueue.reviewed > 0) {
+        startSession(issue, { historyOnly: true });
+        return;
+      }
       if (
         selectedQueue &&
         selectedQueue.pending === 0 &&
@@ -410,7 +416,12 @@ export const ReviewPage = () => {
 
       if (result.changed) {
         if (issueType) {
-          await startSession(issueType);
+          const selectedQueue = issueTypes.find(
+            (candidate) => candidate.id === issueType,
+          );
+          await startSession(issueType, {
+            historyOnly: Boolean(selectedQueue?.blockedBy?.length),
+          });
           return;
         }
       }

--- a/src/types/ISomReview.ts
+++ b/src/types/ISomReview.ts
@@ -209,10 +209,18 @@ export interface SomIssueTypeOption {
   total: number;
   enabled: boolean;
   optional?: boolean;
+  prerequisiteIssueTypes: SomIssueType[];
+  blockedBy: SomIssuePrerequisite[];
   activeSession?: {
     cursor: number;
     total: number;
   };
+}
+
+export interface SomIssuePrerequisite {
+  id: SomIssueType;
+  label: string;
+  remaining: number;
 }
 
 export interface SomSessionState {


### PR DESCRIPTION
## Summary

- add a guided five-phase review path that orders label clarification, meaning/identity decisions, structural review, exact linked actions, and optional quality checks
- encode queue-level prerequisites while preserving proposal-specific diagnosis-to-action follow-ups and access to saved judgments for revision
- enforce the same dependency rules in the review APIs so blocked queues cannot be bypassed through direct requests
- add focused tests plus a workflow specification, literature review, and CHI 2027 study proposal

## Reviewer notes

The current Sell pilot sequences proposals from one frozen ontology snapshot. A production workflow should adjudicate and apply each completed tranche, then regenerate downstream proposals from the updated ontology before continuing. The UI distinguishes this snapshot dependency from exact linked follow-ups such as a placement diagnosis followed by its corresponding move decision.

## Validation

- `npx jest --runInBand __tests__/lib/somReview/reviewDependencies.test.ts __tests__/components/SomReview/ReviewQueueSelector.test.tsx` (11 tests passed)
- changed-file ESLint passed
- `git diff --check origin/main...HEAD` passed
- manually verified the guided path and review flow on desktop and mobile, in light and dark modes

## Existing repository checks

The repository-wide lint and TypeScript checks still report pre-existing issues outside this change, including the NodeGraph ESLint rule configuration and existing Yjs/editor/API typing failures. No new failures were found in the changed files.
