### PR TITLE
Restore saved rationale when revising reviews

### DIFF
--- a/__tests__/components/SomReview/ReviewCard.test.tsx
+++ b/__tests__/components/SomReview/ReviewCard.test.tsx
@@ -115,6 +115,7 @@ describe("Society of Mind review card", () => {
           decision: "disagree",
           disagreementReason: "The original title is more precise.",
           suggestedCorrection: "Keep Sell Supply.",
+          reviewedAt: "2026-07-24T12:00:00.000Z",
         }}
         onSubmit={jest.fn()}
       />,
@@ -134,9 +135,84 @@ describe("Society of Mind review card", () => {
     ).toBeInTheDocument();
     expect(
       window.sessionStorage.getItem(
-        "som-review-draft-reviewer-1-dataset-1-title-1",
+        "som-review-draft-reviewer-1-dataset-1-title-1-revise",
       ),
     ).toBeNull();
+  });
+
+  it("does not let a stale revision draft replace the saved response", async () => {
+    window.sessionStorage.setItem(
+      "som-review-draft-reviewer-1-dataset-1-title-1-revise",
+      JSON.stringify({
+        open: false,
+        reason: "",
+        correction: "",
+      }),
+    );
+
+    render(
+      <ReviewCard
+        card={card}
+        reviewerId="reviewer-1"
+        mode="revise"
+        initialResponse={{
+          decision: "disagree",
+          disagreementReason: "The saved rationale must remain visible.",
+          suggestedCorrection: "Keep the current title.",
+          reviewedAt: "2026-07-24T12:00:00.000Z",
+        }}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    expect(await screen.findByLabelText(/Why do you disagree/i)).toHaveValue(
+      "The saved rationale must remain visible.",
+    );
+    expect(screen.getByLabelText(/Suggested correction/i)).toHaveValue(
+      "Keep the current title.",
+    );
+    expect(
+      window.sessionStorage.getItem(
+        "som-review-draft-reviewer-1-dataset-1-title-1-revise",
+      ),
+    ).toBeNull();
+  });
+
+  it("restores an unfinished revision only for the same saved response", () => {
+    const initialResponse = {
+      decision: "disagree" as const,
+      disagreementReason: "The saved rationale.",
+      suggestedCorrection: "The saved suggestion.",
+      reviewedAt: "2026-07-24T12:00:00.000Z",
+    };
+    const firstRender = render(
+      <ReviewCard
+        card={card}
+        reviewerId="reviewer-1"
+        mode="revise"
+        initialResponse={initialResponse}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Why do you disagree/i), {
+      target: { value: "An unfinished revision." },
+    });
+    firstRender.unmount();
+
+    render(
+      <ReviewCard
+        card={card}
+        reviewerId="reviewer-1"
+        mode="revise"
+        initialResponse={initialResponse}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/Why do you disagree/i)).toHaveValue(
+      "An unfinished revision.",
+    );
   });
 
   it("keeps downstream placement details out of the diagnosis", () => {

--- a/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
+++ b/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
@@ -138,6 +138,7 @@ const followUp: SomLinkedFollowUp = {
 describe("linked proposal review journey", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    window.sessionStorage.clear();
     window.localStorage.setItem(
       "som-review-task-intro-dataset-1-placement",
       "seen",
@@ -301,9 +302,11 @@ describe("linked proposal review journey", () => {
       proposalId: savedCard.proposalId,
       proposalIndex: index,
       question: savedCard.reviewerView.question,
-      decision: "agree" as const,
-      disagreementReason: "",
-      suggestedCorrection: "",
+      decision: index === 1 ? ("disagree" as const) : ("agree" as const),
+      disagreementReason:
+        index === 1 ? "Market means promotion rather than selling." : "",
+      suggestedCorrection:
+        index === 1 ? "Move this activity to Advertise." : "",
       reviewedAt: `2026-07-16T10:${String(index).padStart(2, "0")}:00.000Z`,
     }));
 
@@ -365,6 +368,14 @@ describe("linked proposal review journey", () => {
       screen.getByRole("button", { name: "Open saved answer 2" }),
     );
 
+    window.sessionStorage.setItem(
+      "som-review-draft-reviewer-1-dataset-1-placement-2-revise",
+      JSON.stringify({
+        open: true,
+        reason: "Unfinished replacement",
+        correction: "",
+      }),
+    );
     expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
     expect(screen.getByText("Saved item 2 of 47")).toBeInTheDocument();
     expect(
@@ -379,6 +390,19 @@ describe("linked proposal review journey", () => {
     expect(
       screen.getByRole("button", { name: "Keep saved answer" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("Market means promotion rather than selling."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Move this activity to Advertise."),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Keep saved answer" }));
+    expect(
+      window.sessionStorage.getItem(
+        "som-review-draft-reviewer-1-dataset-1-placement-2-revise",
+      ),
+    ).toBeNull();
   });
 
   it("opens a completed review type from the main menu for revision", async () => {

--- a/src/components/SomReview/ReviewCard.tsx
+++ b/src/components/SomReview/ReviewCard.tsx
@@ -19,6 +19,10 @@ import ContextRenderer, {
   DiffedTitle,
 } from "./ContextRenderer";
 import { reviewAccentColor } from "./reviewStyles";
+import {
+  clearReviewDraft,
+  reviewDraftStorageKey,
+} from "../../lib/somReview/reviewDraft";
 
 export interface ReviewSubmission {
   decision: "agree" | "disagree";
@@ -31,6 +35,7 @@ export interface ExistingReviewResponse {
   decision: "agree" | "disagree";
   disagreementReason: string;
   suggestedCorrection: string;
+  reviewedAt: string;
 }
 
 const stripStatePrefix = (text: string): string =>
@@ -117,22 +122,30 @@ const ReviewCard = ({
   const [saveError, setSaveError] = useState(false);
   const headingRef = useRef<HTMLHeadingElement | null>(null);
   const shownAtRef = useRef<number>(Date.now());
-  const draftKey = useMemo(
-    () =>
-      [
-        "som-review-draft",
-        reviewerId,
-        card.datasetVersion,
-        card.proposalId,
-        mode === "revise" ? "revise" : null,
-      ]
-        .filter(Boolean)
-        .join("-"),
+  const draftIdentity = useMemo(
+    () => ({
+      reviewerId,
+      datasetVersion: card.datasetVersion,
+      proposalId: card.proposalId,
+      mode,
+    }),
     [card.datasetVersion, card.proposalId, mode, reviewerId],
+  );
+  const draftKey = useMemo(
+    () => reviewDraftStorageKey(draftIdentity),
+    [draftIdentity],
   );
   const initialDecision = initialResponse?.decision;
   const initialReason = initialResponse?.disagreementReason || "";
   const initialCorrection = initialResponse?.suggestedCorrection || "";
+  const initialResponseFingerprint = useMemo(
+    () =>
+      JSON.stringify([
+        initialDecision || "",
+        initialResponse?.reviewedAt || "",
+      ]),
+    [initialDecision, initialResponse?.reviewedAt],
+  );
 
   useEffect(() => {
     shownAtRef.current = Date.now();
@@ -147,19 +160,35 @@ const ReviewCard = ({
       const draft = window.sessionStorage.getItem(draftKey);
       if (draft) {
         const parsed = JSON.parse(draft);
-        setDisagreeing(Boolean(parsed.open));
-        setReason(typeof parsed.reason === "string" ? parsed.reason : "");
-        setCorrection(
-          typeof parsed.correction === "string" ? parsed.correction : "",
-        );
+        const matchesSavedResponse =
+          mode !== "revise" ||
+          parsed.baseResponseFingerprint === initialResponseFingerprint;
+        if (matchesSavedResponse) {
+          setDisagreeing(Boolean(parsed.open));
+          setReason(typeof parsed.reason === "string" ? parsed.reason : "");
+          setCorrection(
+            typeof parsed.correction === "string" ? parsed.correction : "",
+          );
+        } else {
+          clearReviewDraft(draftIdentity);
+        }
       }
     } catch {
       // A malformed local draft should never block the review queue.
+      clearReviewDraft(draftIdentity);
     }
 
     const focusTimer = window.setTimeout(() => headingRef.current?.focus(), 0);
     return () => window.clearTimeout(focusTimer);
-  }, [draftKey, initialCorrection, initialDecision, initialReason, mode]);
+  }, [
+    draftIdentity,
+    draftKey,
+    initialCorrection,
+    initialDecision,
+    initialReason,
+    initialResponseFingerprint,
+    mode,
+  ]);
 
   const persistDraft = (
     open: boolean,
@@ -173,6 +202,9 @@ const ReviewCard = ({
           open,
           reason: nextReason,
           correction: nextCorrection,
+          ...(mode === "revise"
+            ? { baseResponseFingerprint: initialResponseFingerprint }
+            : {}),
         }),
       );
     } catch {
@@ -181,11 +213,7 @@ const ReviewCard = ({
   };
 
   const clearDraft = () => {
-    try {
-      window.sessionStorage.removeItem(draftKey);
-    } catch {
-      // The saved response is authoritative even if local cleanup fails.
-    }
+    clearReviewDraft(draftIdentity);
   };
 
   const submit = async (decision: "agree" | "disagree") => {

--- a/src/lib/somReview/reviewDraft.ts
+++ b/src/lib/somReview/reviewDraft.ts
@@ -1,0 +1,31 @@
+export interface ReviewDraftIdentity {
+  reviewerId: string;
+  datasetVersion: string;
+  proposalId: string;
+  mode: "review" | "revise";
+}
+
+export const reviewDraftStorageKey = ({
+  reviewerId,
+  datasetVersion,
+  proposalId,
+  mode,
+}: ReviewDraftIdentity): string =>
+  [
+    "som-review-draft",
+    reviewerId,
+    datasetVersion,
+    proposalId,
+    mode === "revise" ? "revise" : null,
+  ]
+    .filter(Boolean)
+    .join("-");
+
+export const clearReviewDraft = (identity: ReviewDraftIdentity): void => {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(reviewDraftStorageKey(identity));
+  } catch {
+    // The saved server response remains authoritative if storage is unavailable.
+  }
+};

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -27,6 +27,7 @@ import ReviewQueueSelector from "@components/components/SomReview/ReviewQueueSel
 import ReviewTaskIntro from "@components/components/SomReview/ReviewTaskIntro";
 import ThemeModeToggle from "@components/components/SomReview/ThemeModeToggle";
 import { reviewInteractiveSurfaceSx } from "@components/components/SomReview/reviewStyles";
+import { clearReviewDraft } from "@components/lib/somReview/reviewDraft";
 import {
   SomIssueType,
   SomIssueTypeOption,
@@ -458,6 +459,14 @@ export const ReviewPage = () => {
   );
 
   const cancelRevision = useCallback(() => {
+    if (revisionCard && user?.userId) {
+      clearReviewDraft({
+        reviewerId: user.userId,
+        datasetVersion: revisionCard.datasetVersion,
+        proposalId: revisionCard.proposalId,
+        mode: "revise",
+      });
+    }
     setRevisionProposalId("");
     setPhase(
       cards.length === 0
@@ -466,7 +475,7 @@ export const ReviewPage = () => {
           ? "complete"
           : "session",
     );
-  }, [cards.length, cursor]);
+  }, [cards.length, cursor, revisionCard, user?.userId]);
 
   const exitToSelector = useCallback(() => {
     setIssueType(null);
@@ -763,12 +772,51 @@ export const ReviewPage = () => {
                     </Button>
                   }
                 >
-                  Saved answer:{" "}
-                  <strong>
-                    {revisionItem.decision === "agree" ? "Agreed" : "Disagreed"}
-                  </strong>
-                  . Submit a revised answer to replace it, or keep the saved
-                  answer to return to your current review position.
+                  <Stack spacing={0.5}>
+                    <Typography component="div">
+                      Saved answer:{" "}
+                      <strong>
+                        {revisionItem.decision === "agree"
+                          ? "Agreed"
+                          : "Disagreed"}
+                      </strong>
+                      .
+                    </Typography>
+                    {revisionItem.decision === "disagree" && (
+                      <>
+                        <Typography
+                          component="div"
+                          sx={{
+                            whiteSpace: "pre-wrap",
+                            overflowWrap: "anywhere",
+                          }}
+                        >
+                          Saved rationale:{" "}
+                          <strong>
+                            {revisionItem.disagreementReason ||
+                              "No written rationale was saved."}
+                          </strong>
+                        </Typography>
+                        {revisionItem.suggestedCorrection && (
+                          <Typography
+                            component="div"
+                            sx={{
+                              whiteSpace: "pre-wrap",
+                              overflowWrap: "anywhere",
+                            }}
+                          >
+                            Saved suggestion:{" "}
+                            <strong>{revisionItem.suggestedCorrection}</strong>
+                          </Typography>
+                        )}
+                      </>
+                    )}
+                    <Typography component="div">
+                      The form below starts with this saved response. Submit a
+                      revision to replace it, or keep the saved answer to return
+                      to your current review position.
+                    </Typography>
+                  </Stack>
                 </Alert>
               )}
               {!revisionItem &&
@@ -798,6 +846,7 @@ export const ReviewPage = () => {
                           revisionItem.disagreementReason || "",
                         suggestedCorrection:
                           revisionItem.suggestedCorrection || "",
+                        reviewedAt: revisionItem.reviewedAt,
                       }
                     : undefined
                 }


### PR DESCRIPTION
## Summary
- keep the server-saved review response authoritative when reopening a prior item
- bind unfinished revision drafts to the exact saved-response version and discard stale browser drafts
- show the saved decision, disagreement rationale, and suggested correction directly in the revision view
- clear abandoned revision drafts when the reviewer chooses **Keep saved answer**
- add regression coverage for stale drafts, unfinished valid revisions, and the page-level cancellation flow

## Root cause
The API and Firestore store already returned the saved rationale correctly. `ReviewCard` then unconditionally restored a `sessionStorage` revision draft, including older empty drafts, which could hide the saved disagreement and its text.

## Verification
- `npm test -- --watch=false __tests__/components/SomReview __tests__/lib/somReview` (23 suites, 124 tests)
- changed-file `next lint`
- `npm run build`
- local `/review` browser smoke test with no console errors

## Baseline note
`npx tsc --noEmit` still reports existing unrelated errors in YJSEditor, MarkdownEditor, several API routes, and Ontology.tsx. The repository is configured with `typescript.ignoreBuildErrors: true`; this PR adds no new errors in its changed files.