### PR TITLE
Add branch-aware ontology review workspaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
-ENV SOM_REVIEW_DATASET_DIR="/app/Buy_Society_of_Mind_Title_Followup_2026-07-25/review-datasets-title-followup-v1"
 
 RUN apk add --no-cache libc6-compat
 
@@ -80,7 +79,9 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 # Society of Mind review dataset, read from process.cwd() at request time
 # by src/lib/somReview/dataset.ts
+COPY --chown=nextjs:nodejs Buy_Society_of_Mind_Exploratory_2026-07-25/review-datasets-exploratory-v1 ./Buy_Society_of_Mind_Exploratory_2026-07-25/review-datasets-exploratory-v1
 COPY --chown=nextjs:nodejs Buy_Society_of_Mind_Title_Followup_2026-07-25/review-datasets-title-followup-v1 ./Buy_Society_of_Mind_Title_Followup_2026-07-25/review-datasets-title-followup-v1
+COPY --chown=nextjs:nodejs Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15 ./Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15
 
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/__tests__/components/SomReview/OntologyComparisonPanel.test.tsx
+++ b/__tests__/components/SomReview/OntologyComparisonPanel.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import OntologyComparisonPanel from "../../../src/components/SomReview/OntologyComparisonPanel";
+import { Post } from "../../../src/lib/utils/Post";
+import { SomOntologyOutlineResponse } from "../../../src/types/ISomReview";
+
+jest.mock("../../../src/lib/utils/Post", () => ({
+  Post: jest.fn(),
+}));
+
+const outlineResponse: SomOntologyOutlineResponse = {
+  datasetId: "buy-current",
+  workspaceId: "buy",
+  branch: "Buy",
+  currentRound: true,
+  original: {
+    ontologyName: "Original ontology",
+    capturedAt: "2026-07-20T00:00:00.000Z",
+    rootNodeId: "original-root",
+    rootTitle: "Buy",
+    nodes: [
+      { id: "original-root", title: "Buy", evidence: false },
+      { id: "original-child", title: "Purchase product", evidence: false },
+      {
+        id: "original-evidence",
+        title: "(O*Net) Purchase task",
+        evidence: true,
+      },
+    ],
+    edges: [
+      {
+        parentId: "original-root",
+        childId: "original-child",
+        collectionName: "commerce",
+      },
+      {
+        parentId: "original-root",
+        childId: "original-evidence",
+        collectionName: "evidence",
+      },
+    ],
+  },
+  selected: {
+    ontologyName: "Current ontology",
+    capturedAt: "2026-07-25T00:00:00.000Z",
+    rootNodeId: "current-root",
+    rootTitle: "Buy",
+    nodes: [
+      { id: "current-root", title: "Buy", evidence: false },
+      { id: "current-child", title: "Purchase goods", evidence: false },
+    ],
+    edges: [
+      {
+        parentId: "current-root",
+        childId: "current-child",
+        collectionName: "commerce",
+      },
+    ],
+  },
+};
+
+describe("ontology comparison panel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Post as jest.Mock).mockResolvedValue(outlineResponse);
+  });
+
+  it("loads lazily and presents the original and current outlines side by side", async () => {
+    render(
+      <OntologyComparisonPanel
+        datasetId="buy-current"
+        branch="Buy"
+        roundLabel="Current Buy round"
+        currentRound
+      />,
+    );
+
+    expect(Post).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByRole("button", { name: /Compare Buy hierarchy/i }),
+    );
+
+    await waitFor(() =>
+      expect(Post).toHaveBeenCalledWith(
+        "/som-review/outline",
+        { datasetId: "buy-current" },
+        false,
+      ),
+    );
+    expect(
+      screen.getByRole("region", { name: "Original ontology outline" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Current ontology outline" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("commerce")).toHaveLength(2);
+    expect(screen.queryByText("(O*Net) Purchase task")).not.toBeInTheDocument();
+  });
+
+  it("reveals O*NET evidence only when the reviewer requests it", async () => {
+    render(
+      <OntologyComparisonPanel
+        datasetId="buy-current"
+        branch="Buy"
+        roundLabel="Current Buy round"
+        currentRound
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /Compare Buy hierarchy/i }),
+    );
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: "Include O*NET evidence",
+    });
+    fireEvent.click(checkbox);
+
+    expect(
+      await screen.findByText("(O*Net) Purchase task"),
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
+++ b/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
@@ -22,7 +22,12 @@ jest.mock("../../../src/components/context/AuthContext", () => {
 });
 
 jest.mock("next/router", () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({
+    isReady: true,
+    query: {},
+    push: jest.fn(),
+    replace: jest.fn().mockResolvedValue(true),
+  }),
 }));
 
 jest.mock("../../../src/components/hoc/withAuthUser", () => ({
@@ -136,6 +141,31 @@ const followUp: SomLinkedFollowUp = {
   ],
 };
 
+const overviewMetadata = {
+  datasetId: "buy-title-followup",
+  datasetVersion: "dataset-1",
+  workspaceId: "buy",
+  roundLabel: "Title follow-up",
+  currentRound: true,
+  workspaces: [
+    {
+      id: "buy",
+      label: "Buy",
+      activeDatasetId: "buy-title-followup",
+      rounds: [
+        {
+          id: "buy-title-followup",
+          datasetVersion: "dataset-1",
+          label: "Title follow-up",
+          current: true,
+        },
+      ],
+    },
+  ],
+  branch: "Buy",
+  ontologyName: "Test ontology",
+};
+
 describe("linked proposal review journey", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -151,7 +181,7 @@ describe("linked proposal review journey", () => {
     postMock.mockImplementation((url: string, body: any) => {
       if (url === "/som-review/overview") {
         return Promise.resolve({
-          datasetVersion: "dataset-1",
+          ...overviewMetadata,
           canDeliberate: false,
           readyFollowUps: [],
           issueTypes: [
@@ -247,6 +277,7 @@ describe("linked proposal review journey", () => {
     );
     await waitFor(() =>
       expect(postMock).toHaveBeenCalledWith("/som-review/session", {
+        datasetId: "buy-title-followup",
         issueType: "placement",
       }),
     );
@@ -265,6 +296,7 @@ describe("linked proposal review journey", () => {
 
     await waitFor(() =>
       expect(postMock).toHaveBeenCalledWith("/som-review/session", {
+        datasetId: "buy-title-followup",
         issueType: "relocation",
         preferredProposalId: "relocation-1",
       }),
@@ -284,6 +316,7 @@ describe("linked proposal review journey", () => {
 
     await waitFor(() =>
       expect(postMock).toHaveBeenLastCalledWith("/som-review/session", {
+        datasetId: "buy-title-followup",
         issueType: "placement",
       }),
     );
@@ -314,7 +347,7 @@ describe("linked proposal review journey", () => {
     postMock.mockImplementation((url: string, body: any) => {
       if (url === "/som-review/overview") {
         return Promise.resolve({
-          datasetVersion: "dataset-1",
+          ...overviewMetadata,
           canDeliberate: false,
           readyFollowUps: [],
           issueTypes: [
@@ -428,7 +461,7 @@ describe("linked proposal review journey", () => {
     postMock.mockImplementation((url: string, body: any) => {
       if (url === "/som-review/overview") {
         return Promise.resolve({
-          datasetVersion: "dataset-1",
+          ...overviewMetadata,
           canDeliberate: false,
           readyFollowUps: [],
           issueTypes: [
@@ -468,6 +501,7 @@ describe("linked proposal review journey", () => {
 
     await waitFor(() =>
       expect(postMock).toHaveBeenLastCalledWith("/som-review/session", {
+        datasetId: "buy-title-followup",
         issueType: "placement",
       }),
     );

--- a/__tests__/components/SomReview/ReviewWorkspaceSwitcher.test.tsx
+++ b/__tests__/components/SomReview/ReviewWorkspaceSwitcher.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import ReviewWorkspaceSwitcher from "../../../src/components/SomReview/ReviewWorkspaceSwitcher";
+import { SomReviewWorkspaceOption } from "../../../src/types/ISomReview";
+
+const workspaces: SomReviewWorkspaceOption[] = [
+  {
+    id: "buy",
+    label: "Buy",
+    activeDatasetId: "buy-current",
+    rounds: [
+      {
+        id: "buy-current",
+        datasetVersion: "buy-v2",
+        label: "Current Buy round",
+        current: true,
+      },
+      {
+        id: "buy-original",
+        datasetVersion: "buy-v1",
+        label: "Initial Buy round",
+        current: false,
+      },
+    ],
+  },
+  {
+    id: "sell",
+    label: "Sell",
+    activeDatasetId: "sell-current",
+    rounds: [
+      {
+        id: "sell-current",
+        datasetVersion: "sell-v2",
+        label: "Current Sell round",
+        current: true,
+      },
+    ],
+  },
+];
+
+describe("review workspace switcher", () => {
+  it("switches to the active round of another sub-ontology", () => {
+    const onChange = jest.fn();
+    render(
+      <ReviewWorkspaceSwitcher
+        workspaces={workspaces}
+        workspaceId="buy"
+        datasetId="buy-current"
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Sell sub-ontology" }));
+    expect(onChange).toHaveBeenCalledWith("sell-current");
+  });
+
+  it("opens a past round in the selected workspace", () => {
+    const onChange = jest.fn();
+    render(
+      <ReviewWorkspaceSwitcher
+        workspaces={workspaces}
+        workspaceId="buy"
+        datasetId="buy-current"
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.mouseDown(screen.getByLabelText("Review round"));
+    fireEvent.click(screen.getByRole("option", { name: "Initial Buy round" }));
+
+    expect(onChange).toHaveBeenCalledWith("buy-original");
+    expect(screen.getByText("Current hierarchy")).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/somReview/outline.test.ts
+++ b/__tests__/lib/somReview/outline.test.ts
@@ -1,0 +1,37 @@
+import { getDataset } from "../../../src/lib/somReview/dataset";
+import { toOutlineSnapshot } from "../../../src/lib/somReview/outline";
+
+describe("Society of Mind ontology outlines", () => {
+  it.each([
+    ["buy-initial-title-review", "Buy"],
+    ["buy-title-followup", "Buy"],
+    ["sell-initial-review", "Sell"],
+    ["sell-current", "Sell"],
+  ])("projects only the reachable %s branch", (datasetId, rootTitle) => {
+    const dataset = getDataset(datasetId);
+    const outline = toOutlineSnapshot(dataset);
+    const nodeIds = new Set(outline.nodes.map((node) => node.id));
+
+    expect(outline.rootTitle).toBe(rootTitle);
+    expect(nodeIds.has(outline.rootNodeId)).toBe(true);
+    expect(outline.nodes.length).toBeGreaterThan(1);
+    expect(outline.nodes.length).toBeLessThanOrEqual(
+      dataset.snapshot.nodes.length,
+    );
+    expect(
+      outline.edges.every(
+        (edge) => nodeIds.has(edge.parentId) && nodeIds.has(edge.childId),
+      ),
+    ).toBe(true);
+  });
+
+  it("marks O*NET nodes so the interface can hide evidence by default", () => {
+    const outline = toOutlineSnapshot(getDataset("sell-initial-review"));
+    const evidenceNodes = outline.nodes.filter((node) => node.evidence);
+
+    expect(evidenceNodes.length).toBeGreaterThan(0);
+    expect(
+      evidenceNodes.every((node) => node.title.startsWith("(O*Net)")),
+    ).toBe(true);
+  });
+});

--- a/__tests__/lib/somReview/reviewWorkspaces.test.ts
+++ b/__tests__/lib/somReview/reviewWorkspaces.test.ts
@@ -1,0 +1,43 @@
+import {
+  getDataset,
+  getDatasetByVersion,
+} from "../../../src/lib/somReview/dataset";
+import {
+  SOM_REVIEW_WORKSPACES,
+  reviewDatasetConfig,
+  reviewWorkspaceOptions,
+} from "../../../src/lib/somReview/reviewWorkspaces";
+
+describe("Society of Mind review workspaces", () => {
+  it("offers independent Buy and Sell workspaces with one current round each", () => {
+    const options = reviewWorkspaceOptions();
+
+    expect(options.map((workspace) => workspace.id)).toEqual(["buy", "sell"]);
+    expect(options.find((workspace) => workspace.id === "buy")).toMatchObject({
+      activeDatasetId: "buy-title-followup",
+    });
+    expect(options.find((workspace) => workspace.id === "sell")).toMatchObject({
+      activeDatasetId: "sell-current",
+    });
+    for (const workspace of options) {
+      expect(workspace.rounds.filter((round) => round.current)).toHaveLength(1);
+    }
+  });
+
+  it("loads every registered round and resolves it by immutable version", () => {
+    const configurations = SOM_REVIEW_WORKSPACES.flatMap(
+      (workspace) => workspace.datasets,
+    );
+    expect(
+      new Set(configurations.map((dataset) => dataset.datasetVersion)).size,
+    ).toBe(configurations.length);
+
+    for (const configuration of configurations) {
+      const dataset = getDataset(configuration.id);
+      expect(dataset.datasetId).toBe(configuration.id);
+      expect(dataset.datasetVersion).toBe(configuration.datasetVersion);
+      expect(getDatasetByVersion(configuration.datasetVersion)).toBe(dataset);
+      expect(reviewDatasetConfig(configuration.id)).toBe(configuration);
+    }
+  });
+});

--- a/src/components/SomReview/OntologyComparisonPanel.tsx
+++ b/src/components/SomReview/OntologyComparisonPanel.tsx
@@ -1,0 +1,495 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  FormControlLabel,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import UnfoldLessIcon from "@mui/icons-material/UnfoldLess";
+import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
+
+import { Post } from "../../lib/utils/Post";
+import {
+  SomOntologyOutlineResponse,
+  SomOntologyOutlineSnapshot,
+} from "../../types/ISomReview";
+
+interface OutlineChild {
+  childId: string;
+  collectionName: string;
+}
+
+const normalizeCollection = (value: string): string => {
+  const normalized = value.trim().replace(/^\[/, "").replace(/\]$/, "");
+  return !normalized || normalized === "default" ? "main" : normalized;
+};
+
+const OutlineNode = ({
+  nodeId,
+  nodesById,
+  childrenByParent,
+  expanded,
+  showEvidence,
+  ancestors,
+  onToggle,
+  depth,
+}: {
+  nodeId: string;
+  nodesById: Map<string, SomOntologyOutlineSnapshot["nodes"][number]>;
+  childrenByParent: Map<string, OutlineChild[]>;
+  expanded: Set<string>;
+  showEvidence: boolean;
+  ancestors: Set<string>;
+  onToggle: (nodeId: string) => void;
+  depth: number;
+}) => {
+  const node = nodesById.get(nodeId);
+  if (!node || (!showEvidence && node.evidence)) return null;
+
+  const children = (childrenByParent.get(nodeId) || []).filter((child) => {
+    const childNode = nodesById.get(child.childId);
+    return childNode && (showEvidence || !childNode.evidence);
+  });
+  const groupedChildren = new Map<string, OutlineChild[]>();
+  for (const child of children) {
+    const collectionName = normalizeCollection(child.collectionName);
+    groupedChildren.set(collectionName, [
+      ...(groupedChildren.get(collectionName) || []),
+      child,
+    ]);
+  }
+  const groups = [...groupedChildren.entries()]
+    .map(([collectionName, entries]) => ({
+      collectionName,
+      entries: [...entries].sort((left, right) =>
+        (nodesById.get(left.childId)?.title || "").localeCompare(
+          nodesById.get(right.childId)?.title || "",
+          "en",
+        ),
+      ),
+    }))
+    .sort((left, right) =>
+      left.collectionName.localeCompare(right.collectionName, "en"),
+    );
+  const hasChildren = groups.length > 0;
+  const isExpanded = expanded.has(nodeId);
+  const nextAncestors = new Set(ancestors);
+  nextAncestors.add(nodeId);
+
+  return (
+    <Box role="treeitem" aria-expanded={hasChildren ? isExpanded : undefined}>
+      <Stack
+        direction="row"
+        alignItems="flex-start"
+        spacing={0.5}
+        sx={{
+          minHeight: 34,
+          pl: `${Math.min(depth, 8) * 14}px`,
+          py: 0.25,
+        }}
+      >
+        {hasChildren ? (
+          <IconButton
+            size="small"
+            aria-label={`${isExpanded ? "Collapse" : "Expand"} ${node.title}`}
+            onClick={() => onToggle(nodeId)}
+            sx={{ width: 30, height: 30, flex: "0 0 auto" }}
+          >
+            {isExpanded ? (
+              <ExpandMoreIcon fontSize="small" />
+            ) : (
+              <ChevronRightIcon fontSize="small" />
+            )}
+          </IconButton>
+        ) : (
+          <Box aria-hidden="true" sx={{ width: 30, flex: "0 0 auto" }} />
+        )}
+        <Typography
+          sx={{
+            minWidth: 0,
+            pt: 0.45,
+            fontSize: "0.9rem",
+            fontWeight: depth === 0 ? 800 : 600,
+            lineHeight: 1.35,
+            overflowWrap: "anywhere",
+          }}
+        >
+          {node.title}
+        </Typography>
+      </Stack>
+
+      {hasChildren && isExpanded && (
+        <Box role="group">
+          {groups.map((group) => (
+            <Box key={`${nodeId}-${group.collectionName}`}>
+              <Typography
+                sx={{
+                  ml: `${Math.min(depth + 1, 9) * 14 + 30}px`,
+                  mt: 0.4,
+                  mb: 0.15,
+                  color: "text.secondary",
+                  fontSize: "0.72rem",
+                  fontWeight: 800,
+                  lineHeight: 1.3,
+                  textTransform: "uppercase",
+                  letterSpacing: 0,
+                }}
+              >
+                {group.collectionName}
+              </Typography>
+              {group.entries.map((child) =>
+                nextAncestors.has(child.childId) ? (
+                  <Typography
+                    key={`${nodeId}-${group.collectionName}-${child.childId}`}
+                    sx={{
+                      ml: `${Math.min(depth + 2, 10) * 14 + 30}px`,
+                      py: 0.5,
+                      color: "warning.main",
+                      fontSize: "0.85rem",
+                    }}
+                  >
+                    {nodesById.get(child.childId)?.title} (circular reference)
+                  </Typography>
+                ) : (
+                  <OutlineNode
+                    key={`${nodeId}-${group.collectionName}-${child.childId}`}
+                    nodeId={child.childId}
+                    nodesById={nodesById}
+                    childrenByParent={childrenByParent}
+                    expanded={expanded}
+                    showEvidence={showEvidence}
+                    ancestors={nextAncestors}
+                    onToggle={onToggle}
+                    depth={depth + 1}
+                  />
+                ),
+              )}
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+const OutlineColumn = ({
+  heading,
+  snapshot,
+  showEvidence,
+}: {
+  heading: string;
+  snapshot: SomOntologyOutlineSnapshot;
+  showEvidence: boolean;
+}) => {
+  const nodesById = useMemo(
+    () => new Map(snapshot.nodes.map((node) => [node.id, node])),
+    [snapshot.nodes],
+  );
+  const childrenByParent = useMemo(() => {
+    const result = new Map<string, OutlineChild[]>();
+    for (const edge of snapshot.edges) {
+      result.set(edge.parentId, [
+        ...(result.get(edge.parentId) || []),
+        {
+          childId: edge.childId,
+          collectionName: edge.collectionName,
+        },
+      ]);
+    }
+    return result;
+  }, [snapshot.edges]);
+  const expandableNodeIds = useMemo(
+    () =>
+      snapshot.nodes
+        .filter((node) => {
+          if (!showEvidence && node.evidence) return false;
+          return (childrenByParent.get(node.id) || []).some((child) => {
+            const childNode = nodesById.get(child.childId);
+            return childNode && (showEvidence || !childNode.evidence);
+          });
+        })
+        .map((node) => node.id),
+    [childrenByParent, nodesById, showEvidence, snapshot.nodes],
+  );
+  const [expanded, setExpanded] = useState<Set<string>>(
+    () => new Set([snapshot.rootNodeId]),
+  );
+
+  useEffect(() => {
+    setExpanded(new Set([snapshot.rootNodeId]));
+  }, [snapshot.rootNodeId, showEvidence]);
+
+  const visibleNodeCount = snapshot.nodes.filter(
+    (node) => showEvidence || !node.evidence,
+  ).length;
+
+  return (
+    <Box
+      component="section"
+      aria-label={`${heading} ontology outline`}
+      sx={{
+        minWidth: 0,
+        border: 1,
+        borderColor: "divider",
+        borderRadius: 1,
+        overflow: "hidden",
+        backgroundColor: "background.paper",
+      }}
+    >
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        spacing={1}
+        sx={{
+          borderBottom: 1,
+          borderColor: "divider",
+          px: 1.5,
+          py: 1.25,
+        }}
+      >
+        <Box sx={{ minWidth: 0 }}>
+          <Typography
+            component="h3"
+            sx={{ fontSize: "0.95rem", fontWeight: 800 }}
+          >
+            {heading}
+          </Typography>
+          <Typography
+            title={snapshot.ontologyName}
+            sx={{
+              mt: 0.15,
+              color: "text.secondary",
+              fontSize: "0.78rem",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {visibleNodeCount} nodes · {snapshot.ontologyName}
+          </Typography>
+        </Box>
+        <Stack direction="row" spacing={0.25}>
+          <Tooltip title="Expand all">
+            <IconButton
+              size="small"
+              aria-label={`Expand all ${heading.toLowerCase()} nodes`}
+              onClick={() => setExpanded(new Set(expandableNodeIds))}
+            >
+              <UnfoldMoreIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Collapse all">
+            <IconButton
+              size="small"
+              aria-label={`Collapse all ${heading.toLowerCase()} nodes`}
+              onClick={() => setExpanded(new Set())}
+            >
+              <UnfoldLessIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      </Stack>
+      <Box
+        role="tree"
+        aria-label={`${heading} ${snapshot.rootTitle} hierarchy`}
+        sx={{
+          maxHeight: { xs: 420, md: 560 },
+          overflow: "auto",
+          px: 1,
+          py: 1,
+        }}
+      >
+        <OutlineNode
+          nodeId={snapshot.rootNodeId}
+          nodesById={nodesById}
+          childrenByParent={childrenByParent}
+          expanded={expanded}
+          showEvidence={showEvidence}
+          ancestors={new Set()}
+          onToggle={(nodeId) =>
+            setExpanded((current) => {
+              const next = new Set(current);
+              if (next.has(nodeId)) next.delete(nodeId);
+              else next.add(nodeId);
+              return next;
+            })
+          }
+          depth={0}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+const OntologyComparisonPanel = ({
+  datasetId,
+  branch,
+  roundLabel,
+  currentRound,
+}: {
+  datasetId: string;
+  branch: string;
+  roundLabel: string;
+  currentRound: boolean;
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState("");
+  const [outline, setOutline] = useState<SomOntologyOutlineResponse | null>(
+    null,
+  );
+  const [showEvidence, setShowEvidence] = useState(false);
+
+  const loadOutline = async () => {
+    setLoading(true);
+    setLoadError("");
+    try {
+      const result = await Post<SomOntologyOutlineResponse>(
+        "/som-review/outline",
+        { datasetId },
+        false,
+      );
+      setOutline(result);
+    } catch {
+      setLoadError("The ontology outlines could not be loaded.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Accordion
+      expanded={expanded}
+      disableGutters
+      elevation={0}
+      onChange={(_, nextExpanded) => {
+        setExpanded(nextExpanded);
+        if (nextExpanded && !outline && !loading) loadOutline();
+      }}
+      sx={{
+        mt: 4,
+        borderTop: 1,
+        borderBottom: 1,
+        borderColor: "divider",
+        backgroundImage: "none",
+        "&::before": { display: "none" },
+      }}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls="ontology-comparison-content"
+        id="ontology-comparison-header"
+        sx={{
+          px: { xs: 1, sm: 1.5 },
+          minHeight: 64,
+          "& .MuiAccordionSummary-content": { minWidth: 0 },
+        }}
+      >
+        <Stack direction="row" alignItems="center" spacing={1.25} minWidth={0}>
+          <AccountTreeOutlinedIcon color="primary" />
+          <Box minWidth={0}>
+            <Typography sx={{ fontWeight: 800 }}>
+              Compare {branch} hierarchy
+            </Typography>
+            <Typography
+              sx={{
+                color: "text.secondary",
+                fontSize: "0.85rem",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {roundLabel} alongside the original sub-ontology
+            </Typography>
+          </Box>
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails
+        id="ontology-comparison-content"
+        sx={{ px: { xs: 1, sm: 1.5 }, pt: 0, pb: 2 }}
+      >
+        {loading && (
+          <Stack alignItems="center" sx={{ py: 6 }}>
+            <CircularProgress
+              size={32}
+              aria-label="Loading ontology outlines"
+            />
+          </Stack>
+        )}
+        {!loading && loadError && (
+          <Alert
+            severity="error"
+            action={
+              <Button color="inherit" onClick={loadOutline}>
+                Retry
+              </Button>
+            }
+          >
+            {loadError}
+          </Alert>
+        )}
+        {!loading && outline && (
+          <Stack spacing={1.5}>
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              alignItems={{ xs: "flex-start", sm: "center" }}
+              justifyContent="space-between"
+              spacing={0.75}
+            >
+              <Typography sx={{ color: "text.secondary", fontSize: "0.9rem" }}>
+                Expand either outline independently. Collection labels are
+                preserved.
+              </Typography>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    size="small"
+                    checked={showEvidence}
+                    onChange={(event) => setShowEvidence(event.target.checked)}
+                  />
+                }
+                label="Include O*NET evidence"
+                sx={{ mr: 0 }}
+              />
+            </Stack>
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: { xs: "minmax(0, 1fr)", md: "1fr 1fr" },
+                gap: 1.5,
+                alignItems: "start",
+              }}
+            >
+              <OutlineColumn
+                heading="Original"
+                snapshot={outline.original}
+                showEvidence={showEvidence}
+              />
+              <OutlineColumn
+                heading={currentRound ? "Current" : "Selected round"}
+                snapshot={outline.selected}
+                showEvidence={showEvidence}
+              />
+            </Box>
+          </Stack>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+export default OntologyComparisonPanel;

--- a/src/components/SomReview/ReviewQueueSelector.tsx
+++ b/src/components/SomReview/ReviewQueueSelector.tsx
@@ -204,6 +204,7 @@ const ReviewQueueSelector = ({
   canDeliberate = false,
   onOpenDeliberation,
   headerAction,
+  workspaceControls,
   readyFollowUps = [],
   onStartFollowUp,
 }: {
@@ -214,6 +215,7 @@ const ReviewQueueSelector = ({
   canDeliberate?: boolean;
   onOpenDeliberation?: () => void;
   headerAction?: React.ReactNode;
+  workspaceControls?: React.ReactNode;
   readyFollowUps?: SomLinkedFollowUp[];
   onStartFollowUp?: (followUp: SomLinkedFollowUp) => void;
 }) => {
@@ -281,6 +283,8 @@ const ReviewQueueSelector = ({
         Reviews are recorded separately from ontology changes. Choose one type
         of issue to review.
       </Typography>
+
+      {workspaceControls}
 
       <ReviewPath issueTypes={issueTypes} onStart={onStart} />
 

--- a/src/components/SomReview/ReviewWorkspaceSwitcher.tsx
+++ b/src/components/SomReview/ReviewWorkspaceSwitcher.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import {
+  Box,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from "@mui/material";
+
+import { SomReviewWorkspaceOption } from "../../types/ISomReview";
+
+const ReviewWorkspaceSwitcher = ({
+  workspaces,
+  workspaceId,
+  datasetId,
+  disabled = false,
+  onChange,
+}: {
+  workspaces: SomReviewWorkspaceOption[];
+  workspaceId: string;
+  datasetId: string;
+  disabled?: boolean;
+  onChange: (datasetId: string) => void;
+}) => {
+  const workspace =
+    workspaces.find((candidate) => candidate.id === workspaceId) ||
+    workspaces[0];
+  const selectedRound = workspace?.rounds.find(
+    (round) => round.id === datasetId,
+  );
+
+  if (!workspace) return null;
+
+  return (
+    <Box
+      component="section"
+      aria-labelledby="review-workspace-heading"
+      sx={{
+        borderTop: 1,
+        borderBottom: 1,
+        borderColor: "divider",
+        py: 2,
+        mb: 3,
+      }}
+    >
+      <Stack spacing={1.75}>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          alignItems={{ xs: "stretch", sm: "center" }}
+          justifyContent="space-between"
+          spacing={1.5}
+        >
+          <Box>
+            <Typography
+              id="review-workspace-heading"
+              component="h2"
+              sx={{ fontSize: "1rem", fontWeight: 800 }}
+            >
+              Review workspace
+            </Typography>
+            <Typography
+              sx={{ mt: 0.25, color: "text.secondary", lineHeight: 1.45 }}
+            >
+              Switch sub-ontology without mixing review progress.
+            </Typography>
+          </Box>
+          <ToggleButtonGroup
+            exclusive
+            size="small"
+            value={workspace.id}
+            aria-label="Sub-ontology"
+            onChange={(_, nextWorkspaceId: string | null) => {
+              if (!nextWorkspaceId || nextWorkspaceId === workspace.id) return;
+              const nextWorkspace = workspaces.find(
+                (candidate) => candidate.id === nextWorkspaceId,
+              );
+              if (nextWorkspace) onChange(nextWorkspace.activeDatasetId);
+            }}
+            sx={{
+              alignSelf: { xs: "stretch", sm: "center" },
+              "& .MuiToggleButton-root": {
+                flex: { xs: 1, sm: "0 0 auto" },
+                minWidth: { sm: 92 },
+                minHeight: 42,
+                px: 2,
+                fontWeight: 750,
+                letterSpacing: 0,
+              },
+            }}
+          >
+            {workspaces.map((candidate) => (
+              <ToggleButton
+                key={candidate.id}
+                value={candidate.id}
+                disabled={disabled}
+                aria-label={`${candidate.label} sub-ontology`}
+              >
+                {candidate.label}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </Stack>
+
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          alignItems={{ xs: "stretch", sm: "center" }}
+          spacing={1.25}
+        >
+          <FormControl size="small" sx={{ flex: 1, minWidth: 0 }}>
+            <InputLabel id="review-round-label">Review round</InputLabel>
+            <Select
+              labelId="review-round-label"
+              label="Review round"
+              value={selectedRound?.id || workspace.activeDatasetId}
+              disabled={disabled}
+              onChange={(event) => onChange(String(event.target.value))}
+            >
+              {workspace.rounds.map((round) => (
+                <MenuItem key={round.id} value={round.id}>
+                  {round.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <Chip
+            label={selectedRound?.current ? "Current hierarchy" : "Past round"}
+            color={selectedRound?.current ? "primary" : "default"}
+            variant="outlined"
+            sx={{ alignSelf: { xs: "flex-start", sm: "center" } }}
+          />
+        </Stack>
+      </Stack>
+    </Box>
+  );
+};
+
+export default ReviewWorkspaceSwitcher;

--- a/src/lib/somReview/dataset.ts
+++ b/src/lib/somReview/dataset.ts
@@ -7,9 +7,16 @@ import addFormats from "ajv-formats";
 import { SomIssueType } from "../../types/ISomReview";
 import {
   loadOntologySnapshot,
+  SomOntologySnapshot,
   validateProposalAgainstSnapshot,
 } from "./ontologySnapshot";
 import { numberedIssueLabelMap } from "./reviewTaxonomy";
+import {
+  DEFAULT_REVIEW_DATASET_ID,
+  reviewDatasetConfig,
+  reviewDatasetConfigByVersion,
+  reviewDatasetDir,
+} from "./reviewWorkspaces";
 
 const EXPECTED_SCHEMA_VERSION = "som-review-v1";
 
@@ -51,20 +58,18 @@ export const proposalAvailability = (
 };
 
 export interface SomDataset {
+  datasetId: string;
   datasetVersion: string;
+  rootDir: string;
   manifest: any;
+  snapshot: SomOntologySnapshot;
   recordsById: Map<string, any>;
   orderedIdsByIssue: Map<SomIssueType, string[]>;
   issueLabels: Map<SomIssueType, string>;
 }
 
 const datasetDir = (): string =>
-  process.env.SOM_REVIEW_DATASET_DIR ||
-  path.join(
-    process.cwd(),
-    "Buy_Society_of_Mind_Title_Followup_2026-07-25",
-    "review-datasets-title-followup-v1",
-  );
+  reviewDatasetDir(reviewDatasetConfig(DEFAULT_REVIEW_DATASET_ID));
 
 export const isIssueTypeEnabled = (issueType: SomIssueType): boolean => {
   if (!SUPPORTED_ISSUE_TYPES.includes(issueType)) return false;
@@ -130,7 +135,7 @@ const orderKey = (record: any): string =>
     .update(`${record.datasetVersion}|${record.issueType}|${record.proposalId}`)
     .digest("hex");
 
-export const loadDataset = (dir?: string): SomDataset => {
+export const loadDataset = (dir?: string, datasetId = "custom"): SomDataset => {
   const root = dir || datasetDir();
   const manifest = JSON.parse(
     fs.readFileSync(path.join(root, "manifest.json"), "utf8"),
@@ -230,17 +235,31 @@ export const loadDataset = (dir?: string): SomDataset => {
   }
 
   return {
+    datasetId,
     datasetVersion: manifest.datasetVersion,
+    rootDir: root,
     manifest,
+    snapshot: ontologySource.snapshot,
     recordsById,
     orderedIdsByIssue,
     issueLabels,
   };
 };
 
-let cached: SomDataset | null = null;
+const cachedById = new Map<string, SomDataset>();
 
-export const getDataset = (): SomDataset => {
-  if (!cached) cached = loadDataset();
-  return cached;
+export const getDataset = (
+  datasetId = DEFAULT_REVIEW_DATASET_ID,
+): SomDataset => {
+  const config = reviewDatasetConfig(datasetId);
+  const cached = cachedById.get(config.id);
+  if (cached) return cached;
+  const dataset = loadDataset(reviewDatasetDir(config), config.id);
+  cachedById.set(config.id, dataset);
+  return dataset;
+};
+
+export const getDatasetByVersion = (datasetVersion: string): SomDataset => {
+  const config = reviewDatasetConfigByVersion(datasetVersion);
+  return getDataset(config.id);
 };

--- a/src/lib/somReview/outline.ts
+++ b/src/lib/somReview/outline.ts
@@ -1,0 +1,45 @@
+import { SomOntologyOutlineSnapshot } from "../../types/ISomReview";
+import type { SomDataset } from "./dataset";
+
+export const toOutlineSnapshot = (
+  dataset: SomDataset,
+): SomOntologyOutlineSnapshot => {
+  const snapshot = dataset.snapshot;
+  const rootNodeId = snapshot.branchRootNodeId || snapshot.sellRootNodeId || "";
+  const nodesById = new Map(snapshot.nodes.map((node) => [node.id, node]));
+  const childrenByParent = new Map<string, string[]>();
+
+  for (const edge of snapshot.edges) {
+    childrenByParent.set(edge.parentId, [
+      ...(childrenByParent.get(edge.parentId) || []),
+      edge.childId,
+    ]);
+  }
+
+  const reachable = new Set<string>();
+  const pending = [rootNodeId];
+  while (pending.length > 0) {
+    const nodeId = pending.shift() || "";
+    if (!nodeId || reachable.has(nodeId) || !nodesById.has(nodeId)) continue;
+    reachable.add(nodeId);
+    pending.push(...(childrenByParent.get(nodeId) || []));
+  }
+
+  return {
+    ontologyName: snapshot.ontologyName,
+    capturedAt: snapshot.capturedAt,
+    rootNodeId,
+    rootTitle:
+      snapshot.branchRootTitle || nodesById.get(rootNodeId)?.title || "",
+    nodes: snapshot.nodes
+      .filter((node) => reachable.has(node.id))
+      .map((node) => ({
+        id: node.id,
+        title: node.title,
+        evidence: node.title.startsWith("(O*Net)"),
+      })),
+    edges: snapshot.edges.filter(
+      (edge) => reachable.has(edge.parentId) && reachable.has(edge.childId),
+    ),
+  };
+};

--- a/src/lib/somReview/reviewWorkspaces.ts
+++ b/src/lib/somReview/reviewWorkspaces.ts
@@ -1,0 +1,195 @@
+import path from "path";
+
+export interface SomReviewDatasetConfig {
+  id: string;
+  datasetVersion: string;
+  workspaceId: string;
+  label: string;
+  relativeDir: string[];
+  current: boolean;
+}
+
+export interface SomReviewWorkspaceConfig {
+  id: string;
+  label: string;
+  activeDatasetId: string;
+  originalDatasetId: string;
+  datasets: SomReviewDatasetConfig[];
+}
+
+const buyDatasets: SomReviewDatasetConfig[] = [
+  {
+    id: "buy-title-followup",
+    datasetVersion: "buy-title-followup-after-initial-review-2026-07-25-v1",
+    workspaceId: "buy",
+    label: "Title follow-up",
+    relativeDir: [
+      "Buy_Society_of_Mind_Title_Followup_2026-07-25",
+      "review-datasets-title-followup-v1",
+    ],
+    current: true,
+  },
+  {
+    id: "buy-initial-title-review",
+    datasetVersion: "buy-exploratory-transfer-2026-07-25-v1",
+    workspaceId: "buy",
+    label: "Initial title review",
+    relativeDir: [
+      "Buy_Society_of_Mind_Exploratory_2026-07-25",
+      "review-datasets-exploratory-v1",
+    ],
+    current: false,
+  },
+];
+
+const sellDatasets: SomReviewDatasetConfig[] = [
+  {
+    id: "sell-current",
+    datasetVersion: "sell-rob-post-structure-2026-07-25-v1",
+    workspaceId: "sell",
+    label: "Current hierarchy and optional checks",
+    relativeDir: [
+      "Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15",
+      "review-datasets-rob-post-structure-2026-07-25",
+    ],
+    current: true,
+  },
+  {
+    id: "sell-structure-review",
+    datasetVersion: "sell-rob-structure-wave-2026-07-24-v1",
+    workspaceId: "sell",
+    label: "Structure and placement review",
+    relativeDir: [
+      "Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15",
+      "review-datasets-rob-structure-wave-2026-07-24",
+    ],
+    current: false,
+  },
+  {
+    id: "sell-content-review",
+    datasetVersion: "sell-rob-content-wave-2026-07-24-v1",
+    workspaceId: "sell",
+    label: "Content and identity review",
+    relativeDir: [
+      "Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15",
+      "review-datasets-rob-content-wave-2026-07-24",
+    ],
+    current: false,
+  },
+  {
+    id: "sell-after-title-corrections",
+    datasetVersion: "sell-rob-title-v2-downstream-2026-07-23-v2",
+    workspaceId: "sell",
+    label: "Review after title corrections",
+    relativeDir: [
+      "Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15",
+      "review-datasets-rob-title-v2-downstream-2026-07-23",
+    ],
+    current: false,
+  },
+  {
+    id: "sell-title-followup",
+    datasetVersion: "sell-rob-title-applied-title-pass-2026-07-22-v1",
+    workspaceId: "sell",
+    label: "Title follow-up",
+    relativeDir: [
+      "Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15",
+      "review-datasets-rob-title-applied-2026-07-22",
+    ],
+    current: false,
+  },
+  {
+    id: "sell-initial-review",
+    datasetVersion: "sell-final-hierarchy-onet-2026-07-15-v4",
+    workspaceId: "sell",
+    label: "Initial review",
+    relativeDir: [
+      "Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15",
+      "review-datasets",
+    ],
+    current: false,
+  },
+];
+
+export const SOM_REVIEW_WORKSPACES: SomReviewWorkspaceConfig[] = [
+  {
+    id: "buy",
+    label: "Buy",
+    activeDatasetId: "buy-title-followup",
+    originalDatasetId: "buy-initial-title-review",
+    datasets: buyDatasets,
+  },
+  {
+    id: "sell",
+    label: "Sell",
+    activeDatasetId: "sell-current",
+    originalDatasetId: "sell-initial-review",
+    datasets: sellDatasets,
+  },
+];
+
+export const DEFAULT_REVIEW_DATASET_ID =
+  process.env.SOM_REVIEW_DEFAULT_DATASET_ID || "buy-title-followup";
+
+const datasets = SOM_REVIEW_WORKSPACES.flatMap(
+  (workspace) => workspace.datasets,
+);
+const datasetsById = new Map(datasets.map((dataset) => [dataset.id, dataset]));
+const datasetsByVersion = new Map(
+  datasets.map((dataset) => [dataset.datasetVersion, dataset]),
+);
+
+export const reviewDatasetConfig = (
+  datasetId = DEFAULT_REVIEW_DATASET_ID,
+): SomReviewDatasetConfig => {
+  const config = datasetsById.get(datasetId);
+  if (!config) {
+    throw new Error(`Unknown review dataset: ${datasetId}`);
+  }
+  return config;
+};
+
+export const reviewWorkspaceConfig = (
+  workspaceId: string,
+): SomReviewWorkspaceConfig => {
+  const workspace = SOM_REVIEW_WORKSPACES.find(
+    (candidate) => candidate.id === workspaceId,
+  );
+  if (!workspace) {
+    throw new Error(`Unknown review workspace: ${workspaceId}`);
+  }
+  return workspace;
+};
+
+export const reviewDatasetConfigByVersion = (
+  datasetVersion: string,
+): SomReviewDatasetConfig => {
+  const config = datasetsByVersion.get(datasetVersion);
+  if (!config) {
+    throw new Error(`Unknown review dataset version: ${datasetVersion}`);
+  }
+  return config;
+};
+
+export const reviewDatasetDir = (config: SomReviewDatasetConfig): string => {
+  if (
+    config.id === DEFAULT_REVIEW_DATASET_ID &&
+    process.env.SOM_REVIEW_DATASET_DIR
+  ) {
+    return process.env.SOM_REVIEW_DATASET_DIR;
+  }
+  return path.join(process.cwd(), ...config.relativeDir);
+};
+
+export const reviewWorkspaceOptions = () =>
+  SOM_REVIEW_WORKSPACES.map((workspace) => ({
+    id: workspace.id,
+    label: workspace.label,
+    activeDatasetId: workspace.activeDatasetId,
+    rounds: workspace.datasets.map((dataset) => ({
+      id: dataset.id,
+      datasetVersion: dataset.datasetVersion,
+      label: dataset.label,
+      current: dataset.current,
+    })),
+  }));

--- a/src/pages/api/som-review/admin/comment.ts
+++ b/src/pages/api/som-review/admin/comment.ts
@@ -24,7 +24,9 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   try {
     requireDeliberationAccess(req.user);
     const data = reviewRequestData(req.body);
-    const dataset = getDataset();
+    const dataset = getDataset(
+      typeof data.datasetId === "string" ? data.datasetId : undefined,
+    );
     const proposalId =
       typeof data.proposalId === "string" ? data.proposalId : "";
     if (!dataset.recordsById.has(proposalId)) {

--- a/src/pages/api/som-review/admin/overview.ts
+++ b/src/pages/api/som-review/admin/overview.ts
@@ -15,6 +15,7 @@ import {
   SomDeliberationOverviewResponse,
   SomReviewerRole,
 } from "../../../../types/ISomReview";
+import { reviewRequestData } from "../../../../lib/somReview/request";
 
 const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   const req = request as CustomNextApiRequest;
@@ -23,7 +24,10 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   }
   try {
     const { response: access } = requireDeliberationAccess(req.user);
-    const dataset = getDataset();
+    const data = reviewRequestData(req.body);
+    const dataset = getDataset(
+      typeof data.datasetId === "string" ? data.datasetId : undefined,
+    );
     const weights = reviewerRoleWeights();
     const roles: SomReviewerRole[] = ["steward", "researcher", "contributor"];
     const deliberation = await loadDeliberationOverview(dataset, req.user.uid);

--- a/src/pages/api/som-review/admin/position.ts
+++ b/src/pages/api/som-review/admin/position.ts
@@ -21,7 +21,9 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   try {
     requireDeliberationAccess(req.user);
     const data = reviewRequestData(req.body);
-    const dataset = getDataset();
+    const dataset = getDataset(
+      typeof data.datasetId === "string" ? data.datasetId : undefined,
+    );
     const proposalId =
       typeof data.proposalId === "string" ? data.proposalId : "";
     if (!dataset.recordsById.has(proposalId)) {

--- a/src/pages/api/som-review/admin/proposal.ts
+++ b/src/pages/api/som-review/admin/proposal.ts
@@ -18,7 +18,9 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   try {
     const { response: access } = requireDeliberationAccess(req.user);
     const data = reviewRequestData(req.body);
-    const dataset = getDataset();
+    const dataset = getDataset(
+      typeof data.datasetId === "string" ? data.datasetId : undefined,
+    );
     const proposalId =
       typeof data.proposalId === "string" ? data.proposalId : "";
     if (!proposalId) {

--- a/src/pages/api/som-review/admin/resolve.ts
+++ b/src/pages/api/som-review/admin/resolve.ts
@@ -32,7 +32,9 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       );
     }
     const data = reviewRequestData(req.body);
-    const dataset = getDataset();
+    const dataset = getDataset(
+      typeof data.datasetId === "string" ? data.datasetId : undefined,
+    );
     const proposalId =
       typeof data.proposalId === "string" ? data.proposalId : "";
     if (!dataset.recordsById.has(proposalId)) {

--- a/src/pages/api/som-review/outline.ts
+++ b/src/pages/api/som-review/outline.ts
@@ -2,32 +2,36 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import fbAuth, { CustomNextApiRequest } from "../../../middlewares/fbAuth";
 import { getDataset } from "../../../lib/somReview/dataset";
-import { undoPrevious } from "../../../lib/somReview/store";
 import { reviewRequestData } from "../../../lib/somReview/request";
-import { SomIssueType, SomUndoResult } from "../../../types/ISomReview";
+import {
+  reviewDatasetConfig,
+  reviewWorkspaceConfig,
+} from "../../../lib/somReview/reviewWorkspaces";
+import { toOutlineSnapshot } from "../../../lib/somReview/outline";
+import { SomOntologyOutlineResponse } from "../../../types/ISomReview";
 
 const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   const req = request as CustomNextApiRequest;
-  if (req.method !== "POST")
+  if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });
+  }
   try {
     const data = reviewRequestData(req.body);
-    const issueType = data.issueType as SomIssueType;
-    const sessionId = typeof data.sessionId === "string" ? data.sessionId : "";
-    if (!sessionId) return res.status(400).json({ error: "Missing sessionId" });
     const dataset = getDataset(
       typeof data.datasetId === "string" ? data.datasetId : undefined,
     );
-    if (!dataset.orderedIdsByIssue.has(issueType)) {
-      return res.status(400).json({ error: "Unknown issue type" });
-    }
-    const { cursor } = await undoPrevious(
-      sessionId,
-      dataset.datasetVersion,
-      issueType,
-      req.user.uid,
-    );
-    const body: SomUndoResult = { ok: true, cursor };
+    const datasetConfig = reviewDatasetConfig(dataset.datasetId);
+    const workspace = reviewWorkspaceConfig(datasetConfig.workspaceId);
+    const originalDataset = getDataset(workspace.originalDatasetId);
+
+    const body: SomOntologyOutlineResponse = {
+      datasetId: dataset.datasetId,
+      workspaceId: workspace.id,
+      branch: workspace.label,
+      currentRound: datasetConfig.current,
+      selected: toOutlineSnapshot(dataset),
+      original: toOutlineSnapshot(originalDataset),
+    };
     return res.status(200).json(body);
   } catch (error: any) {
     console.error(error);

--- a/src/pages/api/som-review/overview.ts
+++ b/src/pages/api/som-review/overview.ts
@@ -20,13 +20,22 @@ import {
   blockingIssuePrerequisites,
   issuePrerequisiteTypes,
 } from "../../../lib/somReview/reviewDependencies";
+import { reviewRequestData } from "../../../lib/somReview/request";
+import {
+  reviewDatasetConfig,
+  reviewWorkspaceOptions,
+} from "../../../lib/somReview/reviewWorkspaces";
 
 const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   const req = request as CustomNextApiRequest;
   if (req.method !== "POST")
     return res.status(405).json({ error: "Method not allowed" });
   try {
-    const dataset = getDataset();
+    const data = reviewRequestData(req.body);
+    const requestedDatasetId =
+      typeof data.datasetId === "string" ? data.datasetId : undefined;
+    const dataset = getDataset(requestedDatasetId);
+    const datasetConfig = reviewDatasetConfig(dataset.datasetId);
     const reviewerId = req.user.uid;
 
     const [baseIssueTypes, readyFollowUpRecords] = await Promise.all([
@@ -78,7 +87,12 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
     }));
 
     const body: SomOverviewResponse = {
+      datasetId: dataset.datasetId,
       datasetVersion: dataset.datasetVersion,
+      workspaceId: datasetConfig.workspaceId,
+      roundLabel: datasetConfig.label,
+      currentRound: datasetConfig.current,
+      workspaces: reviewWorkspaceOptions(),
       branch: String(dataset.manifest.branch || "Sell"),
       ontologyName: String(
         dataset.manifest.sourceSnapshot?.ontologyName ||

--- a/src/pages/api/som-review/respond.ts
+++ b/src/pages/api/som-review/respond.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import fbAuth, { CustomNextApiRequest } from "../../../middlewares/fbAuth";
 import {
   compileResponseValidator,
-  getDataset,
+  getDatasetByVersion,
   isIssueTypeEnabled,
 } from "../../../lib/somReview/dataset";
 import {
@@ -15,14 +15,16 @@ import { reviewRequestData } from "../../../lib/somReview/request";
 import { SomRespondResult } from "../../../types/ISomReview";
 import { toLinkedFollowUps } from "../../../lib/somReview/followUps";
 
-let validateResponse: ReturnType<typeof compileResponseValidator> | null = null;
+const responseValidators = new Map<
+  string,
+  ReturnType<typeof compileResponseValidator>
+>();
 
 const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   const req = request as CustomNextApiRequest;
   if (req.method !== "POST")
     return res.status(405).json({ error: "Method not allowed" });
   try {
-    const dataset = getDataset();
     const data = reviewRequestData(req.body);
     const payload = data.response as ResponsePayload;
     const sessionId = typeof data.sessionId === "string" ? data.sessionId : "";
@@ -30,7 +32,12 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
     if (!payload)
       return res.status(400).json({ error: "Missing response payload" });
 
-    if (!validateResponse) validateResponse = compileResponseValidator();
+    const dataset = getDatasetByVersion(String(payload.datasetVersion || ""));
+    let validateResponse = responseValidators.get(dataset.datasetVersion);
+    if (!validateResponse) {
+      validateResponse = compileResponseValidator(dataset.rootDir);
+      responseValidators.set(dataset.datasetVersion, validateResponse);
+    }
     if (!validateResponse(payload)) {
       return res.status(400).json({
         error: "Response failed schema validation",
@@ -41,9 +48,6 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       return res
         .status(403)
         .json({ error: "reviewerId does not match the signed-in user" });
-    }
-    if (payload.datasetVersion !== dataset.datasetVersion) {
-      return res.status(400).json({ error: "Unexpected datasetVersion" });
     }
     const record = dataset.recordsById.get(payload.proposalId);
     if (!record) return res.status(400).json({ error: "Unknown proposalId" });

--- a/src/pages/api/som-review/revise.ts
+++ b/src/pages/api/som-review/revise.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import fbAuth, { CustomNextApiRequest } from "../../../middlewares/fbAuth";
 import {
   compileResponseValidator,
-  getDataset,
+  getDatasetByVersion,
   isIssueTypeEnabled,
 } from "../../../lib/somReview/dataset";
 import {
@@ -15,20 +15,27 @@ import { reviewRequestData } from "../../../lib/somReview/request";
 import { SomReviseResult } from "../../../types/ISomReview";
 import { toLinkedFollowUps } from "../../../lib/somReview/followUps";
 
-let validateResponse: ReturnType<typeof compileResponseValidator> | null = null;
+const responseValidators = new Map<
+  string,
+  ReturnType<typeof compileResponseValidator>
+>();
 
 const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   const req = request as CustomNextApiRequest;
   if (req.method !== "POST")
     return res.status(405).json({ error: "Method not allowed" });
   try {
-    const dataset = getDataset();
     const data = reviewRequestData(req.body);
     const payload = data.response as ResponsePayload;
     if (!payload)
       return res.status(400).json({ error: "Missing response payload" });
 
-    if (!validateResponse) validateResponse = compileResponseValidator();
+    const dataset = getDatasetByVersion(String(payload.datasetVersion || ""));
+    let validateResponse = responseValidators.get(dataset.datasetVersion);
+    if (!validateResponse) {
+      validateResponse = compileResponseValidator(dataset.rootDir);
+      responseValidators.set(dataset.datasetVersion, validateResponse);
+    }
     if (!validateResponse(payload)) {
       return res.status(400).json({
         error: "Response failed schema validation",
@@ -39,9 +46,6 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       return res
         .status(403)
         .json({ error: "reviewerId does not match the signed-in user" });
-    }
-    if (payload.datasetVersion !== dataset.datasetVersion) {
-      return res.status(400).json({ error: "Unexpected datasetVersion" });
     }
     const record = dataset.recordsById.get(payload.proposalId);
     if (!record) return res.status(400).json({ error: "Unknown proposalId" });

--- a/src/pages/api/som-review/session.ts
+++ b/src/pages/api/som-review/session.ts
@@ -28,7 +28,9 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
         ? data.preferredProposalId
         : undefined;
     const historyOnly = data.historyOnly === true;
-    const dataset = getDataset();
+    const dataset = getDataset(
+      typeof data.datasetId === "string" ? data.datasetId : undefined,
+    );
     if (!dataset.orderedIdsByIssue.has(issueType)) {
       return res.status(400).json({ error: "Unknown issue type" });
     }

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   Alert,
   Box,
@@ -27,6 +27,8 @@ import ReviewFollowUpPanel from "@components/components/SomReview/ReviewFollowUp
 import ReviewQueueSelector from "@components/components/SomReview/ReviewQueueSelector";
 import ReviewTaskIntro from "@components/components/SomReview/ReviewTaskIntro";
 import ThemeModeToggle from "@components/components/SomReview/ThemeModeToggle";
+import OntologyComparisonPanel from "@components/components/SomReview/OntologyComparisonPanel";
+import ReviewWorkspaceSwitcher from "@components/components/SomReview/ReviewWorkspaceSwitcher";
 import { reviewInteractiveSurfaceSx } from "@components/components/SomReview/reviewStyles";
 import { clearReviewDraft } from "@components/lib/somReview/reviewDraft";
 import {
@@ -38,6 +40,7 @@ import {
   SomRespondResult,
   SomReviewCard,
   SomReviewHistoryItem,
+  SomReviewWorkspaceOption,
   SomReviseResult,
   SomSessionResponse,
 } from "@components/types/ISomReview";
@@ -72,7 +75,13 @@ export const ReviewPage = () => {
   const [{ user }] = useAuth();
   const router = useRouter();
   const [phase, setPhase] = useState<Phase>("loading");
+  const datasetIdRef = useRef("");
+  const [datasetId, setDatasetId] = useState("");
   const [datasetVersion, setDatasetVersion] = useState("");
+  const [workspaceId, setWorkspaceId] = useState("buy");
+  const [workspaces, setWorkspaces] = useState<SomReviewWorkspaceOption[]>([]);
+  const [roundLabel, setRoundLabel] = useState("");
+  const [currentRound, setCurrentRound] = useState(true);
   const [branch, setBranch] = useState("Sell");
   const [ontologyName, setOntologyName] = useState("Ontology");
   const [issueTypes, setIssueTypes] = useState<SomIssueTypeOption[]>([]);
@@ -97,13 +106,23 @@ export const ReviewPage = () => {
   const [completedSequence, setCompletedSequence] =
     useState<CompletedSequence | null>(null);
 
-  const loadOverview = useCallback(async () => {
+  const loadOverview = useCallback(async (requestedDatasetId?: string) => {
     setPhase("loading");
     setLoadError("");
     setRetryIssueType(null);
     try {
-      const overview = await Post<SomOverviewResponse>("/som-review/overview");
+      const targetDatasetId = requestedDatasetId || datasetIdRef.current;
+      const overview = await Post<SomOverviewResponse>(
+        "/som-review/overview",
+        targetDatasetId ? { datasetId: targetDatasetId } : {},
+      );
+      datasetIdRef.current = overview.datasetId;
+      setDatasetId(overview.datasetId);
       setDatasetVersion(overview.datasetVersion);
+      setWorkspaceId(overview.workspaceId);
+      setWorkspaces(overview.workspaces);
+      setRoundLabel(overview.roundLabel);
+      setCurrentRound(overview.currentRound);
       setBranch(overview.branch);
       setOntologyName(overview.ontologyName);
       setIssueTypes(overview.issueTypes);
@@ -117,8 +136,51 @@ export const ReviewPage = () => {
   }, []);
 
   useEffect(() => {
-    if (user) loadOverview();
-  }, [user, loadOverview]);
+    if (!user || !router.isReady) return;
+    const queryDatasetId =
+      typeof router.query.dataset === "string"
+        ? router.query.dataset
+        : undefined;
+    if (
+      datasetIdRef.current &&
+      (!queryDatasetId || queryDatasetId === datasetIdRef.current)
+    ) {
+      return;
+    }
+    loadOverview(queryDatasetId);
+  }, [loadOverview, router.isReady, router.query.dataset, user]);
+
+  const clearActiveReview = useCallback(() => {
+    setIssueType(null);
+    setSessionId("");
+    setCards([]);
+    setCursor(0);
+    setHistory([]);
+    setHistoryCards([]);
+    setRevisionProposalId("");
+    setRetryIssueType(null);
+    setFollowUpOffer(null);
+    setActiveSequence(null);
+    setCompletedSequence(null);
+  }, []);
+
+  const switchDataset = useCallback(
+    async (nextDatasetId: string) => {
+      if (!nextDatasetId || nextDatasetId === datasetIdRef.current) return;
+      clearActiveReview();
+      datasetIdRef.current = nextDatasetId;
+      await router.replace(
+        {
+          pathname: "/review",
+          query: { dataset: nextDatasetId },
+        },
+        undefined,
+        { shallow: true },
+      );
+      await loadOverview(nextDatasetId);
+    },
+    [clearActiveReview, loadOverview, router],
+  );
 
   const startSession = useCallback(
     async (
@@ -138,6 +200,7 @@ export const ReviewPage = () => {
       setActiveSequence(options.sequence || null);
       try {
         const result = await Post<SomSessionResponse>("/som-review/session", {
+          datasetId: datasetIdRef.current,
           issueType: issue,
           ...(options.preferredProposalId
             ? { preferredProposalId: options.preferredProposalId }
@@ -483,19 +546,9 @@ export const ReviewPage = () => {
   }, [cards.length, cursor, revisionCard, user?.userId]);
 
   const exitToSelector = useCallback(() => {
-    setIssueType(null);
-    setSessionId("");
-    setCards([]);
-    setCursor(0);
-    setHistory([]);
-    setHistoryCards([]);
-    setRevisionProposalId("");
-    setRetryIssueType(null);
-    setFollowUpOffer(null);
-    setActiveSequence(null);
-    setCompletedSequence(null);
+    clearActiveReview();
     loadOverview();
-  }, [loadOverview]);
+  }, [clearActiveReview, loadOverview]);
 
   const continueOriginalQueue = useCallback(() => {
     if (!followUpOffer) return;
@@ -544,7 +597,7 @@ export const ReviewPage = () => {
           },
         ]}
       >
-        <Container maxWidth="md">
+        <Container maxWidth="lg">
           {loadError && (
             <Alert
               severity="error"
@@ -585,8 +638,30 @@ export const ReviewPage = () => {
               readyFollowUps={readyFollowUps}
               onStartFollowUp={(followUp) => startLinkedFollowUp(followUp)}
               canDeliberate={canDeliberate}
-              onOpenDeliberation={() => router.push("/review/admin")}
+              onOpenDeliberation={() =>
+                router.push({
+                  pathname: "/review/admin",
+                  query: { dataset: datasetId },
+                })
+              }
               headerAction={<ThemeModeToggle />}
+              workspaceControls={
+                <>
+                  <ReviewWorkspaceSwitcher
+                    workspaces={workspaces}
+                    workspaceId={workspaceId}
+                    datasetId={datasetId}
+                    onChange={switchDataset}
+                  />
+                  {!currentRound && (
+                    <Alert severity="warning" sx={{ mb: 3 }}>
+                      You are reviewing a past round. Revisions are saved with
+                      that round, but they will not affect the current ontology
+                      until its decisions are propagated again.
+                    </Alert>
+                  )}
+                </>
+              }
             />
           )}
 
@@ -1091,6 +1166,16 @@ export const ReviewPage = () => {
                 </Button>
               </Stack>
             </Stack>
+          )}
+
+          {phase !== "loading" && datasetId && (
+            <OntologyComparisonPanel
+              key={datasetId}
+              datasetId={datasetId}
+              branch={branch}
+              roundLabel={roundLabel}
+              currentRound={currentRound}
+            />
           )}
         </Container>
       </Box>

--- a/src/pages/review/admin.tsx
+++ b/src/pages/review/admin.tsx
@@ -30,6 +30,8 @@ import {
 export const DeliberationAdminPage = () => {
   const [{ user }] = useAuth();
   const router = useRouter();
+  const datasetId =
+    typeof router.query.dataset === "string" ? router.query.dataset : "";
   const [overview, setOverview] =
     useState<SomDeliberationOverviewResponse | null>(null);
   const [loadingOverview, setLoadingOverview] = useState(true);
@@ -48,7 +50,7 @@ export const DeliberationAdminPage = () => {
     try {
       const result = await Post<SomDeliberationOverviewResponse>(
         "/som-review/admin/overview",
-        {},
+        datasetId ? { datasetId } : {},
         false,
       );
       setOverview(result);
@@ -62,37 +64,40 @@ export const DeliberationAdminPage = () => {
     } finally {
       setLoadingOverview(false);
     }
-  }, []);
+  }, [datasetId]);
 
   useEffect(() => {
-    if (user) loadOverview();
-  }, [loadOverview, user]);
+    if (user && router.isReady) loadOverview();
+  }, [loadOverview, router.isReady, user]);
 
-  const loadProposal = useCallback(async (proposalId: string) => {
-    if (!proposalId) return;
-    const requestSequence = ++detailRequestSequence.current;
-    setLoadingDetail(true);
-    setDetailError("");
-    try {
-      const result = await Post<SomDeliberationProposalResponse>(
-        "/som-review/admin/proposal",
-        { proposalId },
-        false,
-      );
-      if (requestSequence !== detailRequestSequence.current) return;
-      setDetail(result);
-    } catch (error: any) {
-      if (requestSequence !== detailRequestSequence.current) return;
-      setDetailError(
-        error?.response?.data?.error ||
-          "This deliberation could not be loaded. Please try again.",
-      );
-    } finally {
-      if (requestSequence === detailRequestSequence.current) {
-        setLoadingDetail(false);
+  const loadProposal = useCallback(
+    async (proposalId: string) => {
+      if (!proposalId) return;
+      const requestSequence = ++detailRequestSequence.current;
+      setLoadingDetail(true);
+      setDetailError("");
+      try {
+        const result = await Post<SomDeliberationProposalResponse>(
+          "/som-review/admin/proposal",
+          { proposalId, ...(datasetId ? { datasetId } : {}) },
+          false,
+        );
+        if (requestSequence !== detailRequestSequence.current) return;
+        setDetail(result);
+      } catch (error: any) {
+        if (requestSequence !== detailRequestSequence.current) return;
+        setDetailError(
+          error?.response?.data?.error ||
+            "This deliberation could not be loaded. Please try again.",
+        );
+      } finally {
+        if (requestSequence === detailRequestSequence.current) {
+          setLoadingDetail(false);
+        }
       }
-    }
-  }, []);
+    },
+    [datasetId],
+  );
 
   const openProposal = useCallback(
     (proposalId: string) => {
@@ -116,12 +121,16 @@ export const DeliberationAdminPage = () => {
       if (!selectedProposalId) throw new Error("No proposal is selected");
       await Post<SomDeliberationMutationResult>(
         endpoint,
-        { proposalId: selectedProposalId, ...data },
+        {
+          proposalId: selectedProposalId,
+          ...(datasetId ? { datasetId } : {}),
+          ...data,
+        },
         false,
       );
       await Promise.all([loadProposal(selectedProposalId), loadOverview()]);
     },
-    [loadOverview, loadProposal, selectedProposalId],
+    [datasetId, loadOverview, loadProposal, selectedProposalId],
   );
 
   return (
@@ -152,7 +161,12 @@ export const DeliberationAdminPage = () => {
               disableElevation
               color="inherit"
               startIcon={<ArrowBackIcon />}
-              onClick={() => router.push("/review")}
+              onClick={() =>
+                router.push({
+                  pathname: "/review",
+                  ...(datasetId ? { query: { dataset: datasetId } } : {}),
+                })
+              }
               sx={{ minHeight: 46, fontWeight: 700 }}
             >
               Individual review

--- a/src/types/ISomReview.ts
+++ b/src/types/ISomReview.ts
@@ -296,12 +296,61 @@ export interface SomLinkedFollowUp {
 }
 
 export interface SomOverviewResponse {
+  datasetId: string;
   datasetVersion: string;
+  workspaceId: string;
+  roundLabel: string;
+  currentRound: boolean;
+  workspaces: SomReviewWorkspaceOption[];
   branch: string;
   ontologyName: string;
   issueTypes: SomIssueTypeOption[];
   readyFollowUps: SomLinkedFollowUp[];
   canDeliberate: boolean;
+}
+
+export interface SomReviewRoundOption {
+  id: string;
+  datasetVersion: string;
+  label: string;
+  current: boolean;
+}
+
+export interface SomReviewWorkspaceOption {
+  id: string;
+  label: string;
+  activeDatasetId: string;
+  rounds: SomReviewRoundOption[];
+}
+
+export interface SomOntologyOutlineNode {
+  id: string;
+  title: string;
+  evidence: boolean;
+}
+
+export interface SomOntologyOutlineEdge {
+  parentId: string;
+  childId: string;
+  collectionName: string;
+}
+
+export interface SomOntologyOutlineSnapshot {
+  ontologyName: string;
+  capturedAt: string;
+  rootNodeId: string;
+  rootTitle: string;
+  nodes: SomOntologyOutlineNode[];
+  edges: SomOntologyOutlineEdge[];
+}
+
+export interface SomOntologyOutlineResponse {
+  datasetId: string;
+  workspaceId: string;
+  branch: string;
+  currentRound: boolean;
+  selected: SomOntologyOutlineSnapshot;
+  original: SomOntologyOutlineSnapshot;
 }
 
 export interface SomRespondResult {


### PR DESCRIPTION
## Summary
- add Buy/Sell review-workspace switching with access to each immutable review round
- keep sessions, responses, revisions, follow-ups, and deliberation scoped to the selected dataset version
- add a lazy, collapsible original-versus-selected hierarchy outline with independent expansion and optional O*NET evidence
- package all registered review datasets in the production image

## Why
Experts need to revisit prior Sell judgments while reviewing Buy without mixing progress. They also need a whole-branch reference that makes structural changes inspectable at any point in the workflow.

## User impact
Reviewers can move between Buy and Sell, reopen completed historical rounds, revise saved judgments, and compare the selected hierarchy against its original branch. Historical revisions are clearly marked as requiring a new propagation cycle before they affect the current ontology.

## Validation
- 149 Society of Mind unit and component tests pass
- changed files pass Next.js ESLint
- production Next.js build succeeds
- repository-wide TypeScript check reports only pre-existing errors outside the changed review files
