### PR TITLE
Differentiate collection labels in hierarchy comparison

### DIFF
--- a/__tests__/components/SomReview/OntologyComparisonPanel.test.tsx
+++ b/__tests__/components/SomReview/OntologyComparisonPanel.test.tsx
@@ -99,6 +99,15 @@ describe("ontology comparison panel", () => {
       screen.getByRole("region", { name: "Current ontology outline" }),
     ).toBeInTheDocument();
     expect(screen.getAllByText("commerce")).toHaveLength(2);
+    expect(screen.getAllByLabelText("Collection: commerce")).toHaveLength(2);
+    expect(
+      screen
+        .getAllByLabelText("Collection: commerce")
+        .every(
+          (collection) =>
+            collection.getAttribute("data-outline-kind") === "collection",
+        ),
+    ).toBe(true);
     expect(screen.queryByText("(O*Net) Purchase task")).not.toBeInTheDocument();
   });
 

--- a/src/components/SomReview/OntologyComparisonPanel.tsx
+++ b/src/components/SomReview/OntologyComparisonPanel.tsx
@@ -135,11 +135,19 @@ const OutlineNode = ({
           {groups.map((group) => (
             <Box key={`${nodeId}-${group.collectionName}`}>
               <Typography
+                component="div"
+                aria-label={`Collection: ${group.collectionName}`}
+                data-outline-kind="collection"
                 sx={{
                   ml: `${Math.min(depth + 1, 9) * 14 + 30}px`,
                   mt: 0.4,
                   mb: 0.15,
-                  color: "text.secondary",
+                  pl: 0.75,
+                  borderLeft: "2px solid",
+                  borderColor: (theme) =>
+                    theme.palette.mode === "dark" ? "#80CBC4" : "#00695C",
+                  color: (theme) =>
+                    theme.palette.mode === "dark" ? "#80CBC4" : "#00695C",
                   fontSize: "0.72rem",
                   fontWeight: 800,
                   lineHeight: 1.3,


### PR DESCRIPTION
## Summary
- render collection labels with a high-contrast teal accent and guide line
- expose collection labels semantically so the distinction is not color-only
- add focused component coverage

## Verification
- `npx jest --runInBand __tests__/components/SomReview/OntologyComparisonPanel.test.tsx`
- `npm run build`
- contrast: 7.89:1 dark mode, 6.23:1 light mode