### PR TITLE
Fix inspectable reviewer response counts

### DIFF
--- a/__tests__/lib/somReview/inspectionPolicy.test.ts
+++ b/__tests__/lib/somReview/inspectionPolicy.test.ts
@@ -1,5 +1,6 @@
 import {
   confidenceAuthorizesOntologyMutation,
+  inspectableReviewerCounts,
   inspectionRecordSource,
 } from "../../../src/lib/somReview/inspectionPolicy";
 
@@ -36,4 +37,23 @@ describe("inspection policy", () => {
       ).toBe(false);
     },
   );
+
+  it("counts only responses that still resolve to a proposal card", () => {
+    const counts = inspectableReviewerCounts([
+      {
+        proposalIds: new Set(["proposal-1", "proposal-2"]),
+        responses: [
+          { proposalId: "proposal-1", reviewerId: "rob" },
+          { proposalId: "proposal-2", reviewerId: "rob" },
+          { proposalId: "orphaned", reviewerId: "rob" },
+          { proposalId: "proposal-1", reviewerId: "tom" },
+        ],
+      },
+    ]);
+
+    expect([...counts.entries()]).toEqual([
+      ["rob", 2],
+      ["tom", 1],
+    ]);
+  });
 });

--- a/docs/research/rob-review-workflow-decisions-2026-07-28.md
+++ b/docs/research/rob-review-workflow-decisions-2026-07-28.md
@@ -96,6 +96,9 @@ task before changing propagation logic.
   responses without a preliminary scan or clicking proposal by proposal.
 - Rob can preview the same page using his own account, but cannot add an
   inspection exception to his own response.
+- Reviewer response counts include only records that still resolve to a frozen
+  proposal card. Orphaned historical responses remain in the audit artifacts
+  but are not presented as inspectable before/after proposals.
 - Rob's decision, rationale, and alternative remain visible after an inspection
   exception is saved.
 - An inspector can add, edit, or clear a separate not-aligned exception.

--- a/src/lib/somReview/inspectionPolicy.ts
+++ b/src/lib/somReview/inspectionPolicy.ts
@@ -1,5 +1,24 @@
 import { SomInspectionRecordSource } from "../../types/ISomReview";
 
+export const inspectableReviewerCounts = (
+  rounds: Array<{
+    proposalIds: ReadonlySet<string>;
+    responses: Array<{ proposalId: string; reviewerId: string }>;
+  }>,
+): Map<string, number> => {
+  const counts = new Map<string, number>();
+  for (const { proposalIds, responses } of rounds) {
+    for (const response of responses) {
+      if (!proposalIds.has(response.proposalId)) continue;
+      counts.set(
+        response.reviewerId,
+        (counts.get(response.reviewerId) || 0) + 1,
+      );
+    }
+  }
+  return counts;
+};
+
 export const inspectionRecordSource = (
   record: Record<string, unknown>,
 ): SomInspectionRecordSource => {

--- a/src/lib/somReview/inspectionStore.ts
+++ b/src/lib/somReview/inspectionStore.ts
@@ -19,7 +19,10 @@ import { loadUserProfiles } from "./deliberationStore";
 import { applicableReviewResponses } from "./reviewWorkflow";
 import { reviewDatasetConfig, reviewWorkspaceConfig } from "./reviewWorkspaces";
 import { toReviewerCard } from "./sanitize";
-import { inspectionRecordSource } from "./inspectionPolicy";
+import {
+  inspectableReviewerCounts,
+  inspectionRecordSource,
+} from "./inspectionPolicy";
 
 interface StoredResponseRecord {
   datasetVersion: string;
@@ -119,17 +122,13 @@ const availableReviewers = async (
   workspaceId: string,
 ): Promise<SomInspectionReviewer[]> => {
   const workspace = reviewWorkspaceConfig(workspaceId);
-  const responses = (
-    await Promise.all(
-      workspace.datasets.map((config) =>
-        currentResponsesForDataset(config.datasetVersion),
-      ),
-    )
-  ).flat();
-  const counts = new Map<string, number>();
-  for (const response of responses) {
-    counts.set(response.reviewerId, (counts.get(response.reviewerId) || 0) + 1);
-  }
+  const rounds = await Promise.all(
+    workspace.datasets.map(async (config) => ({
+      proposalIds: new Set(getDataset(config.id).recordsById.keys()),
+      responses: await currentResponsesForDataset(config.datasetVersion),
+    })),
+  );
+  const counts = inspectableReviewerCounts(rounds);
   const profiles = await loadUserProfiles([...counts.keys()]);
   return [...counts.entries()]
     .map(([reviewerId, responseCount]) => ({


### PR DESCRIPTION
## Summary
- count only reviewer responses that still resolve to proposal cards in the frozen review datasets
- keep orphaned historical responses in audit artifacts without presenting them as inspectable cards
- document and test the count policy

## Verification
- `npx jest __tests__/components/SomReview __tests__/lib/somReview --runInBand` (36 suites, 185 tests passed)
- `npm run build`
- changed-file ESLint
- repository-wide Jest: 254 passed; one unrelated pre-existing YjsEditor blur-history test fails