### PR TITLE
Expose prior-review inspection independently

### DIFF
--- a/__tests__/components/SomReview/ReviewQueueSelector.test.tsx
+++ b/__tests__/components/SomReview/ReviewQueueSelector.test.tsx
@@ -389,4 +389,24 @@ describe("Society of Mind review queue selector", () => {
     fireEvent.click(screen.getByRole("button", { name: "Group deliberation" }));
     expect(onOpenDeliberation).toHaveBeenCalledTimes(1);
   });
+
+  it("shows prior-review inspection without enabling group deliberation", () => {
+    const onOpenInspection = jest.fn();
+    render(
+      <ReviewQueueSelector
+        issueTypes={issues}
+        onStart={jest.fn()}
+        canInspectPriorReview
+        onOpenInspection={onOpenInspection}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Group deliberation" }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Inspect prior review" }),
+    );
+    expect(onOpenInspection).toHaveBeenCalledTimes(1);
+  });
 });

--- a/__tests__/lib/somReview/access.test.ts
+++ b/__tests__/lib/somReview/access.test.ts
@@ -2,6 +2,7 @@ import {
   resolveReviewerRole,
   reviewAccessForIdentity,
   reviewerRoleWeights,
+  reviewSurfaceCapabilities,
 } from "../../../src/lib/somReview/access";
 
 describe("Society of Mind reviewer access", () => {
@@ -51,6 +52,30 @@ describe("Society of Mind reviewer access", () => {
       role: "contributor",
       canDeliberate: false,
       canFinalize: false,
+    });
+  });
+
+  it("keeps prior-review inspection available when group deliberation is disabled", () => {
+    const access = reviewAccessForIdentity({
+      uid: "researcher",
+      roleClaim: "researcher",
+    });
+
+    expect(reviewSurfaceCapabilities(access, false)).toEqual({
+      canDeliberate: false,
+      canInspectPriorReview: true,
+    });
+  });
+
+  it("does not expose either review surface to contributors", () => {
+    const access = reviewAccessForIdentity({
+      uid: "outside",
+      email: "reviewer@example.org",
+    });
+
+    expect(reviewSurfaceCapabilities(access, true)).toEqual({
+      canDeliberate: false,
+      canInspectPriorReview: false,
     });
   });
 

--- a/docs/research/rob-review-rollout-2026-07-28.md
+++ b/docs/research/rob-review-rollout-2026-07-28.md
@@ -35,6 +35,9 @@ Send Tom `/review/inspection?workspace=sell`.
 
 Rob can open the same link to preview the interface. His own responses remain
 read-only because a reviewer cannot add an inspection exception to themselves.
+Research-team users can also open this page from **Inspect prior review** on the
+expert review screen even when the separate group-deliberation feature is
+disabled.
 
 ## Non-expert calibration
 

--- a/src/components/SomReview/ReviewQueueSelector.tsx
+++ b/src/components/SomReview/ReviewQueueSelector.tsx
@@ -203,6 +203,7 @@ const ReviewQueueSelector = ({
   ontologyName = "Ontology",
   onStart,
   canDeliberate = false,
+  canInspectPriorReview = false,
   onOpenDeliberation,
   onOpenInspection,
   headerAction,
@@ -215,6 +216,7 @@ const ReviewQueueSelector = ({
   ontologyName?: string;
   onStart: (issueType: SomIssueType) => void;
   canDeliberate?: boolean;
+  canInspectPriorReview?: boolean;
   onOpenDeliberation?: () => void;
   onOpenInspection?: () => void;
   headerAction?: React.ReactNode;
@@ -279,7 +281,7 @@ const ReviewQueueSelector = ({
               Group deliberation
             </Button>
           )}
-          {canDeliberate && onOpenInspection && (
+          {canInspectPriorReview && onOpenInspection && (
             <Button
               disableElevation
               variant="outlined"

--- a/src/lib/somReview/access.ts
+++ b/src/lib/somReview/access.ts
@@ -14,6 +14,11 @@ export interface ReviewAccess {
   canFinalize: boolean;
 }
 
+export interface ReviewSurfaceCapabilities {
+  canDeliberate: boolean;
+  canInspectPriorReview: boolean;
+}
+
 const DEFAULT_STEWARD_EMAILS = ["malone@mit.edu", "rjl@mit.edu"];
 
 const DEFAULT_STEWARD_UIDS = [
@@ -151,3 +156,11 @@ export const reviewAccessForToken = (
     emailVerified: token.email_verified === true,
     claims: token,
   });
+
+export const reviewSurfaceCapabilities = (
+  access: ReviewAccess,
+  deliberationEnabled: boolean,
+): ReviewSurfaceCapabilities => ({
+  canDeliberate: deliberationEnabled && access.canDeliberate,
+  canInspectPriorReview: access.canDeliberate,
+});

--- a/src/pages/api/som-review/overview.ts
+++ b/src/pages/api/som-review/overview.ts
@@ -13,7 +13,10 @@ import {
   reviewerReadyDependentRecords,
 } from "../../../lib/somReview/store";
 import { SomIssueType, SomOverviewResponse } from "../../../types/ISomReview";
-import { reviewAccessForToken } from "../../../lib/somReview/access";
+import {
+  reviewAccessForToken,
+  reviewSurfaceCapabilities,
+} from "../../../lib/somReview/access";
 import { toLinkedFollowUps } from "../../../lib/somReview/followUps";
 import { numberReviewIssues } from "../../../lib/somReview/reviewTaxonomy";
 import {
@@ -86,6 +89,11 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       blockedBy: blockingIssuePrerequisites(issue.id, issuesByType),
     }));
 
+    const reviewAccess = reviewAccessForToken(req.user);
+    const capabilities = reviewSurfaceCapabilities(
+      reviewAccess,
+      process.env.SOM_REVIEW_DELIBERATION_ENABLED === "true",
+    );
     const body: SomOverviewResponse = {
       datasetId: dataset.datasetId,
       datasetVersion: dataset.datasetVersion,
@@ -101,9 +109,7 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       ),
       issueTypes,
       readyFollowUps: toLinkedFollowUps(dataset, readyFollowUpRecords),
-      canDeliberate:
-        process.env.SOM_REVIEW_DELIBERATION_ENABLED === "true" &&
-        reviewAccessForToken(req.user).canDeliberate,
+      ...capabilities,
     };
     return res.status(200).json(body);
   } catch (error: any) {

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -95,6 +95,7 @@ export const ReviewPage = () => {
   const [revisionProposalId, setRevisionProposalId] = useState("");
   const [loadError, setLoadError] = useState("");
   const [canDeliberate, setCanDeliberate] = useState(false);
+  const [canInspectPriorReview, setCanInspectPriorReview] = useState(false);
   const [retryIssueType, setRetryIssueType] = useState<SomIssueType | null>(
     null,
   );
@@ -128,6 +129,7 @@ export const ReviewPage = () => {
       setIssueTypes(overview.issueTypes);
       setReadyFollowUps(overview.readyFollowUps || []);
       setCanDeliberate(overview.canDeliberate);
+      setCanInspectPriorReview(overview.canInspectPriorReview);
       setPhase("select");
     } catch {
       setLoadError("The review queues could not be loaded. Please try again.");
@@ -644,6 +646,7 @@ export const ReviewPage = () => {
                   query: { dataset: datasetId },
                 })
               }
+              canInspectPriorReview={canInspectPriorReview}
               onOpenInspection={() =>
                 router.push({
                   pathname: "/review/inspection",

--- a/src/types/ISomReview.ts
+++ b/src/types/ISomReview.ts
@@ -315,6 +315,7 @@ export interface SomOverviewResponse {
   issueTypes: SomIssueTypeOption[];
   readyFollowUps: SomLinkedFollowUp[];
   canDeliberate: boolean;
+  canInspectPriorReview: boolean;
 }
 
 export interface SomReviewRoundOption {


### PR DESCRIPTION
## Summary
- expose the prior-review inspection entry point to authorized research users even when group deliberation is disabled
- keep contributor access restricted
- document the independent inspection workflow

## Validation
- `npx jest __tests__/lib/somReview/access.test.ts __tests__/components/SomReview/ReviewQueueSelector.test.tsx --runInBand`
- targeted ESLint on all modified TypeScript files
- `npm run build`
- production audit of Sell review, inspection, and calibration surfaces before the change