### PR TITLE
Add trusted-reviewer propagation fast path

### DIFF
--- a/__tests__/components/SomReview/ReviewHistorySelect.test.tsx
+++ b/__tests__/components/SomReview/ReviewHistorySelect.test.tsx
@@ -17,6 +17,7 @@ const history: SomReviewHistoryItem[] = [
     disagreementReason: "",
     suggestedCorrection: "",
     reviewedAt: "2026-07-15T12:00:00.000Z",
+    fastTracked: true,
   },
   {
     proposalId: "proposal-2",
@@ -76,5 +77,20 @@ describe("Review history selector", () => {
     );
 
     expect(screen.getByText("Revising item 11")).toBeInTheDocument();
+  });
+
+  it("marks answers included in the trusted propagation draft", () => {
+    render(
+      <ReviewHistorySelect
+        history={history}
+        selectedProposalId=""
+        onSelect={jest.fn()}
+      />,
+    );
+
+    fireEvent.mouseDown(
+      screen.getByRole("combobox", { name: "Revise an earlier review" }),
+    );
+    expect(screen.getByText(/Agreed \| Fast-tracked/)).toBeInTheDocument();
   });
 });

--- a/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
+++ b/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
@@ -170,6 +170,7 @@ describe("linked proposal review journey", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     window.sessionStorage.clear();
+    window.localStorage.clear();
     window.localStorage.setItem(
       "som-review-task-intro-dataset-1-placement",
       "seen",
@@ -177,12 +178,20 @@ describe("linked proposal review journey", () => {
   });
 
   it("opens the exact follow-up and returns to the preserved source queue", async () => {
+    window.localStorage.setItem(
+      "som-review-trusted-propagation-reviewer-1",
+      "true",
+    );
     const postMock = Post as jest.Mock;
     postMock.mockImplementation((url: string, body: any) => {
       if (url === "/som-review/overview") {
         return Promise.resolve({
           ...overviewMetadata,
           canDeliberate: false,
+          trustedPropagation: {
+            allowed: true,
+            policyVersion: "trusted-reviewer-fast-track-v1",
+          },
           readyFollowUps: [],
           issueTypes: [
             {
@@ -283,6 +292,17 @@ describe("linked proposal review journey", () => {
     );
     fireEvent.click(
       await screen.findByRole("button", { name: "Submit placement-1" }),
+    );
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/som-review/respond",
+        expect.objectContaining({
+          trustedPropagation: true,
+          response: expect.objectContaining({ proposalId: "placement-1" }),
+        }),
+        false,
+      ),
     );
 
     expect(

--- a/__tests__/components/SomReview/TrustedPropagationControl.test.tsx
+++ b/__tests__/components/SomReview/TrustedPropagationControl.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import TrustedPropagationControl from "../../../src/components/SomReview/TrustedPropagationControl";
+
+describe("trusted propagation control", () => {
+  it("starts in review-only mode and requires an explicit opt-in", () => {
+    const onChange = jest.fn();
+    const { rerender } = render(
+      <TrustedPropagationControl enabled={false} onChange={onChange} />,
+    );
+
+    expect(screen.getByText("Review only")).toBeInTheDocument();
+    expect(screen.getByText(/separate batch application/i)).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Trusted-reviewer fast path" }),
+    );
+    expect(onChange).toHaveBeenCalledWith(true);
+
+    rerender(<TrustedPropagationControl enabled onChange={onChange} />);
+    expect(screen.getByText("Fast path on")).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/somReview/access.test.ts
+++ b/__tests__/lib/somReview/access.test.ts
@@ -3,6 +3,7 @@ import {
   reviewAccessForIdentity,
   reviewerRoleWeights,
   reviewSurfaceCapabilities,
+  trustedPropagationAccessForIdentity,
 } from "../../../src/lib/somReview/access";
 
 describe("Society of Mind reviewer access", () => {
@@ -133,5 +134,46 @@ describe("Society of Mind reviewer access", () => {
     const weights = reviewerRoleWeights();
     expect(weights.researcher).toBeGreaterThan(weights.contributor);
     expect(weights.steward).toBeGreaterThan(weights.researcher);
+  });
+
+  it("keeps trusted propagation narrower than the steward role", () => {
+    expect(
+      trustedPropagationAccessForIdentity({
+        uid: "rob",
+        email: "rjl@mit.edu",
+        emailVerified: true,
+      }).allowed,
+    ).toBe(true);
+    expect(
+      trustedPropagationAccessForIdentity({
+        uid: "tom",
+        email: "malone@mit.edu",
+        emailVerified: true,
+      }).allowed,
+    ).toBe(false);
+    expect(
+      trustedPropagationAccessForIdentity({
+        uid: "unverified-rob",
+        email: "rjl@mit.edu",
+        emailVerified: false,
+      }).allowed,
+    ).toBe(false);
+  });
+
+  it("supports an explicit trusted-propagator claim with a deny override", () => {
+    expect(
+      trustedPropagationAccessForIdentity({
+        uid: "trusted",
+        claims: { somReviewTrustedPropagator: true },
+      }).allowed,
+    ).toBe(true);
+    expect(
+      trustedPropagationAccessForIdentity({
+        uid: "rob",
+        email: "rjl@mit.edu",
+        emailVerified: true,
+        claims: { somReviewTrustedPropagator: false },
+      }).allowed,
+    ).toBe(false);
   });
 });

--- a/__tests__/lib/somReview/trustedPropagation.test.ts
+++ b/__tests__/lib/somReview/trustedPropagation.test.ts
@@ -1,0 +1,130 @@
+import path from "path";
+
+import { loadDataset } from "../../../src/lib/somReview/dataset";
+import {
+  TRUSTED_PROPAGATION_POLICY_VERSION,
+  trustedPropagationDirective,
+  trustedPropagationPlanTransition,
+} from "../../../src/lib/somReview/trustedPropagation";
+
+describe("trusted reviewer propagation policy", () => {
+  const currentDataset = loadDataset(
+    path.join(
+      process.cwd(),
+      "Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15",
+      "review-datasets-rob-semantic-coverage-2026-07-29",
+    ),
+  );
+  const proposedChange = [...currentDataset.recordsById.values()][0];
+
+  it("authorizes only an explicitly requested current-snapshot proposal", () => {
+    expect(
+      trustedPropagationDirective({
+        requested: true,
+        allowed: true,
+        currentRound: true,
+        dataset: currentDataset,
+        record: proposedChange,
+      }),
+    ).toEqual({
+      status: "ready",
+      policyVersion: TRUSTED_PROPAGATION_POLICY_VERSION,
+      sourceSnapshotSha256: currentDataset.manifest.sourceOntologySha256,
+    });
+  });
+
+  it("keeps the default path review-only and rejects past rounds", () => {
+    expect(
+      trustedPropagationDirective({
+        requested: false,
+        allowed: true,
+        currentRound: true,
+        dataset: currentDataset,
+        record: proposedChange,
+      }).status,
+    ).toBe("not-requested");
+    expect(
+      trustedPropagationDirective({
+        requested: true,
+        allowed: true,
+        currentRound: false,
+        dataset: currentDataset,
+        record: proposedChange,
+      }),
+    ).toMatchObject({ status: "ineligible", reason: expect.any(String) });
+  });
+
+  it("never fast-tracks a status-quo control", () => {
+    const controlDataset = loadDataset(
+      path.join(
+        process.cwd(),
+        "Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15",
+        "review-datasets",
+      ),
+    );
+    const control = [...controlDataset.recordsById.values()].find(
+      (record) => record.rolloutStatus === "control",
+    );
+    expect(control).toBeDefined();
+    expect(
+      trustedPropagationDirective({
+        requested: true,
+        allowed: true,
+        currentRound: true,
+        dataset: controlDataset,
+        record: control,
+      }),
+    ).toMatchObject({ status: "ineligible", reason: expect.any(String) });
+  });
+
+  it("audits authorization, updates, and retraction without duplicate writes", () => {
+    const directive = {
+      status: "ready" as const,
+      policyVersion: TRUSTED_PROPAGATION_POLICY_VERSION,
+      sourceSnapshotSha256: "snapshot-1",
+    };
+    expect(
+      trustedPropagationPlanTransition({
+        existing: null,
+        directive,
+        decision: "agree",
+      }),
+    ).toEqual({ action: "authorize", status: "ready" });
+    expect(
+      trustedPropagationPlanTransition({
+        existing: {
+          status: "ready",
+          policyVersion: TRUSTED_PROPAGATION_POLICY_VERSION,
+          sourceSnapshotSha256: "snapshot-1",
+          decision: "agree",
+        },
+        directive,
+        decision: "agree",
+      }),
+    ).toBeNull();
+    expect(
+      trustedPropagationPlanTransition({
+        existing: {
+          status: "ready",
+          policyVersion: TRUSTED_PROPAGATION_POLICY_VERSION,
+          sourceSnapshotSha256: "snapshot-1",
+          decision: "agree",
+        },
+        directive,
+        decision: "disagree",
+      }),
+    ).toEqual({ action: "update", status: "ready" });
+    expect(
+      trustedPropagationPlanTransition({
+        existing: {
+          status: "ready",
+          policyVersion: TRUSTED_PROPAGATION_POLICY_VERSION,
+          sourceSnapshotSha256: "snapshot-1",
+          decision: "agree",
+        },
+        directive: { ...directive, status: "not-requested" },
+        decision: "agree",
+      }),
+    ).toEqual({ action: "retract", status: "retracted" });
+  });
+});

--- a/docs/research/trusted-reviewer-propagation-policy-2026-08-02.md
+++ b/docs/research/trusted-reviewer-propagation-policy-2026-08-02.md
@@ -1,0 +1,47 @@
+# Trusted-reviewer propagation fast path
+
+## Decision addressed
+
+Rob asked whether answers from a reviewer judged to be reliable could propagate
+automatically to reduce review overhead. The first implementation treats this
+as a faster route from an individual judgment to a propagation draft. It does
+not copy an answer to a different proposal and does not write to the ontology.
+
+## Policy
+
+- Reliable-reviewer status is explicit and narrower than the reviewer role.
+  It is assigned through a verified-email/UID allowlist or the Firebase custom
+  claim `somReviewTrustedPropagator`.
+- The reviewer must opt in. The default remains review only.
+- Only proposed changes in a current review round are eligible. Status-quo
+  controls, manual checks, past rounds, and non-expert calibration responses are
+  excluded.
+- Every authorization is bound to the proposal ID, dataset version, source
+  ontology snapshot hash, response revision, reviewer, decision, rationale,
+  policy version, and timestamp.
+- An edit updates the authorization. Undo retracts it. Both operations append
+  immutable audit revisions.
+- A trusted answer becomes `ready` in a separate propagation draft. It does not
+  mutate the ontology. Application still requires a separately generated and
+  inspected snapshot-bound batch plan.
+- A dependency means that one proposal unlocks another; it never means that the
+  first answer can be copied to the second proposal.
+- Model confidence cannot grant reviewer reliability or propagation authority.
+
+## Firestore records
+
+- `somReviewTrustedPropagations`: current authorization state, with one stable
+  document per dataset/proposal/reviewer.
+- `somReviewTrustedPropagationRevisions`: append-only authorization, update,
+  and retraction history.
+- Expert responses remain in `somReviewResponses`. Non-expert calibration
+  remains isolated in `somReviewCalibrationResponses` and cannot enter the
+  trusted propagation collections.
+
+## Open study decisions
+
+Before enabling the fast path for anyone beyond the initial expert pilot, the
+team should define the evidence required to classify a reviewer as reliable,
+the review period for that classification, periodic spot-check rates, and the
+error threshold that suspends fast-track access. Those thresholds are research
+parameters, not assumptions embedded in the application.

--- a/src/components/SomReview/ReviewHistorySelect.tsx
+++ b/src/components/SomReview/ReviewHistorySelect.tsx
@@ -77,7 +77,8 @@ const ReviewHistorySelect = ({
               }
               secondary={
                 "Current answer: " +
-                (item.decision === "agree" ? "Agreed" : "Disagreed")
+                (item.decision === "agree" ? "Agreed" : "Disagreed") +
+                (item.fastTracked ? " | Fast-tracked" : "")
               }
               primaryTypographyProps={{
                 sx: {

--- a/src/components/SomReview/TrustedPropagationControl.tsx
+++ b/src/components/SomReview/TrustedPropagationControl.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import {
+  Alert,
+  Box,
+  FormControlLabel,
+  Stack,
+  Switch,
+  Typography,
+} from "@mui/material";
+import BoltOutlinedIcon from "@mui/icons-material/BoltOutlined";
+
+const TrustedPropagationControl = ({
+  enabled,
+  onChange,
+}: {
+  enabled: boolean;
+  onChange: (enabled: boolean) => void;
+}) => (
+  <Alert
+    severity={enabled ? "success" : "info"}
+    icon={<BoltOutlinedIcon aria-hidden="true" />}
+    sx={{
+      mb: 2,
+      alignItems: "center",
+      "& .MuiAlert-message": { width: "100%", minWidth: 0 },
+    }}
+  >
+    <Stack
+      direction={{ xs: "column", sm: "row" }}
+      alignItems={{ xs: "flex-start", sm: "center" }}
+      justifyContent="space-between"
+      spacing={1.25}
+    >
+      <Box sx={{ minWidth: 0 }}>
+        <Typography sx={{ fontWeight: 800 }}>
+          Trusted-reviewer fast path
+        </Typography>
+        <Typography sx={{ color: "text.secondary", lineHeight: 1.45 }}>
+          Eligible answers enter an audited, snapshot-bound propagation draft.
+          Ontology changes still require a separate batch application.
+        </Typography>
+      </Box>
+      <FormControlLabel
+        label={enabled ? "Fast path on" : "Review only"}
+        labelPlacement="start"
+        control={
+          <Switch
+            checked={enabled}
+            onChange={(event) => onChange(event.target.checked)}
+            slotProps={{
+              input: { "aria-label": "Trusted-reviewer fast path" },
+            }}
+          />
+        }
+        sx={{
+          m: 0,
+          flex: "0 0 auto",
+          "& .MuiFormControlLabel-label": { fontWeight: 750 },
+        }}
+      />
+    </Stack>
+  </Alert>
+);
+
+export default TrustedPropagationControl;

--- a/src/lib/firestoreClient/collections.ts
+++ b/src/lib/firestoreClient/collections.ts
@@ -17,6 +17,9 @@ export const TREE_QUEUES = "treeUpdateQueue";
 export const SOM_REVIEW_RESPONSES = "somReviewResponses";
 export const SOM_REVIEW_RESPONSE_REVISIONS = "somReviewResponseRevisions";
 export const SOM_REVIEW_SESSIONS = "somReviewSessions";
+export const SOM_REVIEW_TRUSTED_PROPAGATIONS = "somReviewTrustedPropagations";
+export const SOM_REVIEW_TRUSTED_PROPAGATION_REVISIONS =
+  "somReviewTrustedPropagationRevisions";
 export const SOM_REVIEW_DELIBERATION_COMMENTS = "somReviewDeliberationComments";
 export const SOM_REVIEW_DELIBERATION_POSITIONS =
   "somReviewDeliberationPositions";

--- a/src/lib/somReview/access.ts
+++ b/src/lib/somReview/access.ts
@@ -1,4 +1,5 @@
 import { SomReviewerRole } from "../../types/ISomReview";
+import { TRUSTED_PROPAGATION_POLICY_VERSION } from "./trustedPropagation";
 
 export interface ReviewIdentity {
   uid: string;
@@ -19,12 +20,20 @@ export interface ReviewSurfaceCapabilities {
   canInspectPriorReview: boolean;
 }
 
+export interface TrustedPropagationAccess {
+  allowed: boolean;
+  policyVersion: string;
+}
+
 const DEFAULT_STEWARD_EMAILS = ["malone@mit.edu", "rjl@mit.edu"];
 
 const DEFAULT_STEWARD_UIDS = [
   "ScOrQGUXCNPSniAIFc8nz2epK4l1",
   "vFCAkxKTwjcDKohmiWfiZWz2lZf1",
 ];
+
+// Reliable-reviewer status is intentionally narrower than the steward role.
+const DEFAULT_TRUSTED_PROPAGATION_EMAILS = ["rjl@mit.edu"];
 
 const DEFAULT_RESEARCHER_EMAILS = [
   "oneweb@umich.edu",
@@ -164,3 +173,47 @@ export const reviewSurfaceCapabilities = (
   canDeliberate: deliberationEnabled && access.canDeliberate,
   canInspectPriorReview: access.canDeliberate,
 });
+
+export const trustedPropagationAccessForIdentity = (
+  identity: ReviewIdentity,
+): TrustedPropagationAccess => {
+  const explicitlyConfigured = identity.claims?.somReviewTrustedPropagator;
+  if (explicitlyConfigured === false) {
+    return {
+      allowed: false,
+      policyVersion: TRUSTED_PROPAGATION_POLICY_VERSION,
+    };
+  }
+  if (explicitlyConfigured === true) {
+    return {
+      allowed: true,
+      policyVersion: TRUSTED_PROPAGATION_POLICY_VERSION,
+    };
+  }
+
+  const email = (identity.email || "").trim().toLowerCase();
+  const trustedEmails = normalizedSet(
+    DEFAULT_TRUSTED_PROPAGATION_EMAILS,
+    process.env.SOM_REVIEW_TRUSTED_PROPAGATION_EMAILS,
+  );
+  const trustedUids = uidSet(
+    [],
+    process.env.SOM_REVIEW_TRUSTED_PROPAGATION_UIDS,
+  );
+  return {
+    allowed:
+      trustedUids.has(identity.uid) ||
+      (identity.emailVerified === true && trustedEmails.has(email)),
+    policyVersion: TRUSTED_PROPAGATION_POLICY_VERSION,
+  };
+};
+
+export const trustedPropagationAccessForToken = (
+  token: Record<string, unknown>,
+): TrustedPropagationAccess =>
+  trustedPropagationAccessForIdentity({
+    uid: String(token.uid || token.sub || ""),
+    email: typeof token.email === "string" ? token.email : "",
+    emailVerified: token.email_verified === true,
+    claims: token,
+  });

--- a/src/lib/somReview/store.ts
+++ b/src/lib/somReview/store.ts
@@ -1,10 +1,13 @@
-import { Query, Timestamp } from "firebase-admin/firestore";
+import crypto from "crypto";
+import { Query, Timestamp, Transaction } from "firebase-admin/firestore";
 
 import { db } from "../firestoreServer/admin";
 import {
   SOM_REVIEW_RESPONSES,
   SOM_REVIEW_RESPONSE_REVISIONS,
   SOM_REVIEW_SESSIONS,
+  SOM_REVIEW_TRUSTED_PROPAGATIONS,
+  SOM_REVIEW_TRUSTED_PROPAGATION_REVISIONS,
 } from "../firestoreClient/collections";
 import { SomIssuePrerequisite, SomIssueType } from "../../types/ISomReview";
 import {
@@ -22,6 +25,11 @@ import {
   planUndoTransition,
 } from "./sessionState";
 import { readyDependentRecords } from "./followUps";
+import {
+  TrustedPropagationDirective,
+  TrustedPropagationPlanState,
+  trustedPropagationPlanTransition,
+} from "./trustedPropagation";
 
 export interface SessionDoc {
   datasetVersion: string;
@@ -354,6 +362,143 @@ interface StoredResponseDoc {
   updatedAt: Timestamp;
 }
 
+interface TrustedPropagationDoc extends TrustedPropagationPlanState {
+  schemaVersion: "som-trusted-propagation-v1";
+  datasetVersion: string;
+  proposalId: string;
+  issueType: SomIssueType;
+  reviewerId: string;
+  responseDocId: string;
+  responseRevisionIndex: number;
+  disagreementReason: string;
+  suggestedCorrection: string;
+  applicationMode: "separate-snapshot-bound-batch";
+  ontologyMutated: false;
+  revisionCount: number;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+
+export interface StoredReviewerResponse extends ResponsePayload {
+  fastTracked: boolean;
+}
+
+export interface ResponseWriteResult {
+  fastTracked: boolean;
+  propagationStatus: TrustedPropagationDirective["status"];
+}
+
+const trustedPropagationDocId = (
+  datasetVersion: string,
+  proposalId: string,
+  reviewerId: string,
+): string =>
+  crypto
+    .createHash("sha256")
+    .update(`${datasetVersion}|${proposalId}|${reviewerId}`)
+    .digest("hex");
+
+const trustedPropagationRef = (
+  datasetVersion: string,
+  proposalId: string,
+  reviewerId: string,
+) =>
+  db
+    .collection(SOM_REVIEW_TRUSTED_PROPAGATIONS)
+    .doc(trustedPropagationDocId(datasetVersion, proposalId, reviewerId));
+
+const syncTrustedPropagation = ({
+  transaction,
+  existing,
+  propagationRef,
+  responseRefId,
+  responseRevisionIndex,
+  issueType,
+  payload,
+  directive,
+  now,
+}: {
+  transaction: Transaction;
+  existing: TrustedPropagationDoc | null;
+  propagationRef: ReturnType<typeof trustedPropagationRef>;
+  responseRefId: string;
+  responseRevisionIndex: number;
+  issueType: SomIssueType;
+  payload: ResponsePayload;
+  directive: TrustedPropagationDirective;
+  now: Timestamp;
+}): boolean => {
+  let transition = trustedPropagationPlanTransition({
+    existing,
+    directive,
+    decision: payload.decision,
+  });
+  if (
+    !transition &&
+    directive.status === "ready" &&
+    existing?.status === "ready" &&
+    (existing.responseDocId !== responseRefId ||
+      existing.responseRevisionIndex !== responseRevisionIndex ||
+      existing.disagreementReason !== (payload.disagreementReason || "") ||
+      existing.suggestedCorrection !== (payload.suggestedCorrection || ""))
+  ) {
+    transition = { action: "update", status: "ready" };
+  }
+  if (!transition) return existing?.status === "ready";
+
+  const revisionCount = (existing?.revisionCount || 0) + 1;
+  if (transition.status === "retracted") {
+    if (!existing) return false;
+    const retracted: TrustedPropagationDoc = {
+      ...existing,
+      status: "retracted",
+      revisionCount,
+      updatedAt: now,
+    };
+    transaction.set(propagationRef, retracted);
+    transaction.set(
+      db.collection(SOM_REVIEW_TRUSTED_PROPAGATION_REVISIONS).doc(),
+      {
+        ...retracted,
+        action: transition.action,
+        recordedAt: now,
+      },
+    );
+    return false;
+  }
+
+  const authorized: TrustedPropagationDoc = {
+    schemaVersion: "som-trusted-propagation-v1",
+    datasetVersion: payload.datasetVersion,
+    proposalId: payload.proposalId,
+    issueType,
+    reviewerId: payload.reviewerId,
+    responseDocId: responseRefId,
+    responseRevisionIndex,
+    decision: payload.decision,
+    disagreementReason: payload.disagreementReason || "",
+    suggestedCorrection: payload.suggestedCorrection || "",
+    policyVersion: directive.policyVersion,
+    sourceSnapshotSha256: directive.sourceSnapshotSha256,
+    status: "ready",
+    applicationMode: "separate-snapshot-bound-batch",
+    ontologyMutated: false,
+    revisionCount,
+    createdAt: existing?.createdAt || now,
+    updatedAt: now,
+  };
+  transaction.set(propagationRef, authorized);
+  transaction.set(
+    db.collection(SOM_REVIEW_TRUSTED_PROPAGATION_REVISIONS).doc(),
+    {
+      ...authorized,
+      action: transition.action,
+      recordedAt: now,
+    },
+  );
+  return true;
+};
+
 /** Common fields identifying a response revision's logical subject. */
 const revisionIdentity = (payload: {
   datasetVersion: string;
@@ -374,10 +519,16 @@ export const saveResponse = async (
   sessionId: string,
   issueType: SomIssueType,
   payload: ResponsePayload,
-): Promise<{ cursor: number; completed: boolean }> => {
+  propagation: TrustedPropagationDirective,
+): Promise<{ cursor: number; completed: boolean } & ResponseWriteResult> => {
   return db.runTransaction(async (transaction) => {
     const sessionRef = db.collection(SOM_REVIEW_SESSIONS).doc(sessionId);
-    const [responseSnap, sessionSnap] = await Promise.all([
+    const propagationRef = trustedPropagationRef(
+      payload.datasetVersion,
+      payload.proposalId,
+      payload.reviewerId,
+    );
+    const [responseSnap, sessionSnap, propagationSnap] = await Promise.all([
       transaction.get(
         currentResponseQuery(
           payload.datasetVersion,
@@ -386,6 +537,7 @@ export const saveResponse = async (
         ),
       ),
       transaction.get(sessionRef),
+      transaction.get(propagationRef),
     ]);
     if (!sessionSnap.exists) throw new Error("Review session was not found");
     const session = sessionSnap.data() as SessionDoc;
@@ -412,11 +564,11 @@ export const saveResponse = async (
       payload.proposalId,
       Boolean(identicalRetry),
     );
+    const responseRef = existingDoc
+      ? existingDoc.ref
+      : db.collection(SOM_REVIEW_RESPONSES).doc();
 
     if (transition.shouldPersist) {
-      const responseRef = existingDoc
-        ? existingDoc.ref
-        : db.collection(SOM_REVIEW_RESPONSES).doc();
       const revisionIndex = (existing?.revisionCount || 0) + 1;
       transaction.set(responseRef, {
         ...revisionIdentity(payload),
@@ -437,6 +589,23 @@ export const saveResponse = async (
       });
     }
 
+    const responseRevisionIndex = transition.shouldPersist
+      ? (existing?.revisionCount || 0) + 1
+      : existing?.revisionCount || 1;
+    const fastTracked = syncTrustedPropagation({
+      transaction,
+      existing: propagationSnap.exists
+        ? (propagationSnap.data() as TrustedPropagationDoc)
+        : null,
+      propagationRef,
+      responseRefId: responseRef.id,
+      responseRevisionIndex,
+      issueType,
+      payload,
+      directive: propagation,
+      now,
+    });
+
     transaction.update(sessionRef, {
       cursor: transition.cursor,
       status: transition.completed ? "completed" : "active",
@@ -445,6 +614,8 @@ export const saveResponse = async (
     return {
       cursor: transition.cursor,
       completed: transition.completed,
+      fastTracked,
+      propagationStatus: propagation.status,
     };
   });
 };
@@ -454,7 +625,7 @@ export const issueResponses = async (
   datasetVersion: string,
   issueType: SomIssueType,
   reviewerId: string,
-): Promise<Map<string, ResponsePayload>> => {
+): Promise<Map<string, StoredReviewerResponse>> => {
   const snapshot = await db
     .collection(SOM_REVIEW_RESPONSES)
     .where("datasetVersion", "==", datasetVersion)
@@ -462,11 +633,30 @@ export const issueResponses = async (
     .where("reviewerId", "==", reviewerId)
     .where("status", "==", "current")
     .get();
+  const records = snapshot.docs
+    .map((doc) => doc.data() as StoredResponseDoc)
+    .filter((record) => Boolean(record.response));
+  const propagationSnapshots = records.length
+    ? await db.getAll(
+        ...records.map((record) =>
+          trustedPropagationRef(
+            record.datasetVersion,
+            record.proposalId,
+            record.reviewerId,
+          ),
+        ),
+      )
+    : [];
   return new Map(
-    snapshot.docs
-      .map((doc) => doc.data() as StoredResponseDoc)
-      .filter((record) => Boolean(record.response))
-      .map((record) => [record.proposalId, record.response]),
+    records.map((record, index) => [
+      record.proposalId,
+      {
+        ...record.response,
+        fastTracked:
+          propagationSnapshots[index]?.exists &&
+          propagationSnapshots[index]?.data()?.status === "ready",
+      },
+    ]),
   );
 };
 
@@ -478,15 +668,24 @@ export const issueResponses = async (
 export const reviseResponse = async (
   issueType: SomIssueType,
   payload: ResponsePayload,
-): Promise<{ changed: boolean }> => {
+  propagation: TrustedPropagationDirective,
+): Promise<{ changed: boolean } & ResponseWriteResult> => {
   return db.runTransaction(async (transaction) => {
-    const responseSnap = await transaction.get(
-      currentResponseQuery(
-        payload.datasetVersion,
-        payload.proposalId,
-        payload.reviewerId,
-      ),
+    const propagationRef = trustedPropagationRef(
+      payload.datasetVersion,
+      payload.proposalId,
+      payload.reviewerId,
     );
+    const [responseSnap, propagationSnap] = await Promise.all([
+      transaction.get(
+        currentResponseQuery(
+          payload.datasetVersion,
+          payload.proposalId,
+          payload.reviewerId,
+        ),
+      ),
+      transaction.get(propagationRef),
+    ]);
     if (responseSnap.empty) {
       throw new Error("The prior response could not be found");
     }
@@ -502,25 +701,44 @@ export const reviseResponse = async (
         (payload.disagreementReason || "") &&
       (existing.response.suggestedCorrection || "") ===
         (payload.suggestedCorrection || "");
-    if (identical) return { changed: false };
-
     const now = Timestamp.now();
-    const revisionIndex = (existing.revisionCount || 0) + 1;
-    transaction.update(responseDoc.ref, {
-      response: payload,
-      revisionCount: revisionIndex,
-      updatedAt: now,
-    });
-    transaction.set(db.collection(SOM_REVIEW_RESPONSE_REVISIONS).doc(), {
-      ...revisionIdentity(payload),
+    const revisionIndex = identical
+      ? existing.revisionCount || 1
+      : (existing.revisionCount || 0) + 1;
+    if (!identical) {
+      transaction.update(responseDoc.ref, {
+        response: payload,
+        revisionCount: revisionIndex,
+        updatedAt: now,
+      });
+      transaction.set(db.collection(SOM_REVIEW_RESPONSE_REVISIONS).doc(), {
+        ...revisionIdentity(payload),
+        issueType,
+        responseDocId: responseDoc.id,
+        revisionIndex,
+        action: "edit",
+        response: payload,
+        createdAt: now,
+      });
+    }
+    const fastTracked = syncTrustedPropagation({
+      transaction,
+      existing: propagationSnap.exists
+        ? (propagationSnap.data() as TrustedPropagationDoc)
+        : null,
+      propagationRef,
+      responseRefId: responseDoc.id,
+      responseRevisionIndex: revisionIndex,
       issueType,
-      responseDocId: responseDoc.id,
-      revisionIndex,
-      action: "edit",
-      response: payload,
-      createdAt: now,
+      payload,
+      directive: propagation,
+      now,
     });
-    return { changed: true };
+    return {
+      changed: !identical,
+      fastTracked,
+      propagationStatus: propagation.status,
+    };
   });
 };
 
@@ -549,9 +767,17 @@ export const undoPrevious = async (
     const transition = planUndoTransition(session);
 
     const previousId = session.proposalIds[transition.cursor];
-    const responseSnap = await transaction.get(
-      currentResponseQuery(datasetVersion, previousId, reviewerId),
+    const propagationRef = trustedPropagationRef(
+      datasetVersion,
+      previousId,
+      reviewerId,
     );
+    const [responseSnap, propagationSnap] = await Promise.all([
+      transaction.get(
+        currentResponseQuery(datasetVersion, previousId, reviewerId),
+      ),
+      transaction.get(propagationRef),
+    ]);
     if (responseSnap.empty) throw new Error("Previous response not found");
     const responseDoc = responseSnap.docs[0];
 
@@ -573,6 +799,28 @@ export const undoPrevious = async (
       response: null,
       createdAt: now,
     });
+    const existingPropagation = propagationSnap.exists
+      ? (propagationSnap.data() as TrustedPropagationDoc)
+      : null;
+    if (existingPropagation?.status === "ready") {
+      const propagationRevisionCount =
+        (existingPropagation.revisionCount || 0) + 1;
+      const retracted: TrustedPropagationDoc = {
+        ...existingPropagation,
+        status: "retracted",
+        revisionCount: propagationRevisionCount,
+        updatedAt: now,
+      };
+      transaction.set(propagationRef, retracted);
+      transaction.set(
+        db.collection(SOM_REVIEW_TRUSTED_PROPAGATION_REVISIONS).doc(),
+        {
+          ...retracted,
+          action: "retract",
+          recordedAt: now,
+        },
+      );
+    }
     transaction.update(sessionRef, {
       cursor: transition.cursor,
       status: transition.status,

--- a/src/lib/somReview/trustedPropagation.ts
+++ b/src/lib/somReview/trustedPropagation.ts
@@ -1,0 +1,131 @@
+import { SomReviewDecision } from "../../types/ISomReview";
+import { SomDataset } from "./dataset";
+
+export const TRUSTED_PROPAGATION_POLICY_VERSION =
+  "trusted-reviewer-fast-track-v1";
+
+export type TrustedPropagationStatus = "not-requested" | "ready" | "ineligible";
+
+export interface TrustedPropagationDirective {
+  status: TrustedPropagationStatus;
+  policyVersion: string;
+  sourceSnapshotSha256: string;
+  reason?: string;
+}
+
+export interface TrustedPropagationPlanState {
+  status: "ready" | "retracted";
+  policyVersion: string;
+  sourceSnapshotSha256: string;
+  decision: SomReviewDecision;
+}
+
+export type TrustedPropagationPlanAction = "authorize" | "update" | "retract";
+
+export interface TrustedPropagationPlanTransition {
+  action: TrustedPropagationPlanAction;
+  status: "ready" | "retracted";
+}
+
+const sourceSnapshotSha256 = (dataset: SomDataset): string =>
+  String(
+    dataset.manifest.sourceOntologySha256 ||
+      dataset.manifest.sourceSnapshot?.sha256 ||
+      "",
+  ).trim();
+
+/**
+ * Plans a server-side fast-track directive. This authorizes a reviewed answer
+ * for a later snapshot-bound batch plan; it never authorizes an immediate
+ * ontology write or infers an answer for another proposal.
+ */
+export const trustedPropagationDirective = ({
+  requested,
+  allowed,
+  currentRound,
+  dataset,
+  record,
+}: {
+  requested: boolean;
+  allowed: boolean;
+  currentRound: boolean;
+  dataset: SomDataset;
+  record: any;
+}): TrustedPropagationDirective => {
+  const snapshotSha256 = sourceSnapshotSha256(dataset);
+  const base = {
+    policyVersion: TRUSTED_PROPAGATION_POLICY_VERSION,
+    sourceSnapshotSha256: snapshotSha256,
+  };
+  if (!requested) return { ...base, status: "not-requested" };
+  if (!allowed) {
+    return {
+      ...base,
+      status: "ineligible",
+      reason: "Reviewer is not authorized for trusted propagation",
+    };
+  }
+  if (!currentRound) {
+    return {
+      ...base,
+      status: "ineligible",
+      reason: "Past review rounds cannot enter the current propagation draft",
+    };
+  }
+  if (!snapshotSha256) {
+    return {
+      ...base,
+      status: "ineligible",
+      reason: "The review round is not bound to an ontology snapshot",
+    };
+  }
+  if (
+    record?.datasetVersion !== dataset.datasetVersion ||
+    record?.provenance?.sourceSnapshotSha256 !== snapshotSha256
+  ) {
+    return {
+      ...base,
+      status: "ineligible",
+      reason: "The proposal is not bound to the active source snapshot",
+    };
+  }
+  if (
+    record?.reviewMode !== "proposed-change" ||
+    record?.rolloutStatus === "control"
+  ) {
+    return {
+      ...base,
+      status: "ineligible",
+      reason: "Controls and status-quo checks cannot enter a propagation draft",
+    };
+  }
+  return { ...base, status: "ready" };
+};
+
+/** Returns the audited plan change needed for a response submission. */
+export const trustedPropagationPlanTransition = ({
+  existing,
+  directive,
+  decision,
+}: {
+  existing?: TrustedPropagationPlanState | null;
+  directive: TrustedPropagationDirective;
+  decision: SomReviewDecision;
+}): TrustedPropagationPlanTransition | null => {
+  if (directive.status !== "ready") {
+    return existing?.status === "ready"
+      ? { action: "retract", status: "retracted" }
+      : null;
+  }
+  if (!existing || existing.status === "retracted") {
+    return { action: "authorize", status: "ready" };
+  }
+  if (
+    existing.policyVersion === directive.policyVersion &&
+    existing.sourceSnapshotSha256 === directive.sourceSnapshotSha256 &&
+    existing.decision === decision
+  ) {
+    return null;
+  }
+  return { action: "update", status: "ready" };
+};

--- a/src/pages/api/som-review/overview.ts
+++ b/src/pages/api/som-review/overview.ts
@@ -16,6 +16,7 @@ import { SomIssueType, SomOverviewResponse } from "../../../types/ISomReview";
 import {
   reviewAccessForToken,
   reviewSurfaceCapabilities,
+  trustedPropagationAccessForToken,
 } from "../../../lib/somReview/access";
 import { toLinkedFollowUps } from "../../../lib/somReview/followUps";
 import { numberReviewIssues } from "../../../lib/somReview/reviewTaxonomy";
@@ -90,6 +91,7 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
     }));
 
     const reviewAccess = reviewAccessForToken(req.user);
+    const trustedPropagation = trustedPropagationAccessForToken(req.user);
     const capabilities = reviewSurfaceCapabilities(
       reviewAccess,
       process.env.SOM_REVIEW_DELIBERATION_ENABLED === "true",
@@ -109,6 +111,7 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       ),
       issueTypes,
       readyFollowUps: toLinkedFollowUps(dataset, readyFollowUpRecords),
+      trustedPropagation,
       ...capabilities,
     };
     return res.status(200).json(body);

--- a/src/pages/api/som-review/respond.ts
+++ b/src/pages/api/som-review/respond.ts
@@ -14,6 +14,9 @@ import {
 import { reviewRequestData } from "../../../lib/somReview/request";
 import { SomRespondResult } from "../../../types/ISomReview";
 import { toLinkedFollowUps } from "../../../lib/somReview/followUps";
+import { trustedPropagationAccessForToken } from "../../../lib/somReview/access";
+import { trustedPropagationDirective } from "../../../lib/somReview/trustedPropagation";
+import { reviewDatasetConfigByVersion } from "../../../lib/somReview/reviewWorkspaces";
 
 const responseValidators = new Map<
   string,
@@ -28,6 +31,15 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
     const data = reviewRequestData(req.body);
     const payload = data.response as ResponsePayload;
     const sessionId = typeof data.sessionId === "string" ? data.sessionId : "";
+    if (
+      Object.prototype.hasOwnProperty.call(data, "trustedPropagation") &&
+      typeof data.trustedPropagation !== "boolean"
+    ) {
+      return res
+        .status(400)
+        .json({ error: "trustedPropagation must be a boolean" });
+    }
+    const trustedPropagationRequested = data.trustedPropagation === true;
     if (!sessionId) return res.status(400).json({ error: "Missing sessionId" });
     if (!payload)
       return res.status(400).json({ error: "Missing response payload" });
@@ -63,10 +75,26 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
         .json({ error: "Disagree requires a non-whitespace reason" });
     }
 
-    const { cursor, completed } = await saveResponse(
+    const trustedPropagationAccess = trustedPropagationAccessForToken(req.user);
+    if (trustedPropagationRequested && !trustedPropagationAccess.allowed) {
+      return res.status(403).json({
+        error: "This reviewer is not authorized for trusted propagation",
+      });
+    }
+    const propagationDirective = trustedPropagationDirective({
+      requested: trustedPropagationRequested,
+      allowed: trustedPropagationAccess.allowed,
+      currentRound: reviewDatasetConfigByVersion(dataset.datasetVersion)
+        .current,
+      dataset,
+      record,
+    });
+
+    const { cursor, completed, propagationStatus } = await saveResponse(
       sessionId,
       record.issueType,
       payload,
+      propagationDirective,
     );
     const followUpRecords =
       payload.decision === "agree"
@@ -81,6 +109,13 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       cursor,
       completed,
       followUps: toLinkedFollowUps(dataset, followUpRecords),
+      propagation: {
+        status: propagationStatus,
+        policyVersion: propagationDirective.policyVersion,
+        ...(propagationDirective.reason
+          ? { reason: propagationDirective.reason }
+          : {}),
+      },
     };
     return res.status(200).json(body);
   } catch (error: any) {

--- a/src/pages/api/som-review/revise.ts
+++ b/src/pages/api/som-review/revise.ts
@@ -14,6 +14,9 @@ import {
 import { reviewRequestData } from "../../../lib/somReview/request";
 import { SomReviseResult } from "../../../types/ISomReview";
 import { toLinkedFollowUps } from "../../../lib/somReview/followUps";
+import { trustedPropagationAccessForToken } from "../../../lib/somReview/access";
+import { trustedPropagationDirective } from "../../../lib/somReview/trustedPropagation";
+import { reviewDatasetConfigByVersion } from "../../../lib/somReview/reviewWorkspaces";
 
 const responseValidators = new Map<
   string,
@@ -27,6 +30,15 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
   try {
     const data = reviewRequestData(req.body);
     const payload = data.response as ResponsePayload;
+    if (
+      Object.prototype.hasOwnProperty.call(data, "trustedPropagation") &&
+      typeof data.trustedPropagation !== "boolean"
+    ) {
+      return res
+        .status(400)
+        .json({ error: "trustedPropagation must be a boolean" });
+    }
+    const trustedPropagationRequested = data.trustedPropagation === true;
     if (!payload)
       return res.status(400).json({ error: "Missing response payload" });
 
@@ -61,7 +73,26 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
         .json({ error: "Disagree requires a non-whitespace reason" });
     }
 
-    const { changed } = await reviseResponse(record.issueType, payload);
+    const trustedPropagationAccess = trustedPropagationAccessForToken(req.user);
+    if (trustedPropagationRequested && !trustedPropagationAccess.allowed) {
+      return res.status(403).json({
+        error: "This reviewer is not authorized for trusted propagation",
+      });
+    }
+    const propagationDirective = trustedPropagationDirective({
+      requested: trustedPropagationRequested,
+      allowed: trustedPropagationAccess.allowed,
+      currentRound: reviewDatasetConfigByVersion(dataset.datasetVersion)
+        .current,
+      dataset,
+      record,
+    });
+
+    const { changed, propagationStatus } = await reviseResponse(
+      record.issueType,
+      payload,
+      propagationDirective,
+    );
     const followUpRecords =
       payload.decision === "agree"
         ? await reviewerReadyDependentRecords(
@@ -74,6 +105,13 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
       ok: true,
       changed,
       followUps: toLinkedFollowUps(dataset, followUpRecords),
+      propagation: {
+        status: propagationStatus,
+        policyVersion: propagationDirective.policyVersion,
+        ...(propagationDirective.reason
+          ? { reason: propagationDirective.reason }
+          : {}),
+      },
     };
     return res.status(200).json(body);
   } catch (error: any) {

--- a/src/pages/api/som-review/session.ts
+++ b/src/pages/api/som-review/session.ts
@@ -114,6 +114,7 @@ const handler = async (request: NextApiRequest, res: NextApiResponse) => {
             disagreementReason: response.disagreementReason || "",
             suggestedCorrection: response.suggestedCorrection || "",
             reviewedAt: response.reviewedAt,
+            fastTracked: response.fastTracked,
           },
         ];
       },

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -27,6 +27,7 @@ import ReviewFollowUpPanel from "@components/components/SomReview/ReviewFollowUp
 import ReviewQueueSelector from "@components/components/SomReview/ReviewQueueSelector";
 import ReviewTaskIntro from "@components/components/SomReview/ReviewTaskIntro";
 import ThemeModeToggle from "@components/components/SomReview/ThemeModeToggle";
+import TrustedPropagationControl from "@components/components/SomReview/TrustedPropagationControl";
 import OntologyComparisonPanel from "@components/components/SomReview/OntologyComparisonPanel";
 import ReviewWorkspaceSwitcher from "@components/components/SomReview/ReviewWorkspaceSwitcher";
 import { reviewInteractiveSurfaceSx } from "@components/components/SomReview/reviewStyles";
@@ -97,6 +98,10 @@ export const ReviewPage = () => {
   const [loadError, setLoadError] = useState("");
   const [canDeliberate, setCanDeliberate] = useState(false);
   const [canInspectPriorReview, setCanInspectPriorReview] = useState(false);
+  const [trustedPropagationAllowed, setTrustedPropagationAllowed] =
+    useState(false);
+  const [trustedPropagationEnabled, setTrustedPropagationEnabled] =
+    useState(false);
   const [retryIssueType, setRetryIssueType] = useState<SomIssueType | null>(
     null,
   );
@@ -131,12 +136,47 @@ export const ReviewPage = () => {
       setReadyFollowUps(overview.readyFollowUps || []);
       setCanDeliberate(overview.canDeliberate);
       setCanInspectPriorReview(overview.canInspectPriorReview);
+      setTrustedPropagationAllowed(
+        Boolean(overview.trustedPropagation?.allowed),
+      );
       setPhase("select");
     } catch {
       setLoadError("The review queues could not be loaded. Please try again.");
       setPhase("select");
     }
   }, []);
+
+  useEffect(() => {
+    if (!user?.userId || !trustedPropagationAllowed) {
+      setTrustedPropagationEnabled(false);
+      return;
+    }
+    try {
+      setTrustedPropagationEnabled(
+        window.localStorage.getItem(
+          `som-review-trusted-propagation-${user.userId}`,
+        ) === "true",
+      );
+    } catch {
+      setTrustedPropagationEnabled(false);
+    }
+  }, [trustedPropagationAllowed, user?.userId]);
+
+  const updateTrustedPropagation = useCallback(
+    (enabled: boolean) => {
+      setTrustedPropagationEnabled(enabled);
+      if (!user?.userId) return;
+      try {
+        window.localStorage.setItem(
+          `som-review-trusted-propagation-${user.userId}`,
+          String(enabled),
+        );
+      } catch {
+        // The current page can retain the setting when storage is unavailable.
+      }
+    },
+    [user?.userId],
+  );
 
   useEffect(() => {
     if (!user || !router.isReady) return;
@@ -373,6 +413,9 @@ export const ReviewPage = () => {
             reviewedAt,
             elapsedMs: Math.max(0, Math.round(submission.elapsedMs)),
           },
+          ...(trustedPropagationAllowed && currentRound
+            ? { trustedPropagation: trustedPropagationEnabled }
+            : {}),
         },
         false,
       );
@@ -393,6 +436,7 @@ export const ReviewPage = () => {
             disagreementReason: submission.disagreementReason,
             suggestedCorrection: submission.suggestedCorrection,
             reviewedAt,
+            fastTracked: result.propagation?.status === "ready",
           },
         ].sort((left, right) => left.proposalIndex - right.proposalIndex),
       );
@@ -435,7 +479,17 @@ export const ReviewPage = () => {
       }
       if (result.completed) setPhase("complete");
     },
-    [activeSequence, cards, cursor, issueTypes, sessionId, user?.userId],
+    [
+      activeSequence,
+      cards,
+      currentRound,
+      cursor,
+      issueTypes,
+      sessionId,
+      trustedPropagationAllowed,
+      trustedPropagationEnabled,
+      user?.userId,
+    ],
   );
 
   const revisionItem = history.find(
@@ -474,11 +528,17 @@ export const ReviewPage = () => {
             reviewedAt,
             elapsedMs: Math.max(0, Math.round(submission.elapsedMs)),
           },
+          ...(trustedPropagationAllowed && currentRound
+            ? {
+                trustedPropagation:
+                  Boolean(item.fastTracked) || trustedPropagationEnabled,
+              }
+            : {}),
         },
         false,
       );
 
-      if (result.changed) {
+      if (result.changed || result.propagation) {
         setHistory((currentHistory) =>
           currentHistory.map((historyItem) =>
             historyItem.proposalId === item.proposalId
@@ -488,6 +548,10 @@ export const ReviewPage = () => {
                   disagreementReason: submission.disagreementReason,
                   suggestedCorrection: submission.suggestedCorrection,
                   reviewedAt,
+                  fastTracked:
+                    result.propagation?.status === "ready" ||
+                    (result.propagation === undefined &&
+                      historyItem.fastTracked),
                 }
               : historyItem,
           ),
@@ -536,6 +600,7 @@ export const ReviewPage = () => {
     },
     [
       cards.length,
+      currentRound,
       cursor,
       history,
       historyCards,
@@ -543,6 +608,8 @@ export const ReviewPage = () => {
       issueType,
       revisionProposalId,
       startSession,
+      trustedPropagationAllowed,
+      trustedPropagationEnabled,
       user?.userId,
     ],
   );
@@ -652,6 +719,13 @@ export const ReviewPage = () => {
             >
               {loadError}
             </Alert>
+          )}
+
+          {phase !== "loading" && trustedPropagationAllowed && currentRound && (
+            <TrustedPropagationControl
+              enabled={trustedPropagationEnabled}
+              onChange={updateTrustedPropagation}
+            />
           )}
 
           {phase === "loading" && (

--- a/src/types/ISomReview.ts
+++ b/src/types/ISomReview.ts
@@ -322,6 +322,19 @@ export interface SomReviewHistoryItem {
   disagreementReason: string;
   suggestedCorrection: string;
   reviewedAt: string;
+  /** True when this answer is in the snapshot-bound trusted propagation draft. */
+  fastTracked?: boolean;
+}
+
+export interface SomTrustedPropagationAccess {
+  allowed: boolean;
+  policyVersion: string;
+}
+
+export interface SomTrustedPropagationResult {
+  status: "not-requested" | "ready" | "ineligible";
+  policyVersion: string;
+  reason?: string;
 }
 
 export interface SomFollowUpSource {
@@ -353,6 +366,7 @@ export interface SomOverviewResponse {
   readyFollowUps: SomLinkedFollowUp[];
   canDeliberate: boolean;
   canInspectPriorReview: boolean;
+  trustedPropagation?: SomTrustedPropagationAccess;
 }
 
 export interface SomReviewRoundOption {
@@ -405,6 +419,7 @@ export interface SomRespondResult {
   cursor: number;
   completed: boolean;
   followUps: SomLinkedFollowUp[];
+  propagation?: SomTrustedPropagationResult;
 }
 
 export interface SomUndoResult {
@@ -416,6 +431,7 @@ export interface SomReviseResult {
   ok: boolean;
   changed: boolean;
   followUps: SomLinkedFollowUp[];
+  propagation?: SomTrustedPropagationResult;
 }
 
 export interface SomDeliberationRoleSummary {


### PR DESCRIPTION
## Summary
- Add an explicit, opt-in trusted-reviewer fast path for current, snapshot-bound proposed changes.
- Persist ready/retracted propagation drafts with append-only revision audit records.
- Keep ontology mutation, dependency answers, controls, past rounds, and non-expert calibration outside the fast path.
- Surface authorization and fast-track status in the reviewer UI.
- Document the governance policy and open study decisions.

## Verification
- Society of Mind suites: 216 passed.
- Research baseline: 5 passed.
- Changed-file ESLint, Prettier, and TypeScript filtering: clean.
- Optimized Next.js production build: passed.
- Responsive browser QA: no horizontal overflow; opt-in toggle verified.
- Full Jest: 285 passed; one existing unrelated Yjs blur-history test failed in an untouched file.
- Full lint: existing unrelated missing ESLint-rule definition in NodeGraph.tsx.