### PR TITLE
Preserve equivalent review decisions across proposal revisions

### DIFF
--- a/Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15/review-datasets-rob-semantic-coverage-2026-07-29/diagnostics/one_step_review_revision.json
+++ b/Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15/review-datasets-rob-semantic-coverage-2026-07-29/diagnostics/one_step_review_revision.json
@@ -1,12 +1,13 @@
 {
   "schemaVersion": "som-review-revision-v1",
-  "contentRevision": 3,
+  "contentRevision": 4,
   "sourceDatasetVersion": "sell-rob-semantic-coverage-2026-07-29-v1",
   "reason": "Rob requested one review decision with the proposed alternative visible immediately and enough ancestor context to interpret the current placement.",
   "changes": [
     "Replaced 8 diagnosis-plus-relocation pairs with 8 one-step move proposals.",
     "Added current and proposed hierarchy paths to every move proposal.",
-    "Preserved prior responses under their original proposal IDs rather than reinterpret them as approvals of a newly expanded question.",
+    "Carried the 8 prior exact relocation responses forward to their equivalent one-step cards without changing the stored source records.",
+    "Kept the broader prior diagnosis responses under their original proposal IDs rather than reinterpret them as exact move approvals.",
     "Corrected the provenance distinction between the accepted wrapper proposal and its machine-derived baseline nodes.",
     "Removed the invalid collection-generated activity wrappers from the current snapshot and restored Rent out directly under Sell."
   ],
@@ -37,6 +38,48 @@
     "som-b8c5ba1c90158e6784c7",
     "som-f7564256227086773936",
     "som-b876e1950ee85f53d266"
+  ],
+  "responseCarryForwardMappings": [
+    {
+      "sourceProposalId": "som-a129fc5e2012529a5814",
+      "targetProposalId": "som-756a156508bbc6756859",
+      "subjectTitle": "Lease Property"
+    },
+    {
+      "sourceProposalId": "som-b0618ed6153588a186ba",
+      "targetProposalId": "som-465816b46486fcf5d2bf",
+      "subjectTitle": "Rent Clothing"
+    },
+    {
+      "sourceProposalId": "som-27afd77fd2d9b2564529",
+      "targetProposalId": "som-0b734eb0be482c04eef1",
+      "subjectTitle": "Rent Box"
+    },
+    {
+      "sourceProposalId": "som-3ce0cf5a80839238edf9",
+      "targetProposalId": "som-2712192fe57dd0dbf045",
+      "subjectTitle": "Rent Merchandise"
+    },
+    {
+      "sourceProposalId": "som-3f7e33c2a810735c6d56",
+      "targetProposalId": "som-ed212c77f550f328ce1d",
+      "subjectTitle": "Rent Accommodation"
+    },
+    {
+      "sourceProposalId": "som-fecda86541f0949e2d50",
+      "targetProposalId": "som-b8c5ba1c90158e6784c7",
+      "subjectTitle": "Rent Supply"
+    },
+    {
+      "sourceProposalId": "som-15fba4ccfad0dd29cbc5",
+      "targetProposalId": "som-f7564256227086773936",
+      "subjectTitle": "Rent Equipment"
+    },
+    {
+      "sourceProposalId": "som-2349d16033acaead6103",
+      "targetProposalId": "som-b876e1950ee85f53d266",
+      "subjectTitle": "Rent Item"
+    }
   ],
   "collectionNodeRepair": {
     "auditFile": "Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15/review-datasets-rob-semantic-coverage-2026-07-29/diagnostics/collection_design_node_repair.json",

--- a/Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15/review-datasets-rob-semantic-coverage-2026-07-29/diagnostics/semantic-coverage-generation-audit.json
+++ b/Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15/review-datasets-rob-semantic-coverage-2026-07-29/diagnostics/semantic-coverage-generation-audit.json
@@ -5793,7 +5793,7 @@
     "som-c936209753da4ab48410"
   ],
   "ontologyMutated": false,
-  "contentRevision": 2,
+  "contentRevision": 4,
   "postGenerationRevision": {
     "script": "scripts/som-review/migrate-semantic-coverage-to-one-step.mjs",
     "reason": "Replace diagnosis-plus-relocation pairs with one review item showing evidence and both exact hierarchy locations.",

--- a/Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15/review-datasets-rob-semantic-coverage-2026-07-29/manifest.json
+++ b/Sell_Society_of_Mind_Review_UI_Handoff_2026-07-15/review-datasets-rob-semantic-coverage-2026-07-29/manifest.json
@@ -100,6 +100,68 @@
     "origin": "invalid-collection-node-conflation-rolled-back",
     "file": "diagnostics/accepted_structure_provenance.json"
   },
+  "responseCarryForward": {
+    "schemaVersion": "som-response-carry-forward-v1",
+    "policy": "Carry forward only the prior exact relocation decision whose subject, current parent, proposed parent, and descendant-preserving move match the replacement one-step card. The broader diagnosis response remains historical and is not reinterpreted.",
+    "mappings": [
+      {
+        "sourceProposalId": "som-a129fc5e2012529a5814",
+        "sourceIssueType": "relocation",
+        "targetProposalId": "som-756a156508bbc6756859",
+        "targetIssueType": "cross-branch-recall",
+        "subjectTitle": "Lease Property"
+      },
+      {
+        "sourceProposalId": "som-b0618ed6153588a186ba",
+        "sourceIssueType": "relocation",
+        "targetProposalId": "som-465816b46486fcf5d2bf",
+        "targetIssueType": "cross-branch-recall",
+        "subjectTitle": "Rent Clothing"
+      },
+      {
+        "sourceProposalId": "som-27afd77fd2d9b2564529",
+        "sourceIssueType": "relocation",
+        "targetProposalId": "som-0b734eb0be482c04eef1",
+        "targetIssueType": "cross-branch-recall",
+        "subjectTitle": "Rent Box"
+      },
+      {
+        "sourceProposalId": "som-3ce0cf5a80839238edf9",
+        "sourceIssueType": "relocation",
+        "targetProposalId": "som-2712192fe57dd0dbf045",
+        "targetIssueType": "cross-branch-recall",
+        "subjectTitle": "Rent Merchandise"
+      },
+      {
+        "sourceProposalId": "som-3f7e33c2a810735c6d56",
+        "sourceIssueType": "relocation",
+        "targetProposalId": "som-ed212c77f550f328ce1d",
+        "targetIssueType": "cross-branch-recall",
+        "subjectTitle": "Rent Accommodation"
+      },
+      {
+        "sourceProposalId": "som-fecda86541f0949e2d50",
+        "sourceIssueType": "relocation",
+        "targetProposalId": "som-b8c5ba1c90158e6784c7",
+        "targetIssueType": "cross-branch-recall",
+        "subjectTitle": "Rent Supply"
+      },
+      {
+        "sourceProposalId": "som-15fba4ccfad0dd29cbc5",
+        "sourceIssueType": "relocation",
+        "targetProposalId": "som-f7564256227086773936",
+        "targetIssueType": "cross-branch-recall",
+        "subjectTitle": "Rent Equipment"
+      },
+      {
+        "sourceProposalId": "som-2349d16033acaead6103",
+        "sourceIssueType": "relocation",
+        "targetProposalId": "som-b876e1950ee85f53d266",
+        "targetIssueType": "cross-branch-recall",
+        "subjectTitle": "Rent Item"
+      }
+    ]
+  },
   "limitations": [
     "Embedding similarity retrieves candidates but never authorizes an ontology change.",
     "A semantic-direction judge filters embedding candidates; direct provider-side O*NET evidence is scanned across the full ontology candidate set so the embedding cutoff cannot hide it.",
@@ -151,5 +213,5 @@
     "reviewedCandidateCount": 57,
     "directEvidenceCandidateCount": 8
   },
-  "contentRevision": 3
+  "contentRevision": 4
 }

--- a/__tests__/lib/somReview/responseCarryForward.test.ts
+++ b/__tests__/lib/somReview/responseCarryForward.test.ts
@@ -1,0 +1,86 @@
+import { SomDataset } from "../../../src/lib/somReview/dataset";
+import {
+  CarryForwardResponseRecord,
+  carryForwardResponseRecords,
+  responseCarryForwardSources,
+} from "../../../src/lib/somReview/responseCarryForward";
+
+const dataset = {
+  manifest: {
+    responseCarryForward: {
+      schemaVersion: "som-response-carry-forward-v1",
+      mappings: [
+        {
+          sourceProposalId: "old-move",
+          sourceIssueType: "relocation",
+          targetProposalId: "one-step-move",
+          targetIssueType: "cross-branch-recall",
+          subjectTitle: "Rent Equipment",
+        },
+      ],
+    },
+  },
+  recordsById: new Map([["one-step-move", {}]]),
+} as Pick<SomDataset, "manifest" | "recordsById">;
+
+describe("review-response carry-forward", () => {
+  it("projects an exact retired move response without losing its correction", () => {
+    const [response] = carryForwardResponseRecords(dataset, [
+      {
+        proposalId: "old-move",
+        issueType: "relocation",
+        reviewerId: "reviewer-1",
+        response: {
+          proposalId: "old-move",
+          decision: "disagree",
+          disagreementReason: "Move only two descendants.",
+          suggestedCorrection: "Keep the third descendant under Lease.",
+        },
+      },
+    ]);
+
+    expect(response).toMatchObject({
+      proposalId: "one-step-move",
+      issueType: "cross-branch-recall",
+      carriedForwardFromProposalId: "old-move",
+      response: {
+        proposalId: "one-step-move",
+        decision: "disagree",
+        disagreementReason: "Move only two descendants.",
+        suggestedCorrection: "Keep the third descendant under Lease.",
+      },
+    });
+  });
+
+  it("prefers a response saved directly on the current proposal", () => {
+    const responses = carryForwardResponseRecords(dataset, [
+      {
+        proposalId: "one-step-move",
+        issueType: "cross-branch-recall",
+        reviewerId: "reviewer-1",
+        response: { decision: "agree" },
+      },
+      {
+        proposalId: "old-move",
+        issueType: "relocation",
+        reviewerId: "reviewer-1",
+        response: { decision: "disagree" },
+      },
+    ]);
+
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toMatchObject({
+      proposalId: "one-step-move",
+      response: { decision: "agree" },
+    });
+    expect(
+      (responses[0] as CarryForwardResponseRecord).carriedForwardFromProposalId,
+    ).toBeUndefined();
+  });
+
+  it("returns the retired source ID for an editable inherited answer", () => {
+    expect(responseCarryForwardSources(dataset, "one-step-move")).toEqual([
+      "old-move",
+    ]);
+  });
+});

--- a/__tests__/lib/somReview/semanticCoverageDataset.test.ts
+++ b/__tests__/lib/somReview/semanticCoverageDataset.test.ts
@@ -87,6 +87,30 @@ describe("Sell semantic coverage review wave", () => {
     }
   });
 
+  it("carries only the equivalent prior relocation decisions forward", () => {
+    expect(dataset.manifest.responseCarryForward).toMatchObject({
+      schemaVersion: "som-response-carry-forward-v1",
+    });
+    const mappings = dataset.manifest.responseCarryForward.mappings;
+    expect(mappings).toHaveLength(8);
+    expect(
+      new Set(mappings.map((mapping: any) => mapping.sourceProposalId)),
+    ).toHaveProperty("size", 8);
+    expect(
+      new Set(mappings.map((mapping: any) => mapping.targetProposalId)),
+    ).toHaveProperty("size", 8);
+    for (const mapping of mappings) {
+      expect(mapping).toMatchObject({
+        sourceIssueType: "relocation",
+        targetIssueType: "cross-branch-recall",
+      });
+      expect(
+        dataset.recordsById.get(mapping.targetProposalId)?.subject.title,
+      ).toBe(mapping.subjectTitle);
+      expect(dataset.recordsById.has(mapping.sourceProposalId)).toBe(false);
+    }
+  });
+
   it("limits evidence specialization to explicit modifiers", () => {
     const proposals = records.filter(
       (record) => record.issueType === "evidence-specialization",

--- a/docs/research/review-streamlining-decisions-2026-08-02.md
+++ b/docs/research/review-streamlining-decisions-2026-08-02.md
@@ -17,6 +17,11 @@
   Future exploratory dataset generation marks that card as the action and no
   longer generates a second relocation card for the same move. Historical
   diagnosis-only records remain inspectable but cannot authorize a move.
+- When a one-step card exactly preserves an earlier relocation card's subject,
+  current parent, proposed parent, and move scope, the earlier relocation answer
+  is carried forward at read time. The stored source response and audit history
+  are unchanged, broader diagnosis answers are not reinterpreted, and a response
+  saved directly on the new card takes precedence.
 
 ## Deferred until the Sell sequence is complete
 

--- a/scripts/som-review/migrate-semantic-coverage-after-collection-repair.mjs
+++ b/scripts/som-review/migrate-semantic-coverage-after-collection-repair.mjs
@@ -143,7 +143,7 @@ writeJsonl(manualChecksFile, manualChecks);
 
 const manifestFile = path.join(datasetDir, "manifest.json");
 const manifest = readJson(manifestFile);
-manifest.contentRevision = 3;
+manifest.contentRevision = 4;
 manifest.sourceOntologySha256 = snapshotHash;
 manifest.counts.manualChecks = manualChecks.length;
 manifest.sourceSnapshot = {
@@ -172,6 +172,7 @@ const generationAuditFile = path.join(
   "semantic-coverage-generation-audit.json",
 );
 const generationAudit = readJson(generationAuditFile);
+generationAudit.contentRevision = 4;
 generationAudit.originalSourceSnapshotSha256 ??=
   generationAudit.sourceSnapshotSha256;
 generationAudit.sourceSnapshotSha256 = snapshotHash;
@@ -233,7 +234,7 @@ const revisionFile = path.join(
   "one_step_review_revision.json",
 );
 const revision = readJson(revisionFile);
-revision.contentRevision = 3;
+revision.contentRevision = 4;
 revision.changes = [
   ...revision.changes.filter(
     (change) => !change.startsWith("Removed the invalid collection-generated"),

--- a/scripts/som-review/migrate-semantic-coverage-to-one-step.mjs
+++ b/scripts/som-review/migrate-semantic-coverage-to-one-step.mjs
@@ -172,6 +172,28 @@ const oneStepMoves = diagnoses.map((diagnosis) => {
     },
   };
 });
+const oneStepMoveByDiagnosisId = new Map(
+  diagnoses.map((diagnosis, index) => [
+    diagnosis.proposalId,
+    oneStepMoves[index],
+  ]),
+);
+const responseCarryForwardMappings = relocations.map((relocation) => {
+  const diagnosisId = relocation.workflow.dependsOnProposalIds[0];
+  const replacement = oneStepMoveByDiagnosisId.get(diagnosisId);
+  if (!replacement || replacement.subject.title !== relocation.subject.title) {
+    throw new Error(
+      `Cannot verify exact response carry-forward for ${relocation.proposalId}`,
+    );
+  }
+  return {
+    sourceProposalId: relocation.proposalId,
+    sourceIssueType: "relocation",
+    targetProposalId: replacement.proposalId,
+    targetIssueType: "cross-branch-recall",
+    subjectTitle: replacement.subject.title,
+  };
+});
 
 const retainedRecords = records.filter(
   (record) =>
@@ -213,6 +235,12 @@ manifest.limitations = manifest.limitations.map((value) =>
 );
 manifest.acceptedStructureProvenance.origin =
   "invalid-collection-node-conflation-rolled-back";
+manifest.responseCarryForward = {
+  schemaVersion: "som-response-carry-forward-v1",
+  policy:
+    "Carry forward only the prior exact relocation decision whose subject, current parent, proposed parent, and descendant-preserving move match the replacement one-step card. The broader diagnosis response remains historical and is not reinterpreted.",
+  mappings: responseCarryForwardMappings,
+};
 writeJson(manifestFile, manifest);
 
 const schemaFile = path.join(
@@ -420,7 +448,8 @@ writeJson(
     changes: [
       "Replaced 8 diagnosis-plus-relocation pairs with 8 one-step move proposals.",
       "Added current and proposed hierarchy paths to every move proposal.",
-      "Preserved prior responses under their original proposal IDs rather than reinterpret them as approvals of a newly expanded question.",
+      "Carried prior exact relocation responses forward to their equivalent one-step cards without changing the stored source records.",
+      "Kept the broader prior diagnosis responses under their original proposal IDs rather than reinterpret them as exact move approvals.",
       "Recorded that the invalid collection-generated activity wrappers were rolled back without reinterpreting the prior review answer.",
     ],
     retiredProposalIds: [
@@ -428,5 +457,6 @@ writeJson(
       ...relocations.map((record) => record.proposalId),
     ],
     replacementProposalIds: oneStepMoves.map((record) => record.proposalId),
+    responseCarryForwardMappings,
   },
 );

--- a/src/lib/somReview/deliberationStore.ts
+++ b/src/lib/somReview/deliberationStore.ts
@@ -20,7 +20,7 @@ import {
   SomDeliberationResolutionDecision,
   SomReviewDecision,
 } from "../../types/ISomReview";
-import { SomDataset } from "./dataset";
+import { getDatasetByVersion, SomDataset } from "./dataset";
 import {
   resolveReviewerRole,
   reviewerRoleLabel,
@@ -32,6 +32,10 @@ import {
   applicableReviewResponses,
   remainingIndependentReviewCount,
 } from "./reviewWorkflow";
+import {
+  carryForwardResponseRecords,
+  responseCarryForwardSources,
+} from "./responseCarryForward";
 
 export interface UserProfile {
   userId: string;
@@ -210,12 +214,22 @@ const loadBundle = async (
   datasetVersion: string,
   proposalId?: string,
 ): Promise<DeliberationBundle> => {
+  const dataset = getDatasetByVersion(datasetVersion);
+  const responseProposalIds = proposalId
+    ? [proposalId, ...responseCarryForwardSources(dataset, proposalId)]
+    : [];
   let responseQuery: any = db
     .collection(SOM_REVIEW_RESPONSES)
     .where("datasetVersion", "==", datasetVersion)
     .where("status", "==", "current");
   if (proposalId) {
-    responseQuery = responseQuery.where("proposalId", "==", proposalId);
+    responseQuery = responseQuery.where(
+      "proposalId",
+      responseProposalIds.length === 1 ? "==" : "in",
+      responseProposalIds.length === 1
+        ? responseProposalIds[0]
+        : responseProposalIds,
+    );
   }
   const [
     responseSnapshot,
@@ -230,7 +244,10 @@ const loadBundle = async (
   ]);
 
   const responses = latestBy<ResponseRecord>(
-    responseSnapshot.docs.map((doc: any) => doc.data() as ResponseRecord),
+    carryForwardResponseRecords(
+      dataset,
+      responseSnapshot.docs.map((doc: any) => doc.data() as ResponseRecord),
+    ),
     (record) => `${record.proposalId}|${record.reviewerId}`,
     (record) => record.updatedAt || record.response.reviewedAt,
   );
@@ -410,10 +427,19 @@ export const assertIndependentReview = async (
   proposalId: string,
   reviewerId: string,
 ): Promise<void> => {
+  const dataset = getDatasetByVersion(datasetVersion);
+  const proposalIds = [
+    proposalId,
+    ...responseCarryForwardSources(dataset, proposalId),
+  ];
   const snapshot = await db
     .collection(SOM_REVIEW_RESPONSES)
     .where("datasetVersion", "==", datasetVersion)
-    .where("proposalId", "==", proposalId)
+    .where(
+      "proposalId",
+      proposalIds.length === 1 ? "==" : "in",
+      proposalIds.length === 1 ? proposalIds[0] : proposalIds,
+    )
     .where("reviewerId", "==", reviewerId)
     .where("status", "==", "current")
     .limit(1)
@@ -508,11 +534,20 @@ export const saveDeliberationPosition = async ({
   decision: SomReviewDecision;
   rationale: string;
 }) => {
+  const dataset = getDatasetByVersion(datasetVersion);
+  const proposalIds = [
+    proposalId,
+    ...responseCarryForwardSources(dataset, proposalId),
+  ];
   await db.runTransaction(async (transaction) => {
     const originalQuery = db
       .collection(SOM_REVIEW_RESPONSES)
       .where("datasetVersion", "==", datasetVersion)
-      .where("proposalId", "==", proposalId)
+      .where(
+        "proposalId",
+        proposalIds.length === 1 ? "==" : "in",
+        proposalIds.length === 1 ? proposalIds[0] : proposalIds,
+      )
       .where("reviewerId", "==", reviewerId)
       .where("status", "==", "current")
       .limit(1);

--- a/src/lib/somReview/inspectionStore.ts
+++ b/src/lib/somReview/inspectionStore.ts
@@ -27,6 +27,7 @@ import {
   inspectionIssueTypeFromTaskKey,
   inspectionTasks,
 } from "./inspectionPolicy";
+import { carryForwardResponseRecords } from "./responseCarryForward";
 
 interface StoredResponseRecord {
   datasetVersion: string;
@@ -117,9 +118,10 @@ const currentResponsesForDataset = async (
     query = query.where("reviewerId", "==", reviewerId);
   }
   const snapshot = await query.get();
-  return snapshot.docs
-    .map((doc: any) => doc.data() as StoredResponseRecord)
-    .filter((record: StoredResponseRecord) => Boolean(record.response));
+  return carryForwardResponseRecords<StoredResponseRecord>(
+    getDatasetByVersion(datasetVersion),
+    snapshot.docs.map((doc: any) => doc.data() as StoredResponseRecord),
+  ).filter((record: StoredResponseRecord) => Boolean(record.response));
 };
 
 const availableReviewers = async (

--- a/src/lib/somReview/responseCarryForward.ts
+++ b/src/lib/somReview/responseCarryForward.ts
@@ -1,0 +1,91 @@
+import type { SomIssueType } from "../../types/ISomReview";
+import type { SomDataset } from "./dataset";
+
+export interface ResponseCarryForwardMapping {
+  sourceProposalId: string;
+  sourceIssueType: SomIssueType;
+  targetProposalId: string;
+  targetIssueType: SomIssueType;
+  subjectTitle?: string;
+}
+
+export interface CarryForwardResponseRecord {
+  proposalId: string;
+  reviewerId?: string;
+  issueType?: string;
+  response?: object;
+  carriedForwardFromProposalId?: string;
+}
+
+const configuredMappings = (
+  dataset: Pick<SomDataset, "manifest" | "recordsById">,
+): ResponseCarryForwardMapping[] => {
+  const value = dataset.manifest?.responseCarryForward;
+  if (value?.schemaVersion !== "som-response-carry-forward-v1") return [];
+  if (!Array.isArray(value.mappings)) return [];
+
+  return value.mappings.filter(
+    (mapping: ResponseCarryForwardMapping) =>
+      Boolean(mapping?.sourceProposalId) &&
+      Boolean(mapping?.targetProposalId) &&
+      dataset.recordsById.has(mapping.targetProposalId),
+  );
+};
+
+export const responseCarryForwardSources = (
+  dataset: Pick<SomDataset, "manifest" | "recordsById">,
+  targetProposalId: string,
+): string[] =>
+  configuredMappings(dataset)
+    .filter((mapping) => mapping.targetProposalId === targetProposalId)
+    .map((mapping) => mapping.sourceProposalId);
+
+/**
+ * Projects responses to retired, semantically equivalent proposal IDs onto
+ * their current IDs without changing the stored response or its audit trail.
+ * A response saved directly against the current ID always takes precedence.
+ */
+export const carryForwardResponseRecords = <
+  T extends CarryForwardResponseRecord,
+>(
+  dataset: Pick<SomDataset, "manifest" | "recordsById">,
+  records: T[],
+): T[] => {
+  const bySource = new Map(
+    configuredMappings(dataset).map((mapping) => [
+      mapping.sourceProposalId,
+      mapping,
+    ]),
+  );
+  if (bySource.size === 0) return records;
+
+  const selected = new Map<string, { record: T; carriedForward: boolean }>();
+  for (const record of records) {
+    const mapping = bySource.get(record.proposalId);
+    const canCarry =
+      mapping &&
+      (!record.issueType || record.issueType === mapping.sourceIssueType);
+    const projected = canCarry
+      ? ({
+          ...record,
+          proposalId: mapping.targetProposalId,
+          issueType: mapping.targetIssueType,
+          response: record.response
+            ? { ...record.response, proposalId: mapping.targetProposalId }
+            : record.response,
+          carriedForwardFromProposalId: mapping.sourceProposalId,
+        } as T)
+      : record;
+    const key = `${projected.proposalId}|${projected.reviewerId || ""}`;
+    const previous = selected.get(key);
+
+    // A newer answer saved on the current card must override inherited data.
+    if (!previous || (previous.carriedForward && !canCarry)) {
+      selected.set(key, {
+        record: projected,
+        carriedForward: Boolean(canCarry),
+      });
+    }
+  }
+  return [...selected.values()].map(({ record }) => record);
+};

--- a/src/lib/somReview/reviewWorkflow.ts
+++ b/src/lib/somReview/reviewWorkflow.ts
@@ -1,5 +1,6 @@
 import { SomReviewDecision } from "../../types/ISomReview";
 import { proposalAvailability, SomDataset } from "./dataset";
+import { carryForwardResponseRecords } from "./responseCarryForward";
 
 export interface WorkflowResponseRecord {
   proposalId: string;
@@ -29,8 +30,9 @@ export const applicableReviewResponses = <T extends WorkflowResponseRecord>(
   dataset: SomDataset,
   responses: T[],
 ): T[] => {
-  const reviewerDecisions = decisionsByReviewer(responses);
-  return responses.filter((response) => {
+  const currentResponses = carryForwardResponseRecords(dataset, responses);
+  const reviewerDecisions = decisionsByReviewer(currentResponses);
+  return currentResponses.filter((response) => {
     const record = dataset.recordsById.get(response.proposalId);
     if (!record) return false;
     return (
@@ -49,7 +51,8 @@ export const remainingIndependentReviewCount = <
   reviewerId: string,
   responses: T[],
 ): number => {
-  const reviewerResponses = responses.filter(
+  const currentResponses = carryForwardResponseRecords(dataset, responses);
+  const reviewerResponses = currentResponses.filter(
     (response) => response.reviewerId === reviewerId,
   );
   const decisions = new Map(

--- a/src/lib/somReview/store.ts
+++ b/src/lib/somReview/store.ts
@@ -11,6 +11,7 @@ import {
 } from "../firestoreClient/collections";
 import { SomIssuePrerequisite, SomIssueType } from "../../types/ISomReview";
 import {
+  getDatasetByVersion,
   isIssueTypeEnabled,
   SomDataset,
   proposalAvailability,
@@ -30,6 +31,10 @@ import {
   TrustedPropagationPlanState,
   trustedPropagationPlanTransition,
 } from "./trustedPropagation";
+import {
+  carryForwardResponseRecords,
+  responseCarryForwardSources,
+} from "./responseCarryForward";
 
 export interface SessionDoc {
   datasetVersion: string;
@@ -81,11 +86,18 @@ const answeredProposalIds = async (
   const snapshot = await db
     .collection(SOM_REVIEW_RESPONSES)
     .where("datasetVersion", "==", datasetVersion)
-    .where("issueType", "==", issueType)
     .where("reviewerId", "==", reviewerId)
     .where("status", "==", "current")
     .get();
-  return new Set(snapshot.docs.map((doc) => doc.data().proposalId));
+  const records = carryForwardResponseRecords(
+    getDatasetByVersion(datasetVersion),
+    snapshot.docs.map((doc) => doc.data() as StoredResponseDoc),
+  );
+  return new Set(
+    records
+      .filter((record) => record.issueType === issueType)
+      .map((record) => record.proposalId),
+  );
 };
 
 const reviewerDecisions = async (
@@ -98,11 +110,12 @@ const reviewerDecisions = async (
     .where("reviewerId", "==", reviewerId)
     .where("status", "==", "current")
     .get();
+  const records = carryForwardResponseRecords(
+    getDatasetByVersion(datasetVersion),
+    snapshot.docs.map((doc) => doc.data() as StoredResponseDoc),
+  );
   return new Map(
-    snapshot.docs.map((doc) => {
-      const data = doc.data() as StoredResponseDoc;
-      return [data.proposalId, data.response.decision];
-    }),
+    records.map((record) => [record.proposalId, record.response.decision]),
   );
 };
 
@@ -629,12 +642,14 @@ export const issueResponses = async (
   const snapshot = await db
     .collection(SOM_REVIEW_RESPONSES)
     .where("datasetVersion", "==", datasetVersion)
-    .where("issueType", "==", issueType)
     .where("reviewerId", "==", reviewerId)
     .where("status", "==", "current")
     .get();
-  const records = snapshot.docs
-    .map((doc) => doc.data() as StoredResponseDoc)
+  const records = carryForwardResponseRecords(
+    getDatasetByVersion(datasetVersion),
+    snapshot.docs.map((doc) => doc.data() as StoredResponseDoc),
+  )
+    .filter((record) => record.issueType === issueType)
     .filter((record) => Boolean(record.response));
   const propagationSnapshots = records.length
     ? await db.getAll(
@@ -671,28 +686,48 @@ export const reviseResponse = async (
   propagation: TrustedPropagationDirective,
 ): Promise<{ changed: boolean } & ResponseWriteResult> => {
   return db.runTransaction(async (transaction) => {
+    const dataset = getDatasetByVersion(payload.datasetVersion);
+    const inheritedProposalIds = responseCarryForwardSources(
+      dataset,
+      payload.proposalId,
+    );
     const propagationRef = trustedPropagationRef(
       payload.datasetVersion,
       payload.proposalId,
       payload.reviewerId,
     );
-    const [responseSnap, propagationSnap] = await Promise.all([
-      transaction.get(
-        currentResponseQuery(
-          payload.datasetVersion,
-          payload.proposalId,
-          payload.reviewerId,
-        ),
+    const responseQueries = [
+      currentResponseQuery(
+        payload.datasetVersion,
+        payload.proposalId,
+        payload.reviewerId,
       ),
+      ...(inheritedProposalIds.length
+        ? [
+            db
+              .collection(SOM_REVIEW_RESPONSES)
+              .where("datasetVersion", "==", payload.datasetVersion)
+              .where("proposalId", "in", inheritedProposalIds)
+              .where("reviewerId", "==", payload.reviewerId)
+              .where("status", "==", "current")
+              .limit(inheritedProposalIds.length),
+          ]
+        : []),
+    ];
+    const [responseSnapshots, propagationSnap] = await Promise.all([
+      Promise.all(responseQueries.map((query) => transaction.get(query))),
       transaction.get(propagationRef),
     ]);
-    if (responseSnap.empty) {
+    const directResponseDoc = responseSnapshots[0].docs[0];
+    const inheritedResponseDoc = responseSnapshots[1]?.docs[0];
+    const responseDoc = directResponseDoc || inheritedResponseDoc;
+    const inherited = !directResponseDoc && Boolean(inheritedResponseDoc);
+    if (!responseDoc) {
       throw new Error("The prior response could not be found");
     }
 
-    const responseDoc = responseSnap.docs[0];
     const existing = responseDoc.data() as StoredResponseDoc;
-    if (existing.issueType !== issueType) {
+    if (!inherited && existing.issueType !== issueType) {
       throw new Error("The prior response belongs to another issue type");
     }
     const identical =
@@ -704,20 +739,41 @@ export const reviseResponse = async (
     const now = Timestamp.now();
     const revisionIndex = identical
       ? existing.revisionCount || 1
-      : (existing.revisionCount || 0) + 1;
+      : inherited
+        ? 1
+        : (existing.revisionCount || 0) + 1;
+    const persistedResponseRef =
+      inherited && !identical
+        ? db.collection(SOM_REVIEW_RESPONSES).doc()
+        : responseDoc.ref;
     if (!identical) {
-      transaction.update(responseDoc.ref, {
-        response: payload,
-        revisionCount: revisionIndex,
-        updatedAt: now,
-      });
+      if (inherited) {
+        transaction.set(persistedResponseRef, {
+          ...revisionIdentity(payload),
+          issueType,
+          status: "current",
+          response: payload,
+          revisionCount: revisionIndex,
+          carriedForwardFromProposalId: existing.proposalId,
+          updatedAt: now,
+        });
+      } else {
+        transaction.update(persistedResponseRef, {
+          response: payload,
+          revisionCount: revisionIndex,
+          updatedAt: now,
+        });
+      }
       transaction.set(db.collection(SOM_REVIEW_RESPONSE_REVISIONS).doc(), {
         ...revisionIdentity(payload),
         issueType,
-        responseDocId: responseDoc.id,
+        responseDocId: persistedResponseRef.id,
         revisionIndex,
         action: "edit",
         response: payload,
+        ...(inherited
+          ? { carriedForwardFromProposalId: existing.proposalId }
+          : {}),
         createdAt: now,
       });
     }
@@ -727,7 +783,7 @@ export const reviseResponse = async (
         ? (propagationSnap.data() as TrustedPropagationDoc)
         : null,
       propagationRef,
-      responseRefId: responseDoc.id,
+      responseRefId: persistedResponseRef.id,
       responseRevisionIndex: revisionIndex,
       issueType,
       payload,


### PR DESCRIPTION
## Summary
- carry Rob's eight exact relocation decisions onto the semantically equivalent one-step move cards at read time
- preserve source response records, disagreement rationale, and correction text; direct current-card answers take precedence
- make inherited answers count in review progress, prior-response inspection, editing, and deliberation
- record and test the explicit source-to-target audit mapping

## Verification
- 222 Society of Mind Jest tests pass
- 25 governance/data tests pass
- production build passes
- full Jest suite: 291 pass; one pre-existing Yjs editor blur-history test fails