### PR TITLE
Clarify non-expert review introduction

### DIFF
--- a/__tests__/components/SomReview/CalibrationReviewIntro.test.tsx
+++ b/__tests__/components/SomReview/CalibrationReviewIntro.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import CalibrationReviewIntro from "../../../src/components/SomReview/CalibrationReviewIntro";
+
+describe("CalibrationReviewIntro", () => {
+  it("explains the repository and inserts the frozen assignment size", () => {
+    const onContinue = jest.fn();
+    render(<CalibrationReviewIntro itemCount={35} onContinue={onContinue} />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Work activity repository review",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/arranged from more general to more specific/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/US Department of Labor's O\*NET database/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/asking you to review 35 items/i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Begin review" }));
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/SomReview/CalibrationReviewIntro.tsx
+++ b/src/components/SomReview/CalibrationReviewIntro.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { Box, Button, Stack, Typography } from "@mui/material";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+
+const CalibrationReviewIntro = ({
+  itemCount,
+  onContinue,
+}: {
+  itemCount: number;
+  onContinue: () => void;
+}) => (
+  <Stack
+    justifyContent="center"
+    spacing={2.25}
+    sx={{ minHeight: "70dvh", maxWidth: 760, mx: "auto", py: 5 }}
+  >
+    <Typography
+      component="h1"
+      sx={{
+        fontSize: { xs: "1.65rem", sm: "2rem" },
+        fontWeight: 850,
+      }}
+    >
+      Work activity repository review
+    </Typography>
+
+    <Typography sx={{ fontSize: "1.05rem", lineHeight: 1.7 }}>
+      MIT is developing a repository of work activities, arranged from more
+      general to more specific. For example, &ldquo;Sell&rdquo; is a quite
+      general activity, whereas &ldquo;Sell physical objects&rdquo; is more
+      specific, and &ldquo;Sell food&rdquo; is more specific still.
+    </Typography>
+
+    <Typography sx={{ fontSize: "1.05rem", lineHeight: 1.7 }}>
+      By arranging work activities in this way, we hope to be able to draw
+      inferences about important issues like the impact of new technologies or
+      how workers in one occupation may be able to transfer their skills to
+      another.
+    </Typography>
+
+    <Typography sx={{ fontSize: "1.05rem", lineHeight: 1.7 }}>
+      In the screens that follow, we&apos;ll seek your help in reviewing
+      improvements to our repository that have been suggested by an AI tool.
+    </Typography>
+
+    <Box>
+      <Typography sx={{ fontSize: "1.05rem", lineHeight: 1.7 }}>
+        Each screen will show you:
+      </Typography>
+      <Box
+        component="ul"
+        sx={{
+          mt: 1,
+          mb: 0,
+          pl: 3.5,
+          "& li": { mb: 0.75, pl: 0.5 },
+        }}
+      >
+        <Typography
+          component="li"
+          sx={{ fontSize: "1.05rem", lineHeight: 1.6 }}
+        >
+          an example of the present state of the repository,
+        </Typography>
+        <Typography
+          component="li"
+          sx={{ fontSize: "1.05rem", lineHeight: 1.6 }}
+        >
+          an improvement proposed by the AI tool, and
+        </Typography>
+        <Typography
+          component="li"
+          sx={{ fontSize: "1.05rem", lineHeight: 1.6 }}
+        >
+          the source or sources from the US Department of Labor&apos;s O*NET
+          database that serve as the basis for the work task under
+          consideration.
+        </Typography>
+      </Box>
+    </Box>
+
+    <Typography sx={{ fontSize: "1.05rem", lineHeight: 1.7 }}>
+      We will ask whether you agree or disagree that the change proposed by the
+      AI tool is an improvement. If you disagree, we&apos;ll ask you to explain
+      why and suggest an alternative improvement.
+    </Typography>
+
+    <Typography sx={{ color: "text.secondary", lineHeight: 1.65 }}>
+      We are asking you to review {itemCount}{" "}
+      {itemCount === 1 ? "item" : "items"}, and each should take much less than
+      a minute to complete. Thanks very much for your help!
+    </Typography>
+
+    <Button
+      disableElevation
+      variant="contained"
+      endIcon={<ArrowForwardIcon />}
+      onClick={onContinue}
+      sx={{
+        alignSelf: { xs: "stretch", sm: "flex-start" },
+        minHeight: 50,
+        px: 3,
+        fontWeight: 800,
+      }}
+    >
+      Begin review
+    </Button>
+  </Stack>
+);
+
+export default CalibrationReviewIntro;

--- a/src/pages/review/calibration.tsx
+++ b/src/pages/review/calibration.tsx
@@ -15,6 +15,7 @@ import Head from "next/head";
 import ReviewCard, {
   ReviewSubmission,
 } from "@components/components/SomReview/ReviewCard";
+import CalibrationReviewIntro from "@components/components/SomReview/CalibrationReviewIntro";
 import ThemeModeToggle from "@components/components/SomReview/ThemeModeToggle";
 import { reviewInteractiveSurfaceSx } from "@components/components/SomReview/reviewStyles";
 import { useAuth } from "@components/components/context/AuthContext";
@@ -57,9 +58,7 @@ export const CalibrationReviewPage = () => {
 
   const assignment = overview?.active;
   const card = assignment?.cards[0];
-  const completed = assignment
-    ? assignment.cursor >= assignment.total
-    : false;
+  const completed = assignment ? assignment.cursor >= assignment.total : false;
 
   const submitResponse = async (submission: ReviewSubmission) => {
     if (!assignment || !card || !user?.userId) {
@@ -89,7 +88,7 @@ export const CalibrationReviewPage = () => {
   return (
     <>
       <Head>
-        <title>Ontology calibration | 1Ontology</title>
+        <title>Work activity repository review | 1Ontology</title>
       </Head>
       <Box
         component="main"
@@ -138,54 +137,10 @@ export const CalibrationReviewPage = () => {
           )}
 
           {!loading && !loadError && assignment && !started && !completed && (
-            <Stack
-              justifyContent="center"
-              spacing={3}
-              sx={{ minHeight: "70dvh", maxWidth: 720, mx: "auto" }}
-            >
-              <Box>
-                <Typography
-                  component="h1"
-                  sx={{
-                    fontSize: { xs: "1.65rem", sm: "2rem" },
-                    fontWeight: 850,
-                  }}
-                >
-                  {assignment.title}
-                </Typography>
-                <Typography
-                  sx={{
-                    mt: 0.75,
-                    color: "text.secondary",
-                    fontSize: "1.05rem",
-                    fontWeight: 700,
-                  }}
-                >
-                  {assignment.taskLabel}
-                </Typography>
-              </Box>
-              <Typography sx={{ fontSize: "1.05rem", lineHeight: 1.7 }}>
-                {assignment.introduction}
-              </Typography>
-              <Typography sx={{ color: "text.secondary", lineHeight: 1.6 }}>
-                Review all {assignment.total} items in this task set. Your
-                answers are saved independently and will not change the
-                questions shown to other reviewers.
-              </Typography>
-              <Button
-                disableElevation
-                variant="contained"
-                onClick={() => setStarted(true)}
-                sx={{
-                  alignSelf: { xs: "stretch", sm: "flex-start" },
-                  minHeight: 50,
-                  px: 3,
-                  fontWeight: 800,
-                }}
-              >
-                Begin review
-              </Button>
-            </Stack>
+            <CalibrationReviewIntro
+              itemCount={assignment.total}
+              onContinue={() => setStarted(true)}
+            />
           )}
 
           {!loading &&


### PR DESCRIPTION
## Summary
- replace the abbreviated calibration intro with Rob's participant-facing explanation
- derive the promised review count from the frozen assignment
- keep the one-assignment, non-propagating calibration workflow unchanged

## Verification
- npx jest __tests__/lib/somReview __tests__/components/SomReview --runInBand (223 tests)
- npx eslint src/components/SomReview/CalibrationReviewIntro.tsx src/pages/review/calibration.tsx __tests__/components/SomReview/CalibrationReviewIntro.test.tsx
- npm run build