### PR TITLE
Fix prior-review access for research team

### DIFF
--- a/__tests__/components/SomReview/ReviewInspectionPage.test.tsx
+++ b/__tests__/components/SomReview/ReviewInspectionPage.test.tsx
@@ -6,7 +6,10 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { Post } from "../../../src/lib/utils/Post";
-import { ReviewInspectionPage } from "../../../src/pages/review/inspection";
+import {
+  inspectionLoadErrorMessage,
+  ReviewInspectionPage,
+} from "../../../src/pages/review/inspection";
 
 jest.mock("../../../src/lib/utils/Post", () => ({
   Post: jest.fn(),
@@ -224,6 +227,15 @@ describe("Tom's prior-review inspection page", () => {
         },
         false,
       ),
+    );
+  });
+
+  it("classifies both supported forms of a research-team access error", () => {
+    expect(
+      inspectionLoadErrorMessage("Deliberation access is restricted"),
+    ).toBe("This page is restricted to the Society of Mind research team.");
+    expect(inspectionLoadErrorMessage({ response: { status: 403 } })).toBe(
+      "This page is restricted to the Society of Mind research team.",
     );
   });
 });

--- a/__tests__/lib/somReview/access.test.ts
+++ b/__tests__/lib/somReview/access.test.ts
@@ -39,6 +39,16 @@ describe("Society of Mind reviewer access", () => {
       }),
     ).toBe("researcher");
     expect(
+      resolveReviewerRole({
+        uid: "sam",
+        email: "ouhrac@gmail.com",
+        emailVerified: true,
+      }),
+    ).toBe("researcher");
+    expect(resolveReviewerRole({ uid: "d255rP2ZAnZtsRdN7iZWg3AyxMn2" })).toBe(
+      "researcher",
+    );
+    expect(
       resolveReviewerRole({ uid: "outside", email: "reviewer@example.org" }),
     ).toBe("contributor");
   });

--- a/__tests__/lib/utils/axiosConfig.test.ts
+++ b/__tests__/lib/utils/axiosConfig.test.ts
@@ -1,0 +1,29 @@
+import { getErrorMessage } from "../../../src/lib/utils/axiosConfig";
+
+describe("API response error normalization", () => {
+  it("preserves an API error message instead of returning an empty string", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    expect(
+      getErrorMessage({
+        response: {
+          status: 403,
+          data: { error: "Deliberation access is restricted" },
+        },
+      }),
+    ).toBe("Deliberation access is restricted");
+    expect(consoleError).toHaveBeenCalledWith(
+      "Deliberation access is restricted",
+    );
+
+    consoleError.mockRestore();
+  });
+
+  it("returns the original error when the response has no useful message", () => {
+    const error = { response: { status: 500, data: {} } };
+
+    expect(getErrorMessage(error)).toBe(error);
+  });
+});

--- a/src/lib/somReview/access.ts
+++ b/src/lib/somReview/access.ts
@@ -39,6 +39,7 @@ const DEFAULT_RESEARCHER_EMAILS = [
   "oneweb@umich.edu",
   "oneman@mit.edu",
   "iman@honor.education",
+  "ouhrac@gmail.com",
   "caia@mit.edu",
   "acai@college.harvard.edu",
   "xinru.wang@smart.mit.edu",
@@ -51,6 +52,8 @@ const DEFAULT_RESEARCHER_EMAILS = [
   "aimanim@mit.edu",
   "ethanasi@mit.edu",
 ];
+
+const DEFAULT_RESEARCHER_UIDS = ["d255rP2ZAnZtsRdN7iZWg3AyxMn2"];
 
 const normalizedSet = (defaults: string[], configured?: string): Set<string> =>
   new Set(
@@ -135,7 +138,10 @@ export const resolveReviewerRole = (
     DEFAULT_RESEARCHER_EMAILS,
     process.env.SOM_REVIEW_RESEARCHER_EMAILS,
   );
-  const researcherUids = uidSet([], process.env.SOM_REVIEW_RESEARCHER_UIDS);
+  const researcherUids = uidSet(
+    DEFAULT_RESEARCHER_UIDS,
+    process.env.SOM_REVIEW_RESEARCHER_UIDS,
+  );
   if (
     (emailCanAssignRole && researcherEmails.has(email)) ||
     researcherUids.has(identity.uid)

--- a/src/lib/utils/axiosConfig.ts
+++ b/src/lib/utils/axiosConfig.ts
@@ -1,19 +1,18 @@
 import axios from "axios";
 
-function getErrorMessage(error: any) {
+export function getErrorMessage(error: any) {
   const response = error.response;
   if (!response) return error;
   if (response.status === 418) return error;
-  let errorMessage = "";
   const { data } = response;
-  if (data) {
-    errorMessage += data.message ? data.message : "";
-    errorMessage += data.errorMessage ? data.errorMessage : "";
-    if (data.error) {
-      console.error(data.error);
-    }
+  if (!data) return error;
+  if (data.error) {
+    console.error(data.error);
   }
-  return errorMessage;
+  const errorMessage = [data.message, data.errorMessage, data.error]
+    .filter((message) => typeof message === "string" && message.trim())
+    .join(" ");
+  return errorMessage || error;
 }
 const adapter = axios.create({
   headers: {
@@ -32,7 +31,7 @@ adapter.interceptors.response.use(
   (error) => {
     const errorMessage = getErrorMessage(error);
     return Promise.reject(errorMessage);
-  }
+  },
 );
 
 export default adapter;

--- a/src/pages/review/inspection.tsx
+++ b/src/pages/review/inspection.tsx
@@ -39,6 +39,17 @@ import {
 
 type ItemFilter = "all" | "not-aligned" | "disagreements" | "controls";
 
+export const inspectionLoadErrorMessage = (error: any): string => {
+  const status = error?.response?.status ?? error?.status;
+  const message =
+    typeof error === "string"
+      ? error
+      : error?.response?.data?.error || error?.message || "";
+  return status === 403 || message === "Deliberation access is restricted"
+    ? "This page is restricted to the Society of Mind research team."
+    : "The prior-review inspection could not be loaded.";
+};
+
 export const ReviewInspectionPage = () => {
   const [{ user }] = useAuth();
   const router = useRouter();
@@ -93,11 +104,7 @@ export const ReviewInspectionPage = () => {
           );
         }
       } catch (error: any) {
-        setLoadError(
-          error?.response?.status === 403
-            ? "This page is restricted to the Society of Mind research team."
-            : "The prior-review inspection could not be loaded.",
-        );
+        setLoadError(inspectionLoadErrorMessage(error));
       } finally {
         if (!quiet) setLoading(false);
       }


### PR DESCRIPTION
## Summary
- recognize Sam's verified Firebase account as a Society of Mind researcher
- preserve API error messages through the shared Axios interceptor
- show the correct research-team restriction for both structured and normalized 403 errors
- add access, error-normalization, and inspection regression coverage

## Verification
- `npx jest __tests__/lib/somReview __tests__/components/SomReview __tests__/lib/utils/axiosConfig.test.ts --runInBand` (43 suites, 226 tests passed)
- `npx next lint --file src/lib/somReview/access.ts --file src/lib/utils/axiosConfig.ts --file src/pages/review/inspection.tsx`
- `npm run build`
- Full repository suite: 295/296 tests passed; the existing Yjs editor blur test remains unrelated and failing.