### PR TITLE
Update parts inheritance to move ownership to ancestors

### DIFF
--- a/src/components/StructuredProperty/InheritedPartsViewer.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewer.tsx
@@ -540,7 +540,7 @@ const InheritedPartsViewer: React.FC<InheritedPartsViewerProps> = ({
                   position: "relative",
                   mx: 2,
                   mt: 2,
-                  mb: 2.5,
+                  mb: inheritedPartsRepairing ? 4 : 2.5,
                 }}
               >
                 {/* Left Text */}

--- a/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
@@ -1856,7 +1856,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
               position: "relative",
               mx: 2,
               mt: 2,
-              mb: 2.5,
+              mb: inheritedPartsRepairing ? 4 : 2.5,
             }}
           >
             {/* Left Text */}

--- a/src/lib/server/hierarchy.ts
+++ b/src/lib/server/hierarchy.ts
@@ -871,6 +871,7 @@ export function buildSpecializationNode(
   delete newNode.root;
   delete newNode.oNetTask;
   delete newNode.resolvedParts;
+  delete newNode.partSources;
   delete newNode.partsOverallSource;
   delete newNode.inheritanceParts;
   if (newNode?.textValue?.specializations)

--- a/src/lib/server/parts.ts
+++ b/src/lib/server/parts.ts
@@ -6,8 +6,22 @@ import {
   INode,
   NodeChange,
 } from "@components/types/INode";
-import { NodeCache, getNode, walkSpecializations } from "./hierarchy";
-import { applyGenChange, toPartsNode, PartsGraph } from "./partsModel";
+import {
+  NodeCache,
+  generalizationIds,
+  getNode,
+  walkSpecializations,
+} from "./hierarchy";
+import {
+  absorbOwnedForGens,
+  absorbOwnedPart,
+  applyGenChange,
+  childSourceOf,
+  isOwnedPart,
+  resolveParts,
+  toPartsNode,
+  PartsGraph,
+} from "./partsModel";
 import {
   computeInheritedPartsDetails,
   fetchPartsContext,
@@ -40,15 +54,14 @@ export function asPartsCollections(value: any): ICollection[] {
 }
 
 /**
- * Applies a generalization change to `nodeId`'s parts: stored entries tracked
- * through a removed gen drop unless a remaining gen still provides them, and
- * losing the attached source re-attaches to the first remaining gen by MERGE.
- * The gen list changed, so the annotation pair is refreshed even when the
- * stored parts came out identical.
+ * Apply a gen change to `nodeId`'s parts: entries tracked through a removed
+ * gen drop unless another gen provides them; losing the source re-attaches to
+ * the first remaining gen. Added gens absorb owned copies, here and below.
  */
 export async function applyPartsForGenChange(
   nodeId: string,
   removedGenIds: string[],
+  addedGenIds: string[],
   cache: NodeCache,
   parentLog: NodeChange["triggeredBy"],
   uname: string | undefined,
@@ -69,12 +82,21 @@ export async function applyPartsForGenChange(
   const remainingGenIds = (current.generalizations ?? []).flatMap((c) =>
     (c.nodes ?? []).map((n) => n.id),
   );
-  const { parts, partsInheritance } = applyGenChange(
+  let { parts, partsInheritance } = applyGenChange(
     nodeId,
     graph,
     removedGenIds,
     remainingGenIds,
   );
+
+  const presentAddedGens = addedGenIds.filter((id) => graph.has(id));
+  if (presentAddedGens.length > 0) {
+    const scratch: PartsGraph = new Map(graph);
+    scratch.set(nodeId, { id: nodeId, parts, partsInheritance });
+    const absorbed = absorbOwnedForGens(nodeId, scratch, presentAddedGens);
+    parts = absorbed.parts;
+    partsInheritance = absorbed.partsInheritance;
+  }
 
   const beforeEntries = partsNodes(current.properties?.parts);
   const beforeCol = asPartsCollections(current.properties?.parts);
@@ -87,6 +109,7 @@ export async function applyPartsForGenChange(
   const updatedRelated = { ...relatedNodes, [nodeId]: updatedNode };
   const resolvedOfUpdated = makeResolvedOf(updatedRelated);
 
+  // Gen list changed ⇒ refresh the pair even if the stored parts are identical.
   await db
     .collection(NODES)
     .doc(nodeId)
@@ -102,22 +125,57 @@ export async function applyPartsForGenChange(
     });
   cache.set(nodeId, updatedNode);
 
+  // Strip isPartOf for entries that dropped AND for entries this node no
+  // longer OWNS (an absorb re-tags them in place).
   const keptIds = new Set(parts.map((p) => p.id));
-  const dropped = beforeEntries
-    .map((e) => e.id)
-    .filter((id) => !keptIds.has(id));
-  if (dropped.length > 0) {
+  const ownedAfter = new Set(parts.filter(isOwnedPart).map((p) => p.id));
+  const stripped = [
+    ...new Set(
+      beforeEntries
+        .filter(
+          (e) =>
+            !keptIds.has(e.id) || (isOwnedPart(e) && !ownedAfter.has(e.id)),
+        )
+        .map((e) => e.id),
+    ),
+  ];
+  if (stripped.length > 0) {
     await applyIsPartOfOwnerOnly(
       nodeId,
       current.title ?? "",
       [],
-      dropped,
+      stripped,
       cache,
       parentLog,
       uname,
       appName,
       childLogs,
     );
+  }
+
+  // Every part an added gen provides may also be owned somewhere below.
+  if (presentAddedGens.length > 0) {
+    const seen = new Set<string>();
+    const genProvided: { partId: string; owner: string }[] = [];
+    for (const genId of presentAddedGens) {
+      for (const p of resolveParts(genId, graph)) {
+        if (seen.has(p.id)) continue;
+        seen.add(p.id);
+        genProvided.push({ partId: p.id, owner: childSourceOf(p, genId) });
+      }
+    }
+    if (genProvided.length > 0) {
+      await absorbDescendantOwnership(
+        nodeId,
+        genProvided,
+        updatedRelated,
+        cache,
+        parentLog,
+        uname,
+        appName,
+        childLogs,
+      );
+    }
   }
 
   const changed =
@@ -273,4 +331,132 @@ export async function propagateOwnedPartChange(
     });
     return { "properties.parts": toParts(rePointed) };
   });
+}
+
+/**
+ * `editedNodeId` now provides these parts, so descendants that owned a copy
+ * stop owning it; the parts' isPartOf drops them. Descendants' resolvedParts
+ * are left stale on purpose — read-repair fixes them per node.
+ */
+export async function absorbDescendantOwnership(
+  editedNodeId: string,
+  absorptions: { partId: string; owner: string }[],
+  relatedNodes: { [id: string]: INode },
+  cache: NodeCache,
+  parentLog: NodeChange["triggeredBy"],
+  uname: string | undefined,
+  appName: string | undefined,
+  childLogs: NodeChange[],
+): Promise<void> {
+  for (const [id, n] of Object.entries(relatedNodes)) {
+    if (!cache.has(id)) cache.set(id, n);
+  }
+
+  // Ancestor test: pathIds is a quick positive (primary-parent spine); the
+  // upward generalization walk is authoritative for multi-gen paths.
+  const isDescendant = async (nodeId: string): Promise<boolean> => {
+    const direct = await getNode(nodeId, cache);
+    if (((direct as any)?.pathIds ?? []).includes(editedNodeId)) return true;
+    const visited = new Set<string>([nodeId]);
+    const queue = [nodeId];
+    while (queue.length > 0) {
+      const doc = await getNode(queue.shift() as string, cache);
+      if (!doc) continue;
+      for (const gid of generalizationIds(doc)) {
+        if (gid === editedNodeId) return true;
+        if (!visited.has(gid)) {
+          visited.add(gid);
+          queue.push(gid);
+        }
+      }
+    }
+    return false;
+  };
+
+  const chainGraphFor = async (nodeId: string): Promise<PartsGraph> => {
+    const graph: PartsGraph = new Map();
+    let cursor: string | null | undefined = nodeId;
+    while (cursor && !graph.has(cursor)) {
+      const doc = await getNode(cursor, cache);
+      if (!doc) break;
+      const partsNode = toPartsNode({ ...doc, id: cursor });
+      graph.set(cursor, partsNode);
+      cursor = partsNode.partsInheritance.source;
+    }
+    return graph;
+  };
+
+  for (const { partId, owner } of absorptions) {
+    const partDoc = await getNode(partId, cache);
+    if (!partDoc) continue;
+    const candidateIds = [
+      ...new Set(
+        (partDoc.properties?.isPartOf ?? [])
+          .flatMap((c: ICollection) => c.nodes ?? [])
+          .map((n: ILinkNode) => n.id)
+          .filter((id: string) => id !== owner && id !== editedNodeId),
+      ),
+    ];
+
+    const convertedIds: string[] = [];
+    for (const candidateId of candidateIds) {
+      const candidate = await getNode(candidateId, cache);
+      if (!candidate || candidate.deleted) continue;
+      const entries = partsNodes(
+        asPartsCollections(candidate.properties?.parts),
+      );
+      if (!entries.some((e) => e.id === partId && isOwnedPart(e))) continue;
+      if (!(await isDescendant(candidateId))) continue;
+
+      const graph = await chainGraphFor(candidateId);
+      const { parts, partsInheritance, changed } = absorbOwnedPart(
+        candidateId,
+        graph,
+        partId,
+        owner,
+      );
+      if (!changed) continue;
+      const side = toParts(parts);
+      await db.collection(NODES).doc(candidateId).update({
+        "properties.parts": side,
+        partsInheritance,
+      });
+      cache.set(candidateId, {
+        ...candidate,
+        properties: { ...candidate.properties, parts: side },
+        partsInheritance,
+      } as INode);
+      convertedIds.push(candidateId);
+    }
+    if (convertedIds.length === 0) continue;
+
+    const before = asPartsCollections(partDoc.properties?.isPartOf);
+    const dropSet = new Set(convertedIds);
+    const after: ICollection[] = JSON.parse(JSON.stringify(before));
+    for (const c of after) {
+      c.nodes = (c.nodes || []).filter((n) => !dropSet.has(n.id));
+    }
+    await db
+      .collection(NODES)
+      .doc(partId)
+      .update({ "properties.isPartOf": after });
+    cache.set(partId, {
+      ...partDoc,
+      properties: { ...partDoc.properties, isPartOf: after },
+    } as INode);
+    if (uname) {
+      childLogs.push({
+        nodeId: partId,
+        modifiedBy: uname,
+        modifiedProperty: "isPartOf",
+        previousValue: before,
+        newValue: after,
+        modifiedAt: new Date(),
+        changeType: "remove element",
+        fullNode: partDoc,
+        triggeredBy: parentLog,
+        ...(appName ? { appName } : {}),
+      } as NodeChange);
+    }
+  }
 }

--- a/src/lib/server/parts.ts
+++ b/src/lib/server/parts.ts
@@ -1,4 +1,7 @@
-import { db } from "@components/lib/firestoreServer/admin";
+import {
+  db,
+  MAX_TRANSACTION_WRITES,
+} from "@components/lib/firestoreServer/admin";
 import { NODES } from "@components/lib/firestoreClient/collections";
 import {
   ICollection,
@@ -6,18 +9,15 @@ import {
   INode,
   NodeChange,
 } from "@components/types/INode";
-import {
-  NodeCache,
-  generalizationIds,
-  getNode,
-  walkSpecializations,
-} from "./hierarchy";
+import { NodeCache, generalizationIds, getNode } from "./hierarchy";
 import {
   absorbOwnedForGens,
   absorbOwnedPart,
   applyGenChange,
   childSourceOf,
   isOwnedPart,
+  partSourcesOf,
+  repointTracked,
   resolveParts,
   toPartsNode,
   PartsGraph,
@@ -90,12 +90,14 @@ export async function applyPartsForGenChange(
   );
 
   const presentAddedGens = addedGenIds.filter((id) => graph.has(id));
+  let ownConverted: { partId: string; owner: string }[] = [];
   if (presentAddedGens.length > 0) {
     const scratch: PartsGraph = new Map(graph);
     scratch.set(nodeId, { id: nodeId, parts, partsInheritance });
     const absorbed = absorbOwnedForGens(nodeId, scratch, presentAddedGens);
     parts = absorbed.parts;
     partsInheritance = absorbed.partsInheritance;
+    ownConverted = absorbed.converted;
   }
 
   const beforeEntries = partsNodes(current.properties?.parts);
@@ -116,6 +118,7 @@ export async function applyPartsForGenChange(
     .update({
       "properties.parts": side,
       partsInheritance,
+      partSources: partSourcesOf(parts),
       inheritedPartsDetails: computeInheritedPartsDetails({
         currentNode: updatedNode,
         relatedNodes: updatedRelated,
@@ -124,6 +127,12 @@ export async function applyPartsForGenChange(
       resolvedParts: resolvedOfUpdated(nodeId),
     });
   cache.set(nodeId, updatedNode);
+
+  // Entries elsewhere still tracking a copy this node just stopped owning
+  // follow it to the new owner.
+  for (const { partId, owner } of ownConverted) {
+    await repointTrackedEntries(nodeId, partId, owner);
+  }
 
   // Strip isPartOf for entries that dropped AND for entries this node no
   // longer OWNS (an absorb re-tags them in place).
@@ -284,17 +293,42 @@ export async function applyIsPartOfOwnerOnly(
   }
 }
 
+/** Docs holding a stored entry that tracks `owner`'s copy of `partId`. */
+async function queryTrackingDocs(
+  partId: string,
+  owner: string,
+): Promise<Map<string, INode>> {
+  const snap = await db
+    .collection(NODES)
+    .where("partSources", "array-contains", `${partId}:${owner}`)
+    .get();
+  const docs = new Map<string, INode>();
+  for (const d of snap.docs) {
+    const data = d.data() as INode;
+    if (!data.deleted) docs.set(d.id, { ...data, id: d.id });
+  }
+  return docs;
+}
+
 /**
- * v1 truth propagation for an OWNER's remove/replace: walk the spec subtree
- * and update stored entries that track `ownerId` — broken-node and switched
- * recorders — dropping them, or morphing them when `to` is given. Resolved
- * copies are left stale on purpose; the read-repair path refreshes per node.
+ * After an owner's remove/replace: every stored entry tracking `ownerId`,
+ * found via partSources (so nodes outside the subtree are reached too),
+ * drops — or morphs when `to` is given. resolvedParts stay stale; read-repair fixes them.
  */
 export async function propagateOwnedPartChange(
   ownerId: string,
   changes: { fromId: string; to?: { id: string; title: string } }[],
 ): Promise<void> {
-  await walkSpecializations(ownerId, (node) => {
+  const docs = new Map<string, INode>();
+  for (const c of changes) {
+    for (const [id, data] of await queryTrackingDocs(c.fromId, ownerId)) {
+      if (!docs.has(id)) docs.set(id, data);
+    }
+  }
+
+  let batch = db.batch();
+  let pending = 0;
+  for (const [id, node] of docs) {
     const entries = partsNodes(asPartsCollections(node.properties?.parts));
     const presentIds = new Set(entries.map((e) => e.id));
     const droppedIds = new Set<string>();
@@ -316,7 +350,7 @@ export async function propagateOwnedPartChange(
         droppedIds.add(e.id);
       }
     }
-    if (!touched) return null;
+    if (!touched) continue;
     const byId = new Map(entries.map((e) => [e.id, e]));
     const rePointed = next.map((e) => {
       if (e.after == null || !droppedIds.has(e.after)) return e;
@@ -329,8 +363,54 @@ export async function propagateOwnedPartChange(
       else copy.after = cursor;
       return copy;
     });
-    return { "properties.parts": toParts(rePointed) };
-  });
+    batch.update(db.collection(NODES).doc(id), {
+      "properties.parts": toParts(rePointed),
+      partSources: partSourcesOf(rePointed),
+    });
+    pending += 1;
+    if (pending >= MAX_TRANSACTION_WRITES) {
+      await batch.commit();
+      batch = db.batch();
+      pending = 0;
+    }
+  }
+  if (pending > 0) await batch.commit();
+}
+
+/**
+ * `exOwnerId`'s copy of `partId` moved to `newOwner` (absorption lifted it):
+ * re-point every stored entry still tracking the old copy, wherever it lives,
+ * so the new owner's future removals and morphs keep reaching it.
+ */
+export async function repointTrackedEntries(
+  exOwnerId: string,
+  partId: string,
+  newOwner: string,
+): Promise<void> {
+  const docs = await queryTrackingDocs(partId, exOwnerId);
+  let batch = db.batch();
+  let pending = 0;
+  for (const [id, node] of docs) {
+    const entries = partsNodes(asPartsCollections(node.properties?.parts));
+    const { parts, changed } = repointTracked(
+      entries,
+      partId,
+      exOwnerId,
+      newOwner,
+    );
+    if (!changed) continue;
+    batch.update(db.collection(NODES).doc(id), {
+      "properties.parts": toParts(parts),
+      partSources: partSourcesOf(parts),
+    });
+    pending += 1;
+    if (pending >= MAX_TRANSACTION_WRITES) {
+      await batch.commit();
+      batch = db.batch();
+      pending = 0;
+    }
+  }
+  if (pending > 0) await batch.commit();
 }
 
 /**
@@ -417,16 +497,22 @@ export async function absorbDescendantOwnership(
       );
       if (!changed) continue;
       const side = toParts(parts);
-      await db.collection(NODES).doc(candidateId).update({
-        "properties.parts": side,
-        partsInheritance,
-      });
+      await db
+        .collection(NODES)
+        .doc(candidateId)
+        .update({
+          "properties.parts": side,
+          partsInheritance,
+          partSources: partSourcesOf(parts),
+        });
       cache.set(candidateId, {
         ...candidate,
         properties: { ...candidate.properties, parts: side },
         partsInheritance,
       } as INode);
       convertedIds.push(candidateId);
+      // Deeper entries still tracking the dissolved owner follow the copy.
+      await repointTrackedEntries(candidateId, partId, owner);
     }
     if (convertedIds.length === 0) continue;
 

--- a/src/lib/server/partsModel.ts
+++ b/src/lib/server/partsModel.ts
@@ -55,6 +55,36 @@ export function isOwnedPart(part: ILinkNode): boolean {
 }
 
 /**
+ * Query index for stored entries' inheritedFrom tags: one "partId:ownerId"
+ * key per non-owned entry. Every write of `properties.parts` MUST write
+ * this alongside; a missing field means empty.
+ */
+export function partSourcesOf(parts: PartEntry[]): string[] {
+  return parts
+    .filter((e) => e.inheritedFrom)
+    .map((e) => `${e.id}:${e.inheritedFrom}`);
+}
+
+/**
+ * Re-point entries tracking `fromOwner`'s copy of `partId` to `toOwner`
+ * (ownership moved). Exact matches only; owned entries never change.
+ */
+export function repointTracked(
+  parts: PartEntry[],
+  partId: string,
+  fromOwner: string,
+  toOwner: string,
+): { parts: PartEntry[]; changed: boolean } {
+  let changed = false;
+  const next = parts.map((e) => {
+    if (e.id !== partId || e.inheritedFrom !== fromOwner) return e;
+    changed = true;
+    return { ...e, inheritedFrom: toOwner };
+  });
+  return { parts: changed ? next : parts, changed };
+}
+
+/**
  * The owner a CHILD records for a part it inherits from parent `parentId`:
  * the parent if the parent owns it, else whoever the parent inherited it from.
  * This is what skips a pass-through parent — per part.

--- a/src/lib/server/partsModel.ts
+++ b/src/lib/server/partsModel.ts
@@ -620,3 +620,104 @@ export function applyGenChange(
   }
   return { parts, partsInheritance: { source: next.id, overrides } };
 }
+
+/**
+ * An ancestor (`owner`) now provides `partId`, so this node stops owning its
+ * copy. If the source chain provides it, the entry is deleted (an optional
+ * difference becomes an override); otherwise it's re-tagged as inherited.
+ */
+export function absorbOwnedPart(
+  nodeId: string,
+  graph: PartsGraph,
+  partId: string,
+  owner: string,
+): {
+  parts: PartEntry[];
+  partsInheritance: PartsInheritance;
+  changed: boolean;
+} {
+  const node = graph.get(nodeId);
+  const entry = node?.parts.find((e) => e.id === partId && isOwnedPart(e));
+  if (!node || !entry) {
+    return {
+      parts: node?.parts ?? [],
+      partsInheritance: node?.partsInheritance ?? {
+        source: null,
+        overrides: {},
+      },
+      changed: false,
+    };
+  }
+  const { source, overrides } = node.partsInheritance;
+  const provided =
+    source && graph.has(source)
+      ? resolveParts(source, graph).find((p) => p.id === partId)
+      : undefined;
+
+  if (!provided) {
+    const parts = node.parts.map((e) =>
+      e.id === partId ? { ...e, inheritedFrom: owner } : e,
+    );
+    return { parts, partsInheritance: node.partsInheritance, changed: true };
+  }
+
+  const parts = node.parts.filter((e) => e.id !== partId);
+  const nextOverrides = { ...overrides };
+  delete nextOverrides[partId];
+  if (!!entry.optional !== !!provided.optional) {
+    nextOverrides[partId] = { optional: !!entry.optional };
+  }
+  return {
+    parts,
+    partsInheritance: { source, overrides: nextOverrides },
+    changed: true,
+  };
+}
+
+/**
+ * Absorb every owned entry that a newly linked gen provides. `converted`
+ * lists the absorbed parts so the caller can repeat this on descendants.
+ */
+export function absorbOwnedForGens(
+  nodeId: string,
+  graph: PartsGraph,
+  genIds: string[],
+): {
+  parts: PartEntry[];
+  partsInheritance: PartsInheritance;
+  converted: { partId: string; owner: string }[];
+} {
+  const node = graph.get(nodeId);
+  if (!node) {
+    return {
+      parts: [],
+      partsInheritance: { source: null, overrides: {} },
+      converted: [],
+    };
+  }
+  let current = node;
+  const converted: { partId: string; owner: string }[] = [];
+  for (const genId of genIds) {
+    for (const p of resolveParts(genId, graph)) {
+      if (!current.parts.some((e) => e.id === p.id && isOwnedPart(e))) {
+        continue;
+      }
+      const owner = childSourceOf(p, genId);
+      const scratch: PartsGraph = new Map(graph);
+      scratch.set(nodeId, current);
+      const result = absorbOwnedPart(nodeId, scratch, p.id, owner);
+      if (!result.changed) continue;
+      current = {
+        id: nodeId,
+        parts: result.parts,
+        partsInheritance: result.partsInheritance,
+      };
+      converted.push({ partId: p.id, owner });
+    }
+  }
+  return {
+    parts: current.parts,
+    partsInheritance: current.partsInheritance,
+    converted,
+  };
+}

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -930,6 +930,7 @@ export const createNewNode = (
   delete newNode.root;
   delete newNode.oNetTask;
   delete newNode.resolvedParts;
+  delete newNode.partSources;
   delete newNode.partsOverallSource;
   delete newNode.inheritanceParts;
   if (newNode?.textValue?.specializations) {

--- a/src/pages/api/nodes/hierarchy/cloning.ts
+++ b/src/pages/api/nodes/hierarchy/cloning.ts
@@ -23,6 +23,7 @@ import {
   partsNodes,
   toParts,
 } from "@components/lib/server/parts";
+import { partSourcesOf } from "@components/lib/server/partsModel";
 import {
   computeInheritedPartsDetails,
   fetchPartsContext,
@@ -216,7 +217,8 @@ async function applyClone(ctx: {
     // The new clone is an owned part (its isPartOf backlink was seeded above):
     // append it to the stored entries; appending never breaks attachment.
     sideBefore = asCollections(currentNode.properties?.parts);
-    side = toParts([...partsNodes(sideBefore), { id: newNodeId, title }]);
+    const nextEntries = [...partsNodes(sideBefore), { id: newNodeId, title }];
+    side = toParts(nextEntries);
     const updatedCurrent = {
       ...currentNode,
       properties: { ...currentNode.properties, parts: side },
@@ -228,6 +230,7 @@ async function applyClone(ctx: {
       .doc(currentNodeId)
       .update({
         "properties.parts": side,
+        partSources: partSourcesOf(nextEntries),
         inheritedPartsDetails: computeInheritedPartsDetails({
           currentNode: updatedCurrent,
           relatedNodes,

--- a/src/pages/api/nodes/hierarchy/cloning.ts
+++ b/src/pages/api/nodes/hierarchy/cloning.ts
@@ -310,6 +310,7 @@ async function applyClone(ctx: {
     await applyPartsForGenChange(
       currentNodeId,
       leftRootId ? [leftRootId] : [],
+      [newNodeId],
       cache,
       parentLog,
       uname,

--- a/src/pages/api/nodes/hierarchy/link.ts
+++ b/src/pages/api/nodes/hierarchy/link.ts
@@ -141,6 +141,7 @@ async function applyLink(ctx: ChangeCtx): Promise<{ ok: true }> {
       leftRootId && !removed.includes(leftRootId)
         ? [...removed, leftRootId]
         : removed,
+      added,
       cache,
       parentLog,
       uname,
@@ -157,6 +158,7 @@ async function applyLink(ctx: ChangeCtx): Promise<{ ok: true }> {
       await applyPartsForGenChange(
         id,
         removedGens,
+        added.includes(id) ? [nodeId] : [],
         cache,
         parentLog,
         uname,

--- a/src/pages/api/nodes/hierarchy/move.ts
+++ b/src/pages/api/nodes/hierarchy/move.ts
@@ -128,6 +128,7 @@ async function applyMove(ctx: {
     leftRootId && leftRootId !== fromParentId
       ? [fromParentId, leftRootId]
       : [fromParentId],
+    [toParentId],
     cache,
     parentLog,
     uname,

--- a/src/pages/api/nodes/hierarchy/unlink.ts
+++ b/src/pages/api/nodes/hierarchy/unlink.ts
@@ -73,7 +73,10 @@ async function applyUnlink(ctx: {
     changeType: "modify elements" as const,
   };
 
-  await db.collection(NODES).doc(nodeId).update({ [side]: value });
+  await db
+    .collection(NODES)
+    .doc(nodeId)
+    .update({ [side]: value });
 
   const childLogs: NodeChange[] = [];
   await applyReciprocityRemove(
@@ -109,6 +112,7 @@ async function applyUnlink(ctx: {
     await applyPartsForGenChange(
       nodeId,
       removed,
+      [],
       cache,
       parentLog,
       uname,
@@ -122,6 +126,7 @@ async function applyUnlink(ctx: {
       await applyPartsForGenChange(
         id,
         [nodeId],
+        [],
         cache,
         parentLog,
         uname,
@@ -179,14 +184,22 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     return fail(res, 400, "nodeId is required");
   }
   if (side !== "specializations" && side !== "generalizations") {
-    return fail(res, 400, "side must be 'specializations' or 'generalizations'");
+    return fail(
+      res,
+      400,
+      "side must be 'specializations' or 'generalizations'",
+    );
   }
   const rawIds: any[] | null = Array.isArray(data.removeIds)
     ? data.removeIds
     : typeof data.removeId === "string"
       ? [data.removeId]
       : null;
-  if (!rawIds || !rawIds.length || !rawIds.every((id) => typeof id === "string")) {
+  if (
+    !rawIds ||
+    !rawIds.length ||
+    !rawIds.every((id) => typeof id === "string")
+  ) {
     return fail(res, 400, "removeIds must be a non-empty array of node ids");
   }
   const removeIds: string[] = [
@@ -215,7 +228,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     });
     return res.status(200).json(result);
   } catch (error: any) {
-    if (error instanceof HttpError) return fail(res, error.status, error.message);
+    if (error instanceof HttpError)
+      return fail(res, error.status, error.message);
     console.error("nodes/hierarchy/unlink error", error);
     recordLogs(
       {

--- a/src/pages/api/nodes/parts/add.ts
+++ b/src/pages/api/nodes/parts/add.ts
@@ -21,7 +21,11 @@ import {
   partsNodes,
   toParts,
 } from "@components/lib/server/parts";
-import { childSourceOf, isOwnedPart } from "@components/lib/server/partsModel";
+import {
+  childSourceOf,
+  isOwnedPart,
+  partSourcesOf,
+} from "@components/lib/server/partsModel";
 import {
   computeInheritedPartsDetails,
   fetchPartsContext,
@@ -87,7 +91,8 @@ async function applyAdd(ctx: {
     throw new HttpError(400, "all of the parts are already on this node");
   }
 
-  const side = toParts([...entries, ...additions]);
+  const nextEntries = [...entries, ...additions];
+  const side = toParts(nextEntries);
   const updatedNode = {
     ...nodeData,
     properties: { ...nodeData.properties, parts: side },
@@ -100,6 +105,7 @@ async function applyAdd(ctx: {
     .doc(nodeId)
     .update({
       "properties.parts": side,
+      partSources: partSourcesOf(nextEntries),
       inheritedPartsDetails: computeInheritedPartsDetails({
         currentNode: updatedNode,
         relatedNodes: updatedRelated,

--- a/src/pages/api/nodes/parts/add.ts
+++ b/src/pages/api/nodes/parts/add.ts
@@ -15,6 +15,7 @@ import {
   writeChangeLog,
 } from "@components/lib/server/hierarchy";
 import {
+  absorbDescendantOwnership,
   applyIsPartOfOwnerOnly,
   asPartsCollections,
   partsNodes,
@@ -123,6 +124,19 @@ async function applyAdd(ctx: {
     nodeData.title ?? "",
     addedOwn,
     [],
+    cache,
+    parentLog,
+    uname,
+    appName,
+    childLogs,
+  );
+
+  // A descendant that already owned one of these parts loses that ownership:
+  // the part is now provided from above, so its copy converts to inherited.
+  await absorbDescendantOwnership(
+    nodeId,
+    additions.map((p) => ({ partId: p.id, owner: p.inheritedFrom ?? nodeId })),
+    updatedRelated,
     cache,
     parentLog,
     uname,

--- a/src/pages/api/nodes/parts/reattach.ts
+++ b/src/pages/api/nodes/parts/reattach.ts
@@ -11,6 +11,7 @@ import {
 import { asPartsCollections, toParts } from "@components/lib/server/parts";
 import {
   convertToOverlay,
+  partSourcesOf,
   toPartsNode,
   PartsGraph,
 } from "@components/lib/server/partsModel";
@@ -67,6 +68,7 @@ async function applyReattach(ctx: {
     .update({
       "properties.parts": side,
       partsInheritance,
+      partSources: partSourcesOf(parts),
       inheritedPartsDetails: computeInheritedPartsDetails({
         currentNode: updatedNode,
         relatedNodes: updatedRelated,

--- a/src/pages/api/nodes/parts/remove.ts
+++ b/src/pages/api/nodes/parts/remove.ts
@@ -18,6 +18,7 @@ import {
 import {
   applyRemove,
   isOwnedPart,
+  partSourcesOf,
   toPartsNode,
   PartsGraph,
 } from "@components/lib/server/partsModel";
@@ -72,6 +73,7 @@ async function applyRemoveParts(ctx: {
     .update({
       "properties.parts": side,
       partsInheritance,
+      partSources: partSourcesOf(parts),
       inheritedPartsDetails: computeInheritedPartsDetails({
         currentNode: updatedNode,
         relatedNodes: updatedRelated,

--- a/src/pages/api/nodes/parts/replace.ts
+++ b/src/pages/api/nodes/parts/replace.ts
@@ -19,6 +19,7 @@ import {
 import {
   applyReplace,
   isOwnedPart,
+  partSourcesOf,
   toPartsNode,
   PartsGraph,
 } from "@components/lib/server/partsModel";
@@ -80,6 +81,7 @@ async function applyReplaceParts(ctx: {
     .update({
       "properties.parts": side,
       partsInheritance,
+      partSources: partSourcesOf(parts),
       inheritedPartsDetails: computeInheritedPartsDetails({
         currentNode: updatedNode,
         relatedNodes: updatedRelated,

--- a/src/pages/api/nodes/parts/replace.ts
+++ b/src/pages/api/nodes/parts/replace.ts
@@ -10,6 +10,7 @@ import {
   writeChangeLog,
 } from "@components/lib/server/hierarchy";
 import {
+  absorbDescendantOwnership,
   applyIsPartOfOwnerOnly,
   asPartsCollections,
   propagateOwnedPartChange,
@@ -115,6 +116,19 @@ async function applyReplaceParts(ctx: {
       { fromId, to: { id: toId, title: toNode.title ?? "" } },
     ]);
   }
+
+  // The replacement is owned here now — a descendant's own copy of it
+  // converts to inherited.
+  await absorbDescendantOwnership(
+    nodeId,
+    [{ partId: toId, owner: nodeId }],
+    updatedRelated,
+    cache,
+    parentLog,
+    uname,
+    appName,
+    childLogs,
+  );
 
   if (uname) {
     await writeChangeLog(

--- a/src/pages/api/nodes/parts/sort.ts
+++ b/src/pages/api/nodes/parts/sort.ts
@@ -11,6 +11,7 @@ import {
 import { asPartsCollections, toParts } from "@components/lib/server/parts";
 import {
   classifySort,
+  partSourcesOf,
   toPartsNode,
   PartsGraph,
 } from "@components/lib/server/partsModel";
@@ -78,6 +79,7 @@ async function applySort(ctx: {
     .update({
       "properties.parts": side,
       partsInheritance,
+      partSources: partSourcesOf(result.parts),
       inheritedPartsDetails: computeInheritedPartsDetails({
         currentNode: updatedNode,
         relatedNodes: updatedRelated,

--- a/src/pages/api/nodes/parts/switch-source.ts
+++ b/src/pages/api/nodes/parts/switch-source.ts
@@ -12,6 +12,7 @@ import { asPartsCollections, toParts } from "@components/lib/server/parts";
 import {
   applySwitchSource,
   isOwnedPart,
+  partSourcesOf,
   toPartsNode,
   PartsGraph,
 } from "@components/lib/server/partsModel";
@@ -83,6 +84,7 @@ async function applySwitch(ctx: {
     .update({
       "properties.parts": side,
       partsInheritance,
+      partSources: partSourcesOf(parts),
       inheritedPartsDetails: computeInheritedPartsDetails({
         currentNode: updatedNode,
         relatedNodes: updatedRelated,

--- a/src/pages/api/nodes/parts/toggle-optional.ts
+++ b/src/pages/api/nodes/parts/toggle-optional.ts
@@ -11,6 +11,7 @@ import {
 import { asPartsCollections, toParts } from "@components/lib/server/parts";
 import {
   applyToggleOptional,
+  partSourcesOf,
   toPartsNode,
   PartsGraph,
 } from "@components/lib/server/partsModel";
@@ -63,6 +64,7 @@ async function applyToggle(ctx: {
     .update({
       "properties.parts": side,
       partsInheritance,
+      partSources: partSourcesOf(parts),
       inheritedPartsDetails: computeInheritedPartsDetails({
         currentNode: updatedNode,
         relatedNodes: updatedRelated,

--- a/src/types/INode.ts
+++ b/src/types/INode.ts
@@ -99,6 +99,11 @@ export type INode = {
    * Never shown in the UI directly and never copied to other nodes.
    */
   resolvedParts?: ILinkNode[];
+  /**
+   * Query index: one "partId:ownerId" key per stored entry inherited
+   * from another node. It's used to find who tracks an owner's part. Missing means empty.
+   */
+  partSources?: string[];
   specializations: ICollection[];
   generalizations: ICollection[];
   root: string;


### PR DESCRIPTION
Hi @samadouhra 

This PR updates parts inheritance so that when an ancestor starts providing a part that is already owned by a descendant, ownership moves to the ancestor and the descendant inherits the part.

Changes include:

Implemented ancestor ownership for parts that already exist in descendants:

* adding a part to an ancestor
* replacing a part with a newly owned part
* adding a new generalization that provides the part

Updated descendant parts to:

* remove their owned copy when the new ancestor is already part of their inheritance
* switch their existing copy to specifically inherit from the new owner when overall inheritance is broken or follows a different source
* preserve the part’s position and optional setting when ownership changes

Updated specific inheritance propagation to use partSources instead of walking the owner’s entire subtree:

* added partSources to track which nodes specifically inherit each part
* updated part removals and replacements to find affected nodes through this index
* updated inherited entries to follow the new owner when ownership moves between nodes

Updated generalization changes, linking, unlinking, moving, and cloning to apply the new ownership behavior when a new ancestor provides an existing part.

Notes

* A part is now owned by the highest applicable node that provides it, rather than keeping separate ownership in both the ancestor and descendant.
* The descendant’s isPartOf relationship is removed when ownership moves to the ancestor.
* Existing specific inheritance continues to work after ownership moves, including for descendants whose overall inheritance is broken.
* Specific inheritance propagation now finds affected parts directly instead of walking the entire subtree.
* Added partSources to keep track of parts that are specifically inherited from another node.