### PR TITLE
Focus meta review on Rob's expert responses

### DIFF
--- a/__tests__/components/SomReview/ContextRenderer.test.tsx
+++ b/__tests__/components/SomReview/ContextRenderer.test.tsx
@@ -22,6 +22,9 @@ describe("Society of Mind context renderers", () => {
     expect(
       screen.getByText("Recommend and sell lotions or tonics."),
     ).toBeInTheDocument();
+    expect(screen.getByRole("list")).toContainElement(
+      screen.getByRole("listitem"),
+    );
     const collapseButton = screen.getByRole("button", {
       name: "Hide source O*NET evidence",
     });
@@ -56,7 +59,7 @@ describe("Society of Mind context renderers", () => {
     expect(screen.getAllByText("Sell products or services.")).toHaveLength(1);
   });
 
-  it("shows a title split with numbered evidence and existing-node status", () => {
+  it("shows a title split with bulleted evidence and existing-node status", () => {
     render(
       <ContextRenderer
         context={{
@@ -92,6 +95,7 @@ describe("Society of Mind context renderers", () => {
     expect(screen.getByText("Uses source item 1")).toBeInTheDocument();
     expect(screen.getByText("Uses source item 2")).toBeInTheDocument();
     expect(screen.getAllByText("Sell agricultural products.")).toHaveLength(1);
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
   });
 
   it("keeps the current children alphabetized and labels only the after split", () => {

--- a/__tests__/components/SomReview/ReviewInspectionPage.test.tsx
+++ b/__tests__/components/SomReview/ReviewInspectionPage.test.tsx
@@ -15,20 +15,24 @@ jest.mock("../../../src/lib/utils/Post", () => ({
   Post: jest.fn(),
 }));
 
+const mockUser = { userId: "tom" };
 jest.mock("../../../src/components/context/AuthContext", () => ({
-  useAuth: () => [{ user: { userId: "tom" } }],
+  useAuth: () => [{ user: mockUser }],
 }));
 
 const replace = jest.fn().mockResolvedValue(true);
 const push = jest.fn().mockResolvedValue(true);
 let routerQuery: Record<string, string> = { workspace: "sell" };
+const mockRouter = {
+  isReady: true,
+  get query() {
+    return routerQuery;
+  },
+  push,
+  replace,
+};
 jest.mock("next/router", () => ({
-  useRouter: () => ({
-    isReady: true,
-    query: routerQuery,
-    push,
-    replace,
-  }),
+  useRouter: () => mockRouter,
 }));
 
 jest.mock("../../../src/components/hoc/withAuthUser", () => ({
@@ -136,6 +140,12 @@ describe("Tom's prior-review inspection page", () => {
       screen.getByText(/Phase 1: Resolve meaning and identity/),
     ).toBeVisible();
     expect(screen.getByText("2 responses")).toBeVisible();
+    expect(screen.getByLabelText("Prior reviewer")).toHaveTextContent(
+      /Reviewing prior decisions by\s*Rob Laubacher \(2 responses\)/,
+    );
+    expect(
+      screen.queryByRole("combobox", { name: "Prior reviewer" }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("First reviewed proposal")).toBeNull();
     expect(
       screen.queryByText(/independent hierarchy scan/i),
@@ -217,6 +227,18 @@ describe("Tom's prior-review inspection page", () => {
     expect(await screen.findByText("First reviewed proposal")).toBeVisible();
     expect(screen.getByText("Second reviewed proposal")).toBeVisible();
     expect(screen.getByText("2 shown")).toBeVisible();
+    expect(
+      screen.getByRole("navigation", { name: "Review navigation" }),
+    ).toHaveTextContent("Proposal review/All review tasks");
+    fireEvent.click(screen.getByRole("button", { name: "All review tasks" }));
+    expect(replace).toHaveBeenCalledWith(
+      {
+        pathname: "/review/inspection",
+        query: { workspace: "sell", reviewer: "rob" },
+      },
+      undefined,
+      { shallow: true },
+    );
     await waitFor(() =>
       expect(Post).toHaveBeenCalledWith(
         "/som-review/inspection/overview",

--- a/__tests__/lib/somReview/inspectionPolicy.test.ts
+++ b/__tests__/lib/somReview/inspectionPolicy.test.ts
@@ -2,9 +2,45 @@ import {
   confidenceAuthorizesOntologyMutation,
   inspectableReviewerCounts,
   inspectionRecordSource,
+  inspectionSubjectAllowed,
 } from "../../../src/lib/somReview/inspectionPolicy";
 
 describe("inspection policy", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("exposes only Rob's expert review as the meta-review subject", () => {
+    expect(
+      inspectionSubjectAllowed({
+        reviewerId: "vFCAkxKTwjcDKohmiWfiZWz2lZf1",
+      }),
+    ).toBe(true);
+    expect(
+      inspectionSubjectAllowed({
+        reviewerId: "another-rob-account",
+        email: "rjl@mit.edu",
+        emailVerified: true,
+      }),
+    ).toBe(true);
+    expect(
+      inspectionSubjectAllowed({
+        reviewerId: "development-reviewer",
+        email: "oneman@mit.edu",
+        emailVerified: true,
+      }),
+    ).toBe(false);
+    expect(
+      inspectionSubjectAllowed({
+        reviewerId: "unverified-account",
+        email: "rjl@mit.edu",
+        emailVerified: false,
+      }),
+    ).toBe(false);
+  });
+
   it.each([
     ["proposed-change", "proposed-change"],
     ["status-quo-audit", "status-quo-audit"],

--- a/src/components/SomReview/ContextRenderer.tsx
+++ b/src/components/SomReview/ContextRenderer.tsx
@@ -196,9 +196,20 @@ const TitleComparison = ({
       openLabel="Hide source O*NET evidence"
       initiallyOpen
     >
-      <List dense disablePadding sx={{ pl: 1, pb: 1 }}>
+      <List
+        component="ul"
+        dense
+        disablePadding
+        sx={{ pl: 3, pb: 1, listStyleType: "disc" }}
+      >
         {tasks.map((task) => (
-          <ListItem key={task} disableGutters alignItems="flex-start">
+          <ListItem
+            component="li"
+            key={task}
+            disableGutters
+            alignItems="flex-start"
+            sx={{ display: "list-item", pl: 0.5 }}
+          >
             <ListItemText
               primary={task}
               primaryTypographyProps={{ sx: { lineHeight: 1.5 } }}
@@ -232,7 +243,12 @@ const TitleSplit = ({
         <Typography sx={{ ...sectionLabelSx, mt: 2 }}>
           Source O*NET evidence
         </Typography>
-        <List component="ol" dense disablePadding sx={{ pl: 3, mt: 0.5 }}>
+        <List
+          component="ul"
+          dense
+          disablePadding
+          sx={{ pl: 3, mt: 0.5, listStyleType: "disc" }}
+        >
           {tasks.map((task, index) => (
             <ListItem
               component="li"
@@ -813,9 +829,20 @@ const SourceTasks = ({ tasks }: { tasks: string[] }) => {
       openLabel="Hide source O*NET evidence"
       initiallyOpen
     >
-      <List dense disablePadding sx={{ pl: 1, pb: 1 }}>
+      <List
+        component="ul"
+        dense
+        disablePadding
+        sx={{ pl: 3, pb: 1, listStyleType: "disc" }}
+      >
         {uniqueTasks.map((task) => (
-          <ListItem key={task} disableGutters alignItems="flex-start">
+          <ListItem
+            component="li"
+            key={task}
+            disableGutters
+            alignItems="flex-start"
+            sx={{ display: "list-item", pl: 0.5 }}
+          >
             <ListItemText
               primary={task}
               primaryTypographyProps={{ sx: { lineHeight: 1.5 } }}

--- a/src/lib/somReview/inspectionPolicy.ts
+++ b/src/lib/somReview/inspectionPolicy.ts
@@ -7,6 +7,49 @@ import {
 } from "../../types/ISomReview";
 import { SOM_REVIEW_PATH } from "./reviewDependencies";
 
+export interface InspectionSubjectIdentity {
+  reviewerId: string;
+  email?: string | null;
+  emailVerified?: boolean;
+}
+
+const DEFAULT_INSPECTION_SUBJECT_EMAILS = ["rjl@mit.edu"];
+const DEFAULT_INSPECTION_SUBJECT_UIDS = ["vFCAkxKTwjcDKohmiWfiZWz2lZf1"];
+
+const configuredValues = (
+  defaults: string[],
+  configured: string | undefined,
+  normalize = false,
+): Set<string> =>
+  new Set(
+    [...defaults, ...(configured || "").split(",")]
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .map((value) => (normalize ? value.toLowerCase() : value)),
+  );
+
+/**
+ * The current meta-review protocol evaluates Rob's expert review. Development
+ * team responses are UI test data and must not appear as review subjects.
+ */
+export const inspectionSubjectAllowed = (
+  identity: InspectionSubjectIdentity,
+): boolean => {
+  const allowedUids = configuredValues(
+    DEFAULT_INSPECTION_SUBJECT_UIDS,
+    process.env.SOM_REVIEW_INSPECTION_SUBJECT_UIDS,
+  );
+  if (allowedUids.has(identity.reviewerId)) return true;
+
+  const email = (identity.email || "").trim().toLowerCase();
+  const allowedEmails = configuredValues(
+    DEFAULT_INSPECTION_SUBJECT_EMAILS,
+    process.env.SOM_REVIEW_INSPECTION_SUBJECT_EMAILS,
+    true,
+  );
+  return identity.emailVerified === true && allowedEmails.has(email);
+};
+
 export const inspectableReviewerCounts = (
   rounds: Array<{
     proposalIds: ReadonlySet<string>;

--- a/src/lib/somReview/inspectionStore.ts
+++ b/src/lib/somReview/inspectionStore.ts
@@ -21,6 +21,7 @@ import { reviewDatasetConfig, reviewWorkspaceConfig } from "./reviewWorkspaces";
 import { toReviewerCard } from "./sanitize";
 import {
   inspectableReviewerCounts,
+  inspectionSubjectAllowed,
   inspectionIssueLabel,
   inspectionRecordSource,
   selectInspectionReviewer,
@@ -137,11 +138,25 @@ const availableReviewers = async (
   const counts = inspectableReviewerCounts(rounds);
   const profiles = await loadUserProfiles([...counts.keys()]);
   return [...counts.entries()]
-    .map(([reviewerId, responseCount]) => ({
-      reviewerId,
-      displayName: profiles.get(reviewerId)?.displayName || "Ontology reviewer",
-      responseCount,
-    }))
+    .flatMap(([reviewerId, responseCount]) => {
+      const profile = profiles.get(reviewerId);
+      if (
+        !inspectionSubjectAllowed({
+          reviewerId,
+          email: profile?.email,
+          emailVerified: profile?.emailVerified,
+        })
+      ) {
+        return [];
+      }
+      return [
+        {
+          reviewerId,
+          displayName: profile?.displayName || "Robert Laubacher",
+          responseCount,
+        },
+      ];
+    })
     .sort(
       (left, right) =>
         right.responseCount - left.responseCount ||
@@ -325,6 +340,21 @@ const assertInspectableResponse = async ({
   subjectReviewerId: string;
   inspectorId: string;
 }) => {
+  const subjectProfile = (await loadUserProfiles([subjectReviewerId])).get(
+    subjectReviewerId,
+  );
+  if (
+    !inspectionSubjectAllowed({
+      reviewerId: subjectReviewerId,
+      email: subjectProfile?.email,
+      emailVerified: subjectProfile?.emailVerified,
+    })
+  ) {
+    throw new InspectionStoreError(
+      403,
+      "Only the designated expert review can be inspected",
+    );
+  }
   if (subjectReviewerId === inspectorId) {
     throw new InspectionStoreError(
       400,

--- a/src/pages/review/inspection.tsx
+++ b/src/pages/review/inspection.tsx
@@ -2,16 +2,13 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Alert,
   Box,
+  Breadcrumbs,
   Button,
   Card,
   CardActionArea,
   Chip,
   CircularProgress,
   Container,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
   Stack,
   TextField,
   ToggleButton,
@@ -115,17 +112,6 @@ export const ReviewInspectionPage = () => {
   useEffect(() => {
     if (user && router.isReady) loadOverview();
   }, [loadOverview, router.isReady, user]);
-
-  const selectReviewer = async (reviewerId: string) => {
-    await router.replace(
-      {
-        pathname: "/review/inspection",
-        query: { workspace: workspaceId, reviewer: reviewerId },
-      },
-      undefined,
-      { shallow: true },
-    );
-  };
 
   const selectTask = async (taskKey: string) => {
     await router.push(
@@ -279,26 +265,44 @@ export const ReviewInspectionPage = () => {
             spacing={2}
             sx={{ mb: 2 }}
           >
-            <Button
-              disableElevation
-              color="inherit"
-              startIcon={<ArrowBackIcon />}
-              onClick={() =>
-                router.push({
-                  pathname: "/review",
-                  query: {
-                    dataset:
-                      overview?.activeDatasetId ||
-                      (workspaceId === "sell"
-                        ? "sell-semantic-coverage"
-                        : "buy-content-identity"),
-                  },
-                })
-              }
-              sx={{ minHeight: 44, fontWeight: 750 }}
+            <Breadcrumbs
+              aria-label="Review navigation"
+              sx={{
+                minWidth: 0,
+                "& .MuiBreadcrumbs-ol": { flexWrap: "wrap" },
+              }}
             >
-              Proposal review
-            </Button>
+              <Button
+                disableElevation
+                color="inherit"
+                startIcon={<ArrowBackIcon />}
+                onClick={() =>
+                  router.push({
+                    pathname: "/review",
+                    query: {
+                      dataset:
+                        overview?.activeDatasetId ||
+                        (workspaceId === "sell"
+                          ? "sell-semantic-coverage"
+                          : "buy-content-identity"),
+                    },
+                  })
+                }
+                sx={{ minHeight: 44, fontWeight: 750, whiteSpace: "nowrap" }}
+              >
+                Proposal review
+              </Button>
+              {selectedTask && (
+                <Button
+                  disableElevation
+                  color="inherit"
+                  onClick={returnToTasks}
+                  sx={{ minHeight: 44, fontWeight: 750, whiteSpace: "nowrap" }}
+                >
+                  All review tasks
+                </Button>
+              )}
+            </Breadcrumbs>
             <ThemeModeToggle />
           </Stack>
 
@@ -375,40 +379,21 @@ export const ReviewInspectionPage = () => {
                     alignItems={{ xs: "stretch", md: "center" }}
                     spacing={1.5}
                   >
-                    {selectedTask && (
-                      <Button
-                        disableElevation
-                        color="inherit"
-                        variant="outlined"
-                        startIcon={<ArrowBackIcon />}
-                        onClick={returnToTasks}
-                        sx={{ minHeight: 56, fontWeight: 750 }}
+                    <Box sx={{ minWidth: 260 }} aria-label="Prior reviewer">
+                      <Typography
+                        sx={{
+                          color: "text.secondary",
+                          fontSize: "0.78rem",
+                          fontWeight: 700,
+                        }}
                       >
-                        All review tasks
-                      </Button>
-                    )}
-                    <FormControl sx={{ minWidth: 260 }}>
-                      <InputLabel id="prior-reviewer-label">
-                        Prior reviewer
-                      </InputLabel>
-                      <Select
-                        labelId="prior-reviewer-label"
-                        value={overview.selectedReviewerId || ""}
-                        label="Prior reviewer"
-                        onChange={(event) =>
-                          selectReviewer(String(event.target.value))
-                        }
-                      >
-                        {overview.reviewers.map((reviewer) => (
-                          <MenuItem
-                            key={reviewer.reviewerId}
-                            value={reviewer.reviewerId}
-                          >
-                            {reviewer.displayName} ({reviewer.responseCount})
-                          </MenuItem>
-                        ))}
-                      </Select>
-                    </FormControl>
+                        Reviewing prior decisions by
+                      </Typography>
+                      <Typography sx={{ mt: 0.25, fontWeight: 800 }}>
+                        {selectedReviewer?.displayName || "Robert Laubacher"} (
+                        {selectedReviewer?.responseCount || 0} responses)
+                      </Typography>
+                    </Box>
                     {selectedTask && (
                       <TextField
                         fullWidth


### PR DESCRIPTION
## What changed
- restrict prior-review inspection to Robert Laubacher's substantive expert responses, including server-side authorization
- replace the reviewer picker with fixed review-subject context
- consolidate Proposal Review and All Review Tasks into stable breadcrumb navigation
- render source O*NET evidence as bulleted lists

## Why
The current study protocol asks Tom and Rob to inspect Rob's substantive review decisions. Responses from Iman, Sam, and SoeMin were generated while testing the interface and should not appear as meta-review subjects. The prior navigation also collapsed at narrower widths, and source evidence needed clearer visual separation.

## Validation
- `npx jest --runInBand __tests__/components/SomReview __tests__/lib/somReview` (42 suites, 225 tests)
- `npm run build`
- `git diff --check`

A standalone `npx tsc --noEmit` still reports pre-existing errors in unrelated legacy files; the production Next.js build succeeds.