### PR TITLE
Streamline continuous expert review checkpoints

### DIFF
--- a/__tests__/components/SomReview/ReviewCard.test.tsx
+++ b/__tests__/components/SomReview/ReviewCard.test.tsx
@@ -257,11 +257,9 @@ describe("Society of Mind review card", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getAllByText("Actors and Activities")).not.toHaveLength(0);
+    expect(screen.getByRole("button", { name: "Agree" })).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Approve move" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Reject proposed move" }),
+      screen.getByRole("button", { name: "Disagree" }),
     ).toBeInTheDocument();
     expect(
       screen.queryByText(/advisory candidate home/i),
@@ -271,7 +269,7 @@ describe("Society of Mind review card", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("uses explicit same-activity choices for possible synonyms", () => {
+  it("uses the same verdict choices for possible synonyms", () => {
     const synonymCard: SomReviewCard = {
       proposalId: "synonym-1",
       datasetVersion: "dataset-1",
@@ -302,15 +300,13 @@ describe("Society of Mind review card", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Same activity" })).toBeVisible();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Different activities" }),
-    );
+    expect(screen.getByRole("button", { name: "Agree" })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Disagree" }));
     expect(
       screen.getByLabelText(/What meaningfully distinguishes/i),
     ).toBeVisible();
     expect(
-      screen.getByRole("button", { name: "Save as different activities" }),
+      screen.getByRole("button", { name: "Save disagreement" }),
     ).toBeDisabled();
   });
 
@@ -369,11 +365,9 @@ describe("Society of Mind review card", () => {
     expect(
       screen.queryByText(/parent that is too broad/i),
     ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Agree" })).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Approve move" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Reject proposed move" }),
+      screen.getByRole("button", { name: "Disagree" }),
     ).toBeInTheDocument();
   });
 

--- a/__tests__/components/SomReview/ReviewHistorySelect.test.tsx
+++ b/__tests__/components/SomReview/ReviewHistorySelect.test.tsx
@@ -91,6 +91,8 @@ describe("Review history selector", () => {
     fireEvent.mouseDown(
       screen.getByRole("combobox", { name: "Revise an earlier review" }),
     );
-    expect(screen.getByText(/Agreed \| Fast-tracked/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Agreed \| Staged for checkpoint/),
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
+++ b/__tests__/components/SomReview/ReviewLinkedWorkflow.test.tsx
@@ -177,14 +177,16 @@ describe("linked proposal review journey", () => {
     );
   });
 
-  it("opens the exact follow-up and returns to the preserved source queue", async () => {
+  it("opens the exact follow-up automatically and continues without a handoff", async () => {
     window.localStorage.setItem(
-      "som-review-trusted-propagation-reviewer-1",
+      "som-review-continuous-expert-reviewer-1",
       "true",
     );
     const postMock = Post as jest.Mock;
+    let overviewCalls = 0;
     postMock.mockImplementation((url: string, body: any) => {
       if (url === "/som-review/overview") {
+        overviewCalls += 1;
         return Promise.resolve({
           ...overviewMetadata,
           canDeliberate: false,
@@ -199,8 +201,8 @@ describe("linked proposal review journey", () => {
               label: "10. Wrong place within Sub-branch",
               stage: "within-branch",
               robTaskIds: [11],
-              reviewed: 0,
-              pending: 1,
+              reviewed: overviewCalls > 1 ? 1 : 0,
+              pending: overviewCalls > 1 ? 0 : 1,
               waiting: 0,
               notApplicable: 0,
               total: 1,
@@ -212,9 +214,9 @@ describe("linked proposal review journey", () => {
               label: "14. Review approved relocations",
               stage: "final-action",
               robTaskIds: [11],
-              reviewed: 0,
+              reviewed: overviewCalls > 1 ? 1 : 0,
               pending: 0,
-              waiting: 1,
+              waiting: overviewCalls > 1 ? 0 : 1,
               notApplicable: 0,
               total: 1,
               enabled: true,
@@ -305,15 +307,6 @@ describe("linked proposal review journey", () => {
       ),
     );
 
-    expect(
-      await screen.findByText("Continue with the related decision"),
-    ).toBeInTheDocument();
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: `Review this next: ${followUp.question}`,
-      }),
-    );
-
     await waitFor(() =>
       expect(postMock).toHaveBeenCalledWith("/som-review/session", {
         datasetId: "buy-title-followup",
@@ -325,21 +318,20 @@ describe("linked proposal review journey", () => {
       await screen.findByRole("button", { name: "Submit relocation-1" }),
     );
 
-    expect(
-      await screen.findByText("Related decisions completed"),
-    ).toBeInTheDocument();
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Return to 10. Wrong place within Sub-branch",
-      }),
-    );
-
     await waitFor(() =>
-      expect(postMock).toHaveBeenLastCalledWith("/som-review/session", {
-        datasetId: "buy-title-followup",
-        issueType: "placement",
-      }),
+      expect(
+        postMock.mock.calls.filter(([url]) => url === "/som-review/overview"),
+      ).toHaveLength(2),
     );
+    expect(
+      await screen.findByRole("heading", { name: "Proposal review" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Continue with the related decision"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Related decisions completed"),
+    ).not.toBeInTheDocument();
   });
 
   it("replaces queue progress with an unambiguous saved-answer status while revising", async () => {

--- a/__tests__/components/SomReview/TrustedPropagationControl.test.tsx
+++ b/__tests__/components/SomReview/TrustedPropagationControl.test.tsx
@@ -7,21 +7,21 @@ import "@testing-library/jest-dom";
 
 import TrustedPropagationControl from "../../../src/components/SomReview/TrustedPropagationControl";
 
-describe("trusted propagation control", () => {
-  it("starts in review-only mode and requires an explicit opt-in", () => {
+describe("continuous expert review control", () => {
+  it("explains continuous review and lets the reviewer change navigation mode", () => {
     const onChange = jest.fn();
     const { rerender } = render(
       <TrustedPropagationControl enabled={false} onChange={onChange} />,
     );
 
-    expect(screen.getByText("Review only")).toBeInTheDocument();
-    expect(screen.getByText(/separate batch application/i)).toBeInTheDocument();
+    expect(screen.getByText("Manual navigation")).toBeInTheDocument();
+    expect(screen.getByText(/regeneration checkpoint/i)).toBeInTheDocument();
     fireEvent.click(
-      screen.getByRole("checkbox", { name: "Trusted-reviewer fast path" }),
+      screen.getByRole("checkbox", { name: "Continuous expert review" }),
     );
     expect(onChange).toHaveBeenCalledWith(true);
 
     rerender(<TrustedPropagationControl enabled onChange={onChange} />);
-    expect(screen.getByText("Fast path on")).toBeInTheDocument();
+    expect(screen.getByText("Continuous review on")).toBeInTheDocument();
   });
 });

--- a/__tests__/lib/somReview/sanitize.test.ts
+++ b/__tests__/lib/somReview/sanitize.test.ts
@@ -130,8 +130,8 @@ describe("Society of Mind reviewer card blinding", () => {
       currentState: '"Sell Service" is currently under "Sell (Information)".',
       proposedState:
         '"Sell Service" appears to belong under the more specific category "Actors and Activities".',
-      agreeLabel: "Approve move",
-      disagreeLabel: "Reject proposed move",
+      agreeLabel: "Agree",
+      disagreeLabel: "Disagree",
     });
     expect(JSON.stringify(card)).not.toMatch(
       /advisory candidate home|exact move remains|separate human decision|H1/i,
@@ -182,8 +182,8 @@ describe("Society of Mind reviewer card blinding", () => {
         'Should "Rent Equipment" move from "Lease (Physical Object)" to "Rent out" in the Sell sub-branch?',
       proposedState:
         'Move "Rent Equipment" to "Rent out" because its evidence expresses a provider-side "Sell" action.',
-      agreeLabel: "Approve move",
-      disagreeLabel: "Reject proposed move",
+      agreeLabel: "Agree",
+      disagreeLabel: "Disagree",
       context: {
         currentPathTitles: [
           "Buy",
@@ -234,8 +234,8 @@ describe("Society of Mind reviewer card blinding", () => {
         'Do these 2 activities use "Market" as a different main action from the "Sell" action?',
       proposedState:
         'These activities appear to use "Market" as a different main action from the "Sell" action; "Promote" is the suggested category.',
-      agreeLabel: "Approve all moves",
-      disagreeLabel: "Review individually",
+      agreeLabel: "Agree",
+      disagreeLabel: "Disagree",
     });
     expect(card.reviewerView.context).toMatchObject({
       candidateHome: "Promote",

--- a/artifacts/rob-semantic-coverage-2026-08-04/README.md
+++ b/artifacts/rob-semantic-coverage-2026-08-04/README.md
@@ -1,0 +1,18 @@
+# Rob semantic-coverage checkpoint
+
+This checkpoint captures every current expert judgment in the Sell semantic
+coverage round. Response carry-forward is applied only to the eight exact
+relocation decisions that were replaced by equivalent one-step move cards.
+The broader retired diagnoses remain visible as historical responses but are
+not treated as additional approvals.
+
+The current round is complete: seven whole-node moves were accepted, one move
+requires an evidence-level split, two evidence specializations were accepted,
+and one specialization title was corrected. The ontology has not been mutated
+from these files. `checkpoint-plan.json` deliberately sets
+`applicationAllowed` to `false` until the two expert corrections have been
+regenerated and the resulting Sell outline has been inspected.
+
+Rob's ownership-versus-temporary-use suggestion is recorded as a separate
+collection-only design candidate. It must reorganize existing direct children;
+it must not recreate collection labels as ontology activity nodes.

--- a/artifacts/rob-semantic-coverage-2026-08-04/checkpoint-plan.json
+++ b/artifacts/rob-semantic-coverage-2026-08-04/checkpoint-plan.json
@@ -1,0 +1,131 @@
+{
+  "schemaVersion": "som-semantic-regeneration-checkpoint-v1",
+  "createdAt": "2026-08-04T21:26:06.000Z",
+  "status": "regeneration-required-before-application",
+  "applicationAllowed": false,
+  "sourceDataset": {
+    "version": "sell-rob-semantic-coverage-2026-07-29-v1",
+    "manifestSha256": "de9848c5ee2dc24f5a3c51be2dc781696de3f3a094f71befd10a3377bed6b5d9"
+  },
+  "sourceOntology": {
+    "uri": "firestore://ontology-41607/final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+    "snapshotSha256": "96161f04fb1a4b146b79256be16ba2bebefcb9892308025b9937a400699fa884"
+  },
+  "benchmarks": [
+    {
+      "file": "rob-cross-branch-recall.json",
+      "sha256": "012e69241761c3bde525270b3eed40171c727006d0a536f32a14ae3ee7f9de55",
+      "reviewed": 8,
+      "agreed": 7,
+      "disagreed": 1
+    },
+    {
+      "file": "rob-evidence-specialization.json",
+      "sha256": "fe09999b5fbf6eac0f4800fc76649d9f819bb915938bf57940f8cea9b203d5b0",
+      "reviewed": 3,
+      "agreed": 2,
+      "disagreed": 1
+    }
+  ],
+  "acceptedWholeNodeMoves": [
+    {
+      "proposalId": "som-756a156508bbc6756859",
+      "nodeId": "d3b13d5a832ae6660a02a7b8a5e3",
+      "title": "Lease Property",
+      "from": "Lease (Physical Object)",
+      "to": "Rent out"
+    },
+    {
+      "proposalId": "som-465816b46486fcf5d2bf",
+      "nodeId": "e9453292b42a36f1ee44bfeb9a9b",
+      "title": "Rent Clothing",
+      "from": "Lease (Physical Object)",
+      "to": "Rent out"
+    },
+    {
+      "proposalId": "som-0b734eb0be482c04eef1",
+      "nodeId": "46c6136396258d624dc13f6fcf19",
+      "title": "Rent Box",
+      "from": "Lease (Physical Object)",
+      "to": "Rent out"
+    },
+    {
+      "proposalId": "som-2712192fe57dd0dbf045",
+      "nodeId": "3ed2848b752f08d507bdd822d9c4",
+      "title": "Rent Merchandise",
+      "from": "Lease (Physical Object)",
+      "to": "Rent out"
+    },
+    {
+      "proposalId": "som-ed212c77f550f328ce1d",
+      "nodeId": "2c0e7f8c6385a583070f537c100b",
+      "title": "Rent Accommodation",
+      "from": "Lease (Physical Object)",
+      "to": "Rent out"
+    },
+    {
+      "proposalId": "som-b8c5ba1c90158e6784c7",
+      "nodeId": "fa9f0b2b8332ea554de104de2f23",
+      "title": "Rent Supply",
+      "from": "Lease (Physical Object)",
+      "to": "Rent out"
+    },
+    {
+      "proposalId": "som-b876e1950ee85f53d266",
+      "nodeId": "ec07d44c56346febb6e2c5d80c0f",
+      "title": "Rent Item",
+      "from": "Lease (Physical Object)",
+      "to": "Rent out"
+    }
+  ],
+  "expertCorrections": [
+    {
+      "proposalId": "som-f7564256227086773936",
+      "type": "split-evidence-by-transaction-direction",
+      "nodeId": "03d8487c224612ee7a930e4785f0",
+      "title": "Rent Equipment",
+      "providerSideEvidenceToPlaceUnderRentOut": [
+        "(O*Net) 13170",
+        "(O*Net) 5127"
+      ],
+      "buyerSideEvidenceToKeepUnderLease": ["(O*Net) 17739"],
+      "requiresRegeneration": true
+    },
+    {
+      "proposalId": "som-c3c0349e84b76c8ea6e1",
+      "type": "correct-specialization-title",
+      "rejectedTitle": "Sell Non-Pharmaceutical Merchandise",
+      "acceptedCorrection": "Sell Non-Pharmaceutical Products",
+      "parentTitle": "Sell Products",
+      "requiresRegeneration": true
+    }
+  ],
+  "acceptedEvidenceSpecializations": [
+    {
+      "proposalId": "som-1e8507f5e5299d55a476",
+      "sourceTaskId": "6284bf15ece4581e8d4f0b41ca68",
+      "targetTitle": "Sell Funeral Products",
+      "targetStatus": "existing"
+    },
+    {
+      "proposalId": "som-c7d33b475e51802c7ba0",
+      "sourceTaskId": "6284bf15ece4581e8d4f0b41ca68",
+      "targetTitle": "Sell Funeral Services",
+      "targetStatus": "new"
+    }
+  ],
+  "pendingCollectionDesign": {
+    "status": "requires-separate-review",
+    "policy": "Collections may reorganize existing direct children but may not create activity nodes or hierarchy edges.",
+    "candidate": "After regeneration, show one collection-only proposal that assigns explicit Rent/Lease activities to temporary usage and treats the remaining Sell children as ownership by default.",
+    "forbiddenInterpretation": "Do not recreate Sell ownership or Sell temporary use as activity nodes."
+  },
+  "nextSteps": [
+    "Clone the pinned source ontology into a new checkpoint application.",
+    "Apply the seven accepted whole-node moves.",
+    "Regenerate Rent Equipment so provider-side and buyer-side evidence remain in their correct transaction directions.",
+    "Apply the two accepted funeral specializations and regenerate the corrected non-pharmaceutical-products specialization.",
+    "Emit and inspect the revised Sell outline before any production application.",
+    "Regenerate downstream empty-node, empty-collection, and collection-design review items from that revised snapshot."
+  ]
+}

--- a/artifacts/rob-semantic-coverage-2026-08-04/rob-cross-branch-recall.json
+++ b/artifacts/rob-semantic-coverage-2026-08-04/rob-cross-branch-recall.json
@@ -1,0 +1,640 @@
+{
+  "schemaVersion": "som-reviewer-benchmark-v1",
+  "exportedAt": "2026-08-04T21:19:30.821Z",
+  "firestoreProjectId": "ontology-41607",
+  "datasetVersion": "sell-rob-semantic-coverage-2026-07-29-v1",
+  "sourceOntology": "firestore://ontology-41607/final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+  "sourceOntologySha256": "96161f04fb1a4b146b79256be16ba2bebefcb9892308025b9937a400699fa884",
+  "issueType": "cross-branch-recall",
+  "reviewer": {
+    "label": "rob"
+  },
+  "counts": {
+    "expected": 8,
+    "reviewed": 8,
+    "agreed": 7,
+    "disagreed": 1,
+    "missing": 0,
+    "orphanedHistoricalResponses": 8
+  },
+  "missingProposalIds": [],
+  "orphanedResponses": [
+    {
+      "proposalId": "som-03c75772f02aef876ae1",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1
+    },
+    {
+      "proposalId": "som-152c3617d61c68732b2b",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1
+    },
+    {
+      "proposalId": "som-2b26108a6a522921055e",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1
+    },
+    {
+      "proposalId": "som-530b4d746f060412f399",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1
+    },
+    {
+      "proposalId": "som-5d15d4f7220de932be23",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1
+    },
+    {
+      "proposalId": "som-5fbed1619f03f4a1bc30",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1
+    },
+    {
+      "proposalId": "som-cd8212e05c8a5640b40d",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1
+    },
+    {
+      "proposalId": "som-e028ab9536c3a5dcf0d5",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1
+    }
+  ],
+  "sourceNodeEvidence": [
+    {
+      "nodeId": "d3b13d5a832ae6660a02a7b8a5e3",
+      "title": "Lease Property",
+      "appName": "final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+      "specializations": [
+        {
+          "collectionName": "main",
+          "nodes": [
+            {
+              "nodeId": "0fd2fc376658f99acd0f6b8b792d",
+              "linkTitle": "(O*Net) 2470 - Rent or lease properties on behalf of clients.",
+              "title": "(O*Net) 2470 - Rent or lease properties on behalf of clients.",
+              "oNet": false,
+              "generalizationTitles": [
+                "Lease Property"
+              ]
+            },
+            {
+              "nodeId": "81fa404c77270aeaef087763f5ec",
+              "linkTitle": "(O*Net) 4612 - Rent properties or manage rental properties.",
+              "title": "(O*Net) 4612 - Rent properties or manage rental properties.",
+              "oNet": false,
+              "generalizationTitles": [
+                "Lease Property",
+                "Manage Property"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeId": "2c0e7f8c6385a583070f537c100b",
+      "title": "Rent Accommodation",
+      "appName": "final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+      "specializations": [
+        {
+          "collectionName": "main",
+          "nodes": [
+            {
+              "nodeId": "7b743c9698fc94cd1ab2dc457a3f",
+              "linkTitle": "(O*Net) 1114 - Show, rent, or assign accommodations.",
+              "title": "(O*Net) 1114 - Show, rent, or assign accommodations.",
+              "oNet": false,
+              "generalizationTitles": [
+                "Show Accommodation",
+                "Rent Accommodation",
+                "Assign Accommodation"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeId": "46c6136396258d624dc13f6fcf19",
+      "title": "Rent Box",
+      "appName": "final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+      "specializations": [
+        {
+          "collectionName": "main",
+          "nodes": [
+            {
+              "nodeId": "ec7e8256c4b3057da37735673d0c",
+              "linkTitle": "(O*Net) 11332 - Rent post office boxes to customers.",
+              "title": "(O*Net) 11332 - Rent post office boxes to customers.",
+              "oNet": false,
+              "generalizationTitles": [
+                "Rent Box"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeId": "e9453292b42a36f1ee44bfeb9a9b",
+      "title": "Rent Clothing",
+      "appName": "final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+      "specializations": [
+        {
+          "collectionName": "main",
+          "nodes": [
+            {
+              "nodeId": "d2cc3a79b128d4154994d5533812",
+              "linkTitle": "(O*Net) 13170 - Sell or rent equipment, clothing, and supplies related to expeditions.",
+              "title": "(O*Net) 13170 - Sell or rent equipment, clothing, and supplies related to expeditions.",
+              "oNet": false,
+              "generalizationTitles": [
+                "Rent Clothing",
+                "Rent Equipment",
+                "Rent Supply",
+                "Sell Expedition Clothing",
+                "Sell Expedition Equipment",
+                "Sell Expedition Supplies"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeId": "03d8487c224612ee7a930e4785f0",
+      "title": "Rent Equipment",
+      "appName": "final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+      "specializations": [
+        {
+          "collectionName": "main",
+          "nodes": [
+            {
+              "nodeId": "d2cc3a79b128d4154994d5533812",
+              "linkTitle": "(O*Net) 13170 - Sell or rent equipment, clothing, and supplies related to expeditions.",
+              "title": "(O*Net) 13170 - Sell or rent equipment, clothing, and supplies related to expeditions.",
+              "oNet": false,
+              "generalizationTitles": [
+                "Rent Clothing",
+                "Rent Equipment",
+                "Rent Supply",
+                "Sell Expedition Clothing",
+                "Sell Expedition Equipment",
+                "Sell Expedition Supplies"
+              ]
+            },
+            {
+              "nodeId": "64fc66fb71ca60ed1fff6a00ff0a",
+              "linkTitle": "(O*Net) 17739 - Purchase or rent equipment for solar energy system installation.",
+              "title": "(O*Net) 17739 - Purchase or rent equipment for solar energy system installation.",
+              "oNet": false,
+              "generalizationTitles": [
+                "Purchase Equipment",
+                "Rent Equipment"
+              ]
+            },
+            {
+              "nodeId": "9a2f1cc2c19eec098cb1f9382b5e",
+              "linkTitle": "(O*Net) 5127 - Rent, sell, or issue sporting equipment and supplies, such as bowling shoes, golf balls, swimming suits, or beach chairs.",
+              "title": "(O*Net) 5127 - Rent, sell, or issue sporting equipment and supplies, such as bowling shoes, golf balls, swimming suits, or beach chairs.",
+              "oNet": false,
+              "generalizationTitles": [
+                "Rent Equipment",
+                "Sell Sporting Equipment",
+                "Supply Equipment"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeId": "ec07d44c56346febb6e2c5d80c0f",
+      "title": "Rent Item",
+      "appName": "final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+      "specializations": [
+        {
+          "collectionName": "main",
+          "nodes": [
+            {
+              "nodeId": "3779c527b0e45610f8d842d2576e",
+              "linkTitle": "(O*Net) 690 - Rent items, arrange for provision of services to customers, and accept returns.",
+              "title": "(O*Net) 690 - Rent items, arrange for provision of services to customers, and accept returns.",
+              "oNet": false,
+              "generalizationTitles": [
+                "Rent Item",
+                "Accept Return",
+                "Arrange Service"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeId": "3ed2848b752f08d507bdd822d9c4",
+      "title": "Rent Merchandise",
+      "appName": "final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+      "specializations": [
+        {
+          "collectionName": "main",
+          "nodes": [
+            {
+              "nodeId": "2a3acf7a2c408321831e68d91aa8",
+              "linkTitle": "(O*Net) 717 - Rent merchandise to customers.",
+              "title": "(O*Net) 717 - Rent merchandise to customers.",
+              "oNet": false,
+              "generalizationTitles": [
+                "Rent Merchandise"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeId": "fa9f0b2b8332ea554de104de2f23",
+      "title": "Rent Supply",
+      "appName": "final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+      "specializations": [
+        {
+          "collectionName": "main",
+          "nodes": [
+            {
+              "nodeId": "d2cc3a79b128d4154994d5533812",
+              "linkTitle": "(O*Net) 13170 - Sell or rent equipment, clothing, and supplies related to expeditions.",
+              "title": "(O*Net) 13170 - Sell or rent equipment, clothing, and supplies related to expeditions.",
+              "oNet": false,
+              "generalizationTitles": [
+                "Rent Clothing",
+                "Rent Equipment",
+                "Rent Supply",
+                "Sell Expedition Clothing",
+                "Sell Expedition Equipment",
+                "Sell Expedition Supplies"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "judgments": [
+    {
+      "proposalId": "som-b876e1950ee85f53d266",
+      "reviewMode": "proposed-change",
+      "subjectNodeId": "ec07d44c56346febb6e2c5d80c0f",
+      "parentNodeId": "412f9a026c089649ff3f27dfd9f6",
+      "subjectTitle": "Rent Item",
+      "subjectParentTitle": "Lease (Physical Object)",
+      "currentTitle": "",
+      "proposedTitle": "",
+      "currentParentTitle": "Lease (Physical Object)",
+      "proposedParentTitle": "Rent out",
+      "context": {
+        "type": "placement-comparison",
+        "nodeTitle": "Rent Item",
+        "currentParentTitle": "Lease (Physical Object)",
+        "candidateHome": "Rent out",
+        "placementIssue": "missing-from-branch",
+        "sourceTasks": [
+          "(O*Net) 690 - Rent items, arrange for provision of services to customers, and accept returns."
+        ],
+        "currentPathTitles": [
+          "Buy",
+          "Rent (pay for time-limited use)",
+          "Lease",
+          "Lease (Physical Object)",
+          "Rent Item"
+        ],
+        "proposedPathTitles": [
+          "Sell",
+          "Rent out",
+          "Rent Item"
+        ]
+      },
+      "linkedTasks": [],
+      "proposedNodes": [],
+      "agentReasoning": "Direct source evidence uses rent or lease in a provider-side context: '(O*Net) 690 - Rent items, arrange for provision of services to customers, and accept returns.'.",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1,
+      "carriedForwardFromProposalId": "som-2349d16033acaead6103"
+    },
+    {
+      "proposalId": "som-2712192fe57dd0dbf045",
+      "reviewMode": "proposed-change",
+      "subjectNodeId": "3ed2848b752f08d507bdd822d9c4",
+      "parentNodeId": "412f9a026c089649ff3f27dfd9f6",
+      "subjectTitle": "Rent Merchandise",
+      "subjectParentTitle": "Lease (Physical Object)",
+      "currentTitle": "",
+      "proposedTitle": "",
+      "currentParentTitle": "Lease (Physical Object)",
+      "proposedParentTitle": "Rent out",
+      "context": {
+        "type": "placement-comparison",
+        "nodeTitle": "Rent Merchandise",
+        "currentParentTitle": "Lease (Physical Object)",
+        "candidateHome": "Rent out",
+        "placementIssue": "missing-from-branch",
+        "sourceTasks": [
+          "(O*Net) 717 - Rent merchandise to customers."
+        ],
+        "currentPathTitles": [
+          "Buy",
+          "Rent (pay for time-limited use)",
+          "Lease",
+          "Lease (Physical Object)",
+          "Rent Merchandise"
+        ],
+        "proposedPathTitles": [
+          "Sell",
+          "Rent out",
+          "Rent Merchandise"
+        ]
+      },
+      "linkedTasks": [],
+      "proposedNodes": [],
+      "agentReasoning": "Direct source evidence uses rent or lease in a provider-side context: '(O*Net) 717 - Rent merchandise to customers.'.",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1,
+      "carriedForwardFromProposalId": "som-3ce0cf5a80839238edf9"
+    },
+    {
+      "proposalId": "som-0b734eb0be482c04eef1",
+      "reviewMode": "proposed-change",
+      "subjectNodeId": "46c6136396258d624dc13f6fcf19",
+      "parentNodeId": "412f9a026c089649ff3f27dfd9f6",
+      "subjectTitle": "Rent Box",
+      "subjectParentTitle": "Lease (Physical Object)",
+      "currentTitle": "",
+      "proposedTitle": "",
+      "currentParentTitle": "Lease (Physical Object)",
+      "proposedParentTitle": "Rent out",
+      "context": {
+        "type": "placement-comparison",
+        "nodeTitle": "Rent Box",
+        "currentParentTitle": "Lease (Physical Object)",
+        "candidateHome": "Rent out",
+        "placementIssue": "missing-from-branch",
+        "sourceTasks": [
+          "(O*Net) 11332 - Rent post office boxes to customers."
+        ],
+        "currentPathTitles": [
+          "Buy",
+          "Rent (pay for time-limited use)",
+          "Lease",
+          "Lease (Physical Object)",
+          "Rent Box"
+        ],
+        "proposedPathTitles": [
+          "Sell",
+          "Rent out",
+          "Rent Box"
+        ]
+      },
+      "linkedTasks": [],
+      "proposedNodes": [],
+      "agentReasoning": "Direct source evidence uses rent or lease in a provider-side context: '(O*Net) 11332 - Rent post office boxes to customers.'.",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1,
+      "carriedForwardFromProposalId": "som-27afd77fd2d9b2564529"
+    },
+    {
+      "proposalId": "som-756a156508bbc6756859",
+      "reviewMode": "proposed-change",
+      "subjectNodeId": "d3b13d5a832ae6660a02a7b8a5e3",
+      "parentNodeId": "412f9a026c089649ff3f27dfd9f6",
+      "subjectTitle": "Lease Property",
+      "subjectParentTitle": "Lease (Physical Object)",
+      "currentTitle": "",
+      "proposedTitle": "",
+      "currentParentTitle": "Lease (Physical Object)",
+      "proposedParentTitle": "Rent out",
+      "context": {
+        "type": "placement-comparison",
+        "nodeTitle": "Lease Property",
+        "currentParentTitle": "Lease (Physical Object)",
+        "candidateHome": "Rent out",
+        "placementIssue": "missing-from-branch",
+        "sourceTasks": [
+          "(O*Net) 2470 - Rent or lease properties on behalf of clients.",
+          "(O*Net) 4612 - Rent properties or manage rental properties."
+        ],
+        "currentPathTitles": [
+          "Buy",
+          "Rent (pay for time-limited use)",
+          "Lease",
+          "Lease (Physical Object)",
+          "Lease Property"
+        ],
+        "proposedPathTitles": [
+          "Sell",
+          "Rent out",
+          "Lease Property"
+        ]
+      },
+      "linkedTasks": [],
+      "proposedNodes": [],
+      "agentReasoning": "Direct source evidence uses rent or lease in a provider-side context: '(O*Net) 2470 - Rent or lease properties on behalf of clients.'; '(O*Net) 4612 - Rent properties or manage rental properties.'.",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1,
+      "carriedForwardFromProposalId": "som-a129fc5e2012529a5814"
+    },
+    {
+      "proposalId": "som-ed212c77f550f328ce1d",
+      "reviewMode": "proposed-change",
+      "subjectNodeId": "2c0e7f8c6385a583070f537c100b",
+      "parentNodeId": "412f9a026c089649ff3f27dfd9f6",
+      "subjectTitle": "Rent Accommodation",
+      "subjectParentTitle": "Lease (Physical Object)",
+      "currentTitle": "",
+      "proposedTitle": "",
+      "currentParentTitle": "Lease (Physical Object)",
+      "proposedParentTitle": "Rent out",
+      "context": {
+        "type": "placement-comparison",
+        "nodeTitle": "Rent Accommodation",
+        "currentParentTitle": "Lease (Physical Object)",
+        "candidateHome": "Rent out",
+        "placementIssue": "missing-from-branch",
+        "sourceTasks": [
+          "(O*Net) 1114 - Show, rent, or assign accommodations."
+        ],
+        "currentPathTitles": [
+          "Buy",
+          "Rent (pay for time-limited use)",
+          "Lease",
+          "Lease (Physical Object)",
+          "Rent Accommodation"
+        ],
+        "proposedPathTitles": [
+          "Sell",
+          "Rent out",
+          "Rent Accommodation"
+        ]
+      },
+      "linkedTasks": [],
+      "proposedNodes": [],
+      "agentReasoning": "Direct source evidence uses rent or lease in a provider-side context: '(O*Net) 1114 - Show, rent, or assign accommodations.'.",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1,
+      "carriedForwardFromProposalId": "som-3f7e33c2a810735c6d56"
+    },
+    {
+      "proposalId": "som-f7564256227086773936",
+      "reviewMode": "proposed-change",
+      "subjectNodeId": "03d8487c224612ee7a930e4785f0",
+      "parentNodeId": "412f9a026c089649ff3f27dfd9f6",
+      "subjectTitle": "Rent Equipment",
+      "subjectParentTitle": "Lease (Physical Object)",
+      "currentTitle": "",
+      "proposedTitle": "",
+      "currentParentTitle": "Lease (Physical Object)",
+      "proposedParentTitle": "Rent out",
+      "context": {
+        "type": "placement-comparison",
+        "nodeTitle": "Rent Equipment",
+        "currentParentTitle": "Lease (Physical Object)",
+        "candidateHome": "Rent out",
+        "placementIssue": "missing-from-branch",
+        "sourceTasks": [
+          "(O*Net) 13170 - Sell or rent equipment, clothing, and supplies related to expeditions.",
+          "(O*Net) 17739 - Purchase or rent equipment for solar energy system installation.",
+          "(O*Net) 5127 - Rent, sell, or issue sporting equipment and supplies, such as bowling shoes, golf balls, swimming suits, or beach chairs."
+        ],
+        "currentPathTitles": [
+          "Buy",
+          "Rent (pay for time-limited use)",
+          "Lease",
+          "Lease (Physical Object)",
+          "Rent Equipment"
+        ],
+        "proposedPathTitles": [
+          "Sell",
+          "Rent out",
+          "Rent Equipment"
+        ]
+      },
+      "linkedTasks": [],
+      "proposedNodes": [],
+      "agentReasoning": "Direct source evidence uses rent or lease in a provider-side context: '(O*Net) 13170 - Sell or rent equipment, clothing, and supplies related to expeditions.'; '(O*Net) 5127 - Rent, sell, or issue sporting equipment and supplies, such as bowling shoes, golf balls, swimming suits, or beach chairs.'.",
+      "decision": "disagree",
+      "disagreementReason": "O*NET items 13170 and 5127 should be moved to Rent out. But O*NET item 17739 should be kept in its original place.",
+      "suggestedCorrection": "O*NET 13170 and 5127 move so they are under Rent equipment. O*NET 17739 stays under Lease.",
+      "revisionCount": 1,
+      "carriedForwardFromProposalId": "som-15fba4ccfad0dd29cbc5"
+    },
+    {
+      "proposalId": "som-465816b46486fcf5d2bf",
+      "reviewMode": "proposed-change",
+      "subjectNodeId": "e9453292b42a36f1ee44bfeb9a9b",
+      "parentNodeId": "412f9a026c089649ff3f27dfd9f6",
+      "subjectTitle": "Rent Clothing",
+      "subjectParentTitle": "Lease (Physical Object)",
+      "currentTitle": "",
+      "proposedTitle": "",
+      "currentParentTitle": "Lease (Physical Object)",
+      "proposedParentTitle": "Rent out",
+      "context": {
+        "type": "placement-comparison",
+        "nodeTitle": "Rent Clothing",
+        "currentParentTitle": "Lease (Physical Object)",
+        "candidateHome": "Rent out",
+        "placementIssue": "missing-from-branch",
+        "sourceTasks": [
+          "(O*Net) 13170 - Sell or rent equipment, clothing, and supplies related to expeditions."
+        ],
+        "currentPathTitles": [
+          "Buy",
+          "Rent (pay for time-limited use)",
+          "Lease",
+          "Lease (Physical Object)",
+          "Rent Clothing"
+        ],
+        "proposedPathTitles": [
+          "Sell",
+          "Rent out",
+          "Rent Clothing"
+        ]
+      },
+      "linkedTasks": [],
+      "proposedNodes": [],
+      "agentReasoning": "Direct source evidence uses rent or lease in a provider-side context: '(O*Net) 13170 - Sell or rent equipment, clothing, and supplies related to expeditions.'.",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1,
+      "carriedForwardFromProposalId": "som-b0618ed6153588a186ba"
+    },
+    {
+      "proposalId": "som-b8c5ba1c90158e6784c7",
+      "reviewMode": "proposed-change",
+      "subjectNodeId": "fa9f0b2b8332ea554de104de2f23",
+      "parentNodeId": "412f9a026c089649ff3f27dfd9f6",
+      "subjectTitle": "Rent Supply",
+      "subjectParentTitle": "Lease (Physical Object)",
+      "currentTitle": "",
+      "proposedTitle": "",
+      "currentParentTitle": "Lease (Physical Object)",
+      "proposedParentTitle": "Rent out",
+      "context": {
+        "type": "placement-comparison",
+        "nodeTitle": "Rent Supply",
+        "currentParentTitle": "Lease (Physical Object)",
+        "candidateHome": "Rent out",
+        "placementIssue": "missing-from-branch",
+        "sourceTasks": [
+          "(O*Net) 13170 - Sell or rent equipment, clothing, and supplies related to expeditions."
+        ],
+        "currentPathTitles": [
+          "Buy",
+          "Rent (pay for time-limited use)",
+          "Lease",
+          "Lease (Physical Object)",
+          "Rent Supply"
+        ],
+        "proposedPathTitles": [
+          "Sell",
+          "Rent out",
+          "Rent Supply"
+        ]
+      },
+      "linkedTasks": [],
+      "proposedNodes": [],
+      "agentReasoning": "Direct source evidence uses rent or lease in a provider-side context: '(O*Net) 13170 - Sell or rent equipment, clothing, and supplies related to expeditions.'.",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1,
+      "carriedForwardFromProposalId": "som-fecda86541f0949e2d50"
+    }
+  ]
+}

--- a/artifacts/rob-semantic-coverage-2026-08-04/rob-evidence-specialization.json
+++ b/artifacts/rob-semantic-coverage-2026-08-04/rob-evidence-specialization.json
@@ -1,0 +1,174 @@
+{
+  "schemaVersion": "som-reviewer-benchmark-v1",
+  "exportedAt": "2026-08-04T21:19:32.499Z",
+  "firestoreProjectId": "ontology-41607",
+  "datasetVersion": "sell-rob-semantic-coverage-2026-07-29-v1",
+  "sourceOntology": "firestore://ontology-41607/final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+  "sourceOntologySha256": "96161f04fb1a4b146b79256be16ba2bebefcb9892308025b9937a400699fa884",
+  "issueType": "evidence-specialization",
+  "reviewer": {
+    "label": "rob"
+  },
+  "counts": {
+    "expected": 3,
+    "reviewed": 3,
+    "agreed": 2,
+    "disagreed": 1,
+    "missing": 0,
+    "orphanedHistoricalResponses": 0
+  },
+  "missingProposalIds": [],
+  "orphanedResponses": [],
+  "sourceNodeEvidence": [
+    {
+      "nodeId": "7d3b4037617aaee4825b696c3b59",
+      "title": "(O*Net) 1822 - Manage pharmacy operations, hiring or supervising staff, performing administrative duties, or buying or selling non-pharmaceutical merchandise.",
+      "appName": "final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+      "specializations": [
+        {
+          "collectionName": "main",
+          "nodes": []
+        }
+      ]
+    },
+    {
+      "nodeId": "6284bf15ece4581e8d4f0b41ca68",
+      "title": "(O*Net) 18843 - Sell funeral services, products, or merchandise to clients.",
+      "appName": "final-hierarchy-with-o*net-rob-structure-applied-2026-07-25",
+      "specializations": [
+        {
+          "collectionName": "main",
+          "nodes": []
+        }
+      ]
+    }
+  ],
+  "judgments": [
+    {
+      "proposalId": "som-c3c0349e84b76c8ea6e1",
+      "reviewMode": "proposed-change",
+      "subjectNodeId": "7d3b4037617aaee4825b696c3b59",
+      "parentNodeId": "126b0f1051d40fabc1a06aa627c7",
+      "subjectTitle": "(O*Net) 1822 - Manage pharmacy operations, hiring or supervising staff, performing administrative duties, or buying or selling non-pharmaceutical merchandise.",
+      "subjectParentTitle": "Sell Products",
+      "currentTitle": "",
+      "proposedTitle": "Sell Non-Pharmaceutical Merchandise",
+      "currentParentTitle": "",
+      "proposedParentTitle": "",
+      "context": {
+        "type": "evidence-specialization",
+        "genericNodeTitle": "Sell Products",
+        "sourceTask": "(O*Net) 1822 - Manage pharmacy operations, hiring or supervising staff, performing administrative duties, or buying or selling non-pharmaceutical merchandise.",
+        "currentParentTitles": [
+          "Buy Merchandise",
+          "Hire Staff",
+          "Manage Operation",
+          "Oversee Staff",
+          "Perform Duty",
+          "Sell Products"
+        ],
+        "proposedTitle": "Sell Non-Pharmaceutical Merchandise",
+        "proposedTitleStatus": "new",
+        "targetParentTitle": "Sell Products",
+        "removedParentTitles": [
+          "Sell Products"
+        ],
+        "retainedParentTitles": [
+          "Buy Merchandise",
+          "Hire Staff",
+          "Manage Operation",
+          "Oversee Staff",
+          "Perform Duty"
+        ]
+      },
+      "linkedTasks": [],
+      "proposedNodes": [],
+      "agentReasoning": "The task explicitly says \"non-pharmaceutical merchandise\", so the generic Sell Products assignment can be reviewed against a more specific activity.",
+      "decision": "disagree",
+      "disagreementReason": "I disagree with use of the word \"Merchandise.\" The prior term, \"Products,\" works well, and there is no reason to change it.",
+      "suggestedCorrection": "Sell Non-Pharmaceutical Products",
+      "revisionCount": 1,
+      "carriedForwardFromProposalId": ""
+    },
+    {
+      "proposalId": "som-1e8507f5e5299d55a476",
+      "reviewMode": "proposed-change",
+      "subjectNodeId": "6284bf15ece4581e8d4f0b41ca68",
+      "parentNodeId": "126b0f1051d40fabc1a06aa627c7",
+      "subjectTitle": "(O*Net) 18843 - Sell funeral services, products, or merchandise to clients.",
+      "subjectParentTitle": "Sell Products",
+      "currentTitle": "",
+      "proposedTitle": "Sell Funeral Products",
+      "currentParentTitle": "",
+      "proposedParentTitle": "",
+      "context": {
+        "type": "evidence-specialization",
+        "genericNodeTitle": "Sell Products",
+        "sourceTask": "(O*Net) 18843 - Sell funeral services, products, or merchandise to clients.",
+        "currentParentTitles": [
+          "Sell Funeral Products",
+          "Sell Products",
+          "Sell Services"
+        ],
+        "proposedTitle": "Sell Funeral Products",
+        "proposedTitleStatus": "existing",
+        "targetParentTitle": "Sell Funeral Products",
+        "removedParentTitles": [
+          "Sell Products"
+        ],
+        "retainedParentTitles": [
+          "Sell Funeral Products",
+          "Sell Services"
+        ]
+      },
+      "linkedTasks": [],
+      "proposedNodes": [],
+      "agentReasoning": "The task explicitly says \"funeral products\", so the generic Sell Products assignment can be reviewed against a more specific activity.",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1,
+      "carriedForwardFromProposalId": ""
+    },
+    {
+      "proposalId": "som-c7d33b475e51802c7ba0",
+      "reviewMode": "proposed-change",
+      "subjectNodeId": "6284bf15ece4581e8d4f0b41ca68",
+      "parentNodeId": "2bdf7edf2a4a6cb8ab52781f59f8",
+      "subjectTitle": "(O*Net) 18843 - Sell funeral services, products, or merchandise to clients.",
+      "subjectParentTitle": "Sell Services",
+      "currentTitle": "",
+      "proposedTitle": "Sell Funeral Services",
+      "currentParentTitle": "",
+      "proposedParentTitle": "",
+      "context": {
+        "type": "evidence-specialization",
+        "genericNodeTitle": "Sell Services",
+        "sourceTask": "(O*Net) 18843 - Sell funeral services, products, or merchandise to clients.",
+        "currentParentTitles": [
+          "Sell Funeral Products",
+          "Sell Products",
+          "Sell Services"
+        ],
+        "proposedTitle": "Sell Funeral Services",
+        "proposedTitleStatus": "new",
+        "targetParentTitle": "Sell Services",
+        "removedParentTitles": [
+          "Sell Services"
+        ],
+        "retainedParentTitles": [
+          "Sell Funeral Products",
+          "Sell Products"
+        ]
+      },
+      "linkedTasks": [],
+      "proposedNodes": [],
+      "agentReasoning": "The task explicitly says \"funeral services\", so the generic Sell Services assignment can be reviewed against a more specific activity.",
+      "decision": "agree",
+      "disagreementReason": "",
+      "suggestedCorrection": "",
+      "revisionCount": 1,
+      "carriedForwardFromProposalId": ""
+    }
+  ]
+}

--- a/docs/research/trusted-reviewer-propagation-policy-2026-08-02.md
+++ b/docs/research/trusted-reviewer-propagation-policy-2026-08-02.md
@@ -1,18 +1,22 @@
-# Trusted-reviewer propagation fast path
+# Continuous expert review and propagation checkpoints
 
 ## Decision addressed
 
-Rob asked whether answers from a reviewer judged to be reliable could propagate
-automatically to reduce review overhead. The first implementation treats this
-as a faster route from an individual judgment to a propagation draft. It does
-not copy an answer to a different proposal and does not write to the ontology.
+Rob asked whether answers from a reviewer judged to be reliable could be
+propagated quickly enough to review a sub-branch in one near-continuous session.
+The implementation now separates two operations: continuous traversal of work
+that has already been generated, and explicit regeneration checkpoints when an
+accepted answer changes the ontology or the downstream proposal set.
 
 ## Policy
 
 - Reliable-reviewer status is explicit and narrower than the reviewer role.
   It is assigned through a verified-email/UID allowlist or the Firebase custom
   claim `somReviewTrustedPropagator`.
-- The reviewer must opt in. The default remains review only.
+- Continuous expert review is enabled by default for an authorized reviewer in
+  the current round, and the reviewer can switch to manual queue navigation.
+- A saved answer advances directly to an already-generated dependent question.
+  When a queue ends, the next available queue starts without a handoff screen.
 - Only proposed changes in a current review round are eligible. Status-quo
   controls, manual checks, past rounds, and non-expert calibration responses are
   excluded.
@@ -22,8 +26,11 @@ not copy an answer to a different proposal and does not write to the ontology.
 - An edit updates the authorization. Undo retracts it. Both operations append
   immutable audit revisions.
 - A trusted answer becomes `ready` in a separate propagation draft. It does not
-  mutate the ontology. Application still requires a separately generated and
-  inspected snapshot-bound batch plan.
+  mutate the ontology by itself.
+- When accepted changes alter the ontology or require new model work, the
+  continuous session stops at a regeneration checkpoint. The checkpoint must
+  produce a new snapshot-bound application plan, revised ontology outline, and
+  downstream proposal set before review resumes.
 - A dependency means that one proposal unlocks another; it never means that the
   first answer can be copied to the second proposal.
 - Model confidence cannot grant reviewer reliability or propagation authority.
@@ -40,8 +47,8 @@ not copy an answer to a different proposal and does not write to the ontology.
 
 ## Open study decisions
 
-Before enabling the fast path for anyone beyond the initial expert pilot, the
-team should define the evidence required to classify a reviewer as reliable,
-the review period for that classification, periodic spot-check rates, and the
-error threshold that suspends fast-track access. Those thresholds are research
-parameters, not assumptions embedded in the application.
+Before enabling continuous propagation for anyone beyond the initial expert
+pilot, the team should define the evidence required to classify a reviewer as
+reliable, the review period for that classification, periodic spot-check rates,
+and the error threshold that suspends fast-track access. Those thresholds are
+research parameters, not assumptions embedded in the application.

--- a/scripts/som-review/export-reviewer-benchmark.mjs
+++ b/scripts/som-review/export-reviewer-benchmark.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
 const { loadEnvConfig } = require("@next/env");
@@ -48,6 +49,46 @@ function readJsonl(file) {
     .split("\n")
     .filter((line) => line.trim())
     .map((line) => JSON.parse(line));
+}
+
+function currentRecordsForIssue(records, manifest, issueType) {
+  const mappings = Array.isArray(manifest.responseCarryForward?.mappings)
+    ? manifest.responseCarryForward.mappings.filter(
+        (mapping) => mapping.targetIssueType === issueType,
+      )
+    : [];
+  const mappingBySource = new Map(
+    mappings.map((mapping) => [mapping.sourceProposalId, mapping]),
+  );
+  const selected = new Map();
+
+  for (const record of records) {
+    const mapping = mappingBySource.get(record.proposalId);
+    const carriedForward = Boolean(
+      mapping && record.issueType === mapping.sourceIssueType,
+    );
+    if (!carriedForward && record.issueType !== issueType) continue;
+
+    const projected = carriedForward
+      ? {
+          ...record,
+          proposalId: mapping.targetProposalId,
+          issueType: mapping.targetIssueType,
+          response: record.response
+            ? { ...record.response, proposalId: mapping.targetProposalId }
+            : record.response,
+          carriedForwardFromProposalId: mapping.sourceProposalId,
+        }
+      : record;
+    const previous = selected.get(projected.proposalId);
+    if (!previous || (previous.carriedForward && !carriedForward)) {
+      selected.set(projected.proposalId, {
+        record: projected,
+        carriedForward,
+      });
+    }
+  }
+  return [...selected.values()].map(({ record }) => record);
 }
 
 function credentials() {
@@ -122,12 +163,15 @@ async function main() {
   const snapshot = await db
     .collection("somReviewResponses")
     .where("datasetVersion", "==", manifest.datasetVersion)
-    .where("issueType", "==", issueType)
     .where("reviewerId", "==", reviewer.uid)
     .where("status", "==", "current")
     .get();
 
-  const currentRecords = snapshot.docs.map((doc) => doc.data());
+  const currentRecords = currentRecordsForIssue(
+    snapshot.docs.map((doc) => doc.data()),
+    manifest,
+    issueType,
+  );
   const orphanedResponses = currentRecords
     .filter((record) => !proposalsById.has(record.proposalId))
     .map((record) => ({
@@ -147,8 +191,17 @@ async function main() {
         reviewMode: proposal.reviewMode,
         subjectNodeId: proposal.provenance?.subjectNodeId || "",
         parentNodeId: proposal.provenance?.parentNodeId || "",
+        subjectTitle: proposal.subject?.title || "",
+        subjectParentTitle: proposal.subject?.parentTitle || "",
         currentTitle: proposal.reviewerView?.context?.currentTitle || "",
         proposedTitle: proposal.reviewerView?.context?.proposedTitle || "",
+        currentParentTitle:
+          proposal.reviewerView?.context?.currentParentTitle || "",
+        proposedParentTitle:
+          proposal.reviewerView?.context?.proposedParentTitle ||
+          proposal.reviewerView?.context?.candidateHome ||
+          "",
+        context: proposal.reviewerView?.context || {},
         linkedTasks: proposal.reviewerView?.context?.linkedTasks || [],
         proposedNodes: proposal.reviewerView?.context?.proposedNodes || [],
         agentReasoning: proposal.reviewerView?.reasoning || "",
@@ -156,6 +209,7 @@ async function main() {
         disagreementReason: record.response?.disagreementReason || "",
         suggestedCorrection: record.response?.suggestedCorrection || "",
         revisionCount: record.revisionCount || 0,
+        carriedForwardFromProposalId: record.carriedForwardFromProposalId || "",
       };
     })
     .sort((left, right) =>
@@ -254,7 +308,14 @@ async function main() {
   );
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : error);
-  process.exitCode = 1;
-});
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}
+
+export { currentRecordsForIssue };

--- a/scripts/som-review/export-reviewer-benchmark.test.mjs
+++ b/scripts/som-review/export-reviewer-benchmark.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { currentRecordsForIssue } from "./export-reviewer-benchmark.mjs";
+
+const manifest = {
+  responseCarryForward: {
+    schemaVersion: "som-response-carry-forward-v1",
+    mappings: [
+      {
+        sourceProposalId: "old-relocation",
+        sourceIssueType: "relocation",
+        targetProposalId: "new-one-step-move",
+        targetIssueType: "cross-branch-recall",
+      },
+    ],
+  },
+};
+
+test("projects an exact prior decision onto its replacement proposal", () => {
+  const records = currentRecordsForIssue(
+    [
+      {
+        proposalId: "old-relocation",
+        issueType: "relocation",
+        response: { proposalId: "old-relocation", decision: "agree" },
+      },
+      {
+        proposalId: "retired-diagnosis",
+        issueType: "cross-branch-recall",
+        response: { proposalId: "retired-diagnosis", decision: "agree" },
+      },
+    ],
+    manifest,
+    "cross-branch-recall",
+  );
+
+  assert.deepEqual(records.map((record) => record.proposalId).sort(), [
+    "new-one-step-move",
+    "retired-diagnosis",
+  ]);
+  const projected = records.find(
+    (record) => record.proposalId === "new-one-step-move",
+  );
+  assert.equal(projected.response.proposalId, "new-one-step-move");
+  assert.equal(projected.carriedForwardFromProposalId, "old-relocation");
+});
+
+test("a response saved on the current proposal overrides inherited history", () => {
+  const records = currentRecordsForIssue(
+    [
+      {
+        proposalId: "old-relocation",
+        issueType: "relocation",
+        response: { proposalId: "old-relocation", decision: "agree" },
+      },
+      {
+        proposalId: "new-one-step-move",
+        issueType: "cross-branch-recall",
+        response: {
+          proposalId: "new-one-step-move",
+          decision: "disagree",
+        },
+      },
+    ],
+    manifest,
+    "cross-branch-recall",
+  );
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].response.decision, "disagree");
+  assert.equal(records[0].carriedForwardFromProposalId, undefined);
+});

--- a/scripts/som-review/semantic-checkpoint-plan.test.mjs
+++ b/scripts/som-review/semantic-checkpoint-plan.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../..");
+const artifactDir = path.join(
+  repoRoot,
+  "artifacts",
+  "rob-semantic-coverage-2026-08-04",
+);
+
+const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+const sha256File = (file) =>
+  crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+
+test("semantic checkpoint is complete, snapshot-bound, and blocked pending corrections", () => {
+  const plan = readJson(path.join(artifactDir, "checkpoint-plan.json"));
+
+  assert.equal(plan.applicationAllowed, false);
+  assert.equal(plan.status, "regeneration-required-before-application");
+  assert.match(plan.sourceDataset.manifestSha256, /^[a-f0-9]{64}$/);
+  assert.match(plan.sourceOntology.snapshotSha256, /^[a-f0-9]{64}$/);
+  assert.equal(plan.acceptedWholeNodeMoves.length, 7);
+
+  for (const benchmark of plan.benchmarks) {
+    const file = path.join(artifactDir, benchmark.file);
+    const payload = readJson(file);
+    assert.equal(sha256File(file), benchmark.sha256);
+    assert.equal(payload.counts.reviewed, benchmark.reviewed);
+    assert.equal(payload.counts.agreed, benchmark.agreed);
+    assert.equal(payload.counts.disagreed, benchmark.disagreed);
+    assert.equal(payload.counts.missing, 0);
+  }
+
+  assert.deepEqual(plan.expertCorrections.map((item) => item.type).sort(), [
+    "correct-specialization-title",
+    "split-evidence-by-transaction-direction",
+  ]);
+  assert.ok(
+    plan.expertCorrections.every((item) => item.requiresRegeneration === true),
+  );
+  assert.match(
+    plan.pendingCollectionDesign.policy,
+    /may not create activity nodes/i,
+  );
+});

--- a/src/components/SomReview/ReviewCard.tsx
+++ b/src/components/SomReview/ReviewCard.tsx
@@ -259,32 +259,10 @@ const ReviewCard = ({
   const affectedPlacementNodes = placementContext?.affectedNodes || [];
   const groupedPlacement = affectedPlacementNodes.length > 1;
   const exactPlacement = Boolean(placementContext?.candidateHome);
-  const agreeLabel = duplicateContext
-    ? "Same activity"
-    : groupedPlacement
-      ? view.agreeLabel
-      : missingFromBranch
-        ? "Approve move"
-        : exactPlacement
-          ? "Approve move"
-          : wrongVerb
-            ? "Yes, different action"
-            : placementContext
-              ? "Yes, misplaced"
-              : view.agreeLabel;
-  const disagreeLabel = duplicateContext
-    ? "Different activities"
-    : groupedPlacement
-      ? view.disagreeLabel
-      : exactPlacement
-        ? "Reject proposed move"
-        : missingFromBranch
-          ? "Keep current location"
-          : wrongVerb
-            ? "No, it belongs here"
-            : placementContext
-              ? "No, keep here"
-              : view.disagreeLabel;
+  // Keep the verdict vocabulary stable across every review task. The question
+  // and comparison panels carry the task-specific meaning.
+  const agreeLabel = "Agree";
+  const disagreeLabel = "Disagree";
 
   return (
     <Box
@@ -617,13 +595,7 @@ const ReviewCard = ({
               >
                 {mode === "revise"
                   ? "Save revised answer"
-                  : duplicateContext
-                    ? "Save as different activities"
-                    : placementContext
-                      ? exactPlacement
-                        ? "Reject proposed move"
-                        : "Keep current placement"
-                      : "Save disagreement"}
+                  : "Save disagreement"}
               </Button>
             </Stack>
           </Stack>

--- a/src/components/SomReview/ReviewHistorySelect.tsx
+++ b/src/components/SomReview/ReviewHistorySelect.tsx
@@ -78,7 +78,7 @@ const ReviewHistorySelect = ({
               secondary={
                 "Current answer: " +
                 (item.decision === "agree" ? "Agreed" : "Disagreed") +
-                (item.fastTracked ? " | Fast-tracked" : "")
+                (item.fastTracked ? " | Staged for checkpoint" : "")
               }
               primaryTypographyProps={{
                 sx: {

--- a/src/components/SomReview/TrustedPropagationControl.tsx
+++ b/src/components/SomReview/TrustedPropagationControl.tsx
@@ -33,22 +33,24 @@ const TrustedPropagationControl = ({
     >
       <Box sx={{ minWidth: 0 }}>
         <Typography sx={{ fontWeight: 800 }}>
-          Trusted-reviewer fast path
+          Continuous expert review
         </Typography>
         <Typography sx={{ color: "text.secondary", lineHeight: 1.45 }}>
-          Eligible answers enter an audited, snapshot-bound propagation draft.
-          Ontology changes still require a separate batch application.
+          Save each decision immediately, open already-generated dependent
+          questions automatically, and continue into the next ready review type.
+          The session pauses only when accepted changes require an auditable
+          ontology-regeneration checkpoint.
         </Typography>
       </Box>
       <FormControlLabel
-        label={enabled ? "Fast path on" : "Review only"}
+        label={enabled ? "Continuous review on" : "Manual navigation"}
         labelPlacement="start"
         control={
           <Switch
             checked={enabled}
             onChange={(event) => onChange(event.target.checked)}
             slotProps={{
-              input: { "aria-label": "Trusted-reviewer fast path" },
+              input: { "aria-label": "Continuous expert review" },
             }}
           />
         }

--- a/src/lib/somReview/sanitize.ts
+++ b/src/lib/somReview/sanitize.ts
@@ -228,16 +228,8 @@ export const toReviewerCard = (record: any): SomReviewCard => {
           ? firstSentence(sanitizeReasoning(view.reasoning))
           : sanitizeReasoning(view.reasoning),
       context,
-      agreeLabel:
-        placementText?.agreeLabel ||
-        duplicateText?.agreeLabel ||
-        cleanText(view.agreeLabel) ||
-        "Agree",
-      disagreeLabel:
-        placementText?.disagreeLabel ||
-        duplicateText?.disagreeLabel ||
-        cleanText(view.disagreeLabel) ||
-        "Disagree",
+      agreeLabel: "Agree",
+      disagreeLabel: "Disagree",
     },
   };
 };

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -113,38 +113,49 @@ export const ReviewPage = () => {
   const [completedSequence, setCompletedSequence] =
     useState<CompletedSequence | null>(null);
 
-  const loadOverview = useCallback(async (requestedDatasetId?: string) => {
-    setPhase("loading");
-    setLoadError("");
-    setRetryIssueType(null);
-    try {
-      const targetDatasetId = requestedDatasetId || datasetIdRef.current;
-      const overview = await Post<SomOverviewResponse>(
-        "/som-review/overview",
-        targetDatasetId ? { datasetId: targetDatasetId } : {},
-      );
-      datasetIdRef.current = overview.datasetId;
-      setDatasetId(overview.datasetId);
-      setDatasetVersion(overview.datasetVersion);
-      setWorkspaceId(overview.workspaceId);
-      setWorkspaces(overview.workspaces);
-      setRoundLabel(overview.roundLabel);
-      setCurrentRound(overview.currentRound);
-      setBranch(overview.branch);
-      setOntologyName(overview.ontologyName);
-      setIssueTypes(overview.issueTypes);
-      setReadyFollowUps(overview.readyFollowUps || []);
-      setCanDeliberate(overview.canDeliberate);
-      setCanInspectPriorReview(overview.canInspectPriorReview);
-      setTrustedPropagationAllowed(
-        Boolean(overview.trustedPropagation?.allowed),
-      );
-      setPhase("select");
-    } catch {
-      setLoadError("The review queues could not be loaded. Please try again.");
-      setPhase("select");
-    }
+  const applyOverview = useCallback((overview: SomOverviewResponse) => {
+    datasetIdRef.current = overview.datasetId;
+    setDatasetId(overview.datasetId);
+    setDatasetVersion(overview.datasetVersion);
+    setWorkspaceId(overview.workspaceId);
+    setWorkspaces(overview.workspaces);
+    setRoundLabel(overview.roundLabel);
+    setCurrentRound(overview.currentRound);
+    setBranch(overview.branch);
+    setOntologyName(overview.ontologyName);
+    setIssueTypes(overview.issueTypes);
+    setReadyFollowUps(overview.readyFollowUps || []);
+    setCanDeliberate(overview.canDeliberate);
+    setCanInspectPriorReview(overview.canInspectPriorReview);
+    setTrustedPropagationAllowed(Boolean(overview.trustedPropagation?.allowed));
   }, []);
+
+  const loadOverview = useCallback(
+    async (
+      requestedDatasetId?: string,
+    ): Promise<SomOverviewResponse | null> => {
+      setPhase("loading");
+      setLoadError("");
+      setRetryIssueType(null);
+      try {
+        const targetDatasetId = requestedDatasetId || datasetIdRef.current;
+        const overview = await Post<SomOverviewResponse>(
+          "/som-review/overview",
+          targetDatasetId ? { datasetId: targetDatasetId } : {},
+        );
+        applyOverview(overview);
+        setPhase("select");
+        return overview;
+      } catch {
+        setLoadError(
+          "The review queues could not be loaded. Please try again.",
+        );
+        setPhase("select");
+        return null;
+      }
+    },
+    [applyOverview],
+  );
 
   useEffect(() => {
     if (!user?.userId || !trustedPropagationAllowed) {
@@ -152,13 +163,12 @@ export const ReviewPage = () => {
       return;
     }
     try {
-      setTrustedPropagationEnabled(
-        window.localStorage.getItem(
-          `som-review-trusted-propagation-${user.userId}`,
-        ) === "true",
+      const stored = window.localStorage.getItem(
+        `som-review-continuous-expert-${user.userId}`,
       );
+      setTrustedPropagationEnabled(stored === null ? true : stored === "true");
     } catch {
-      setTrustedPropagationEnabled(false);
+      setTrustedPropagationEnabled(true);
     }
   }, [trustedPropagationAllowed, user?.userId]);
 
@@ -168,7 +178,7 @@ export const ReviewPage = () => {
       if (!user?.userId) return;
       try {
         window.localStorage.setItem(
-          `som-review-trusted-propagation-${user.userId}`,
+          `som-review-continuous-expert-${user.userId}`,
           String(enabled),
         );
       } catch {
@@ -291,18 +301,41 @@ export const ReviewPage = () => {
     (followUp: SomLinkedFollowUp, source?: SomFollowUpSource) => {
       const linkedSource = source || followUp.sources[0];
       if (!linkedSource) {
-        startSession(followUp.issueType, {
+        return startSession(followUp.issueType, {
           preferredProposalId: followUp.proposalId,
         });
-        return;
       }
-      startSession(followUp.issueType, {
+      return startSession(followUp.issueType, {
         preferredProposalId: followUp.proposalId,
         sequence: { source: linkedSource, followUp },
       });
     },
     [startSession],
   );
+
+  const continueContinuousReview = useCallback(async () => {
+    clearActiveReview();
+    const overview = await loadOverview();
+    if (!overview) return;
+
+    const nextFollowUp = overview.readyFollowUps?.[0];
+    if (nextFollowUp) {
+      await startLinkedFollowUp(nextFollowUp);
+      return;
+    }
+    const nextIssue = overview.issueTypes.find(
+      (candidate) =>
+        candidate.enabled &&
+        candidate.released &&
+        candidate.pending > 0 &&
+        !(candidate.blockedBy || []).length,
+    );
+    if (nextIssue) {
+      await startSession(nextIssue.id);
+      return;
+    }
+    setPhase("select");
+  }, [clearActiveReview, loadOverview, startLinkedFollowUp, startSession]);
 
   const introStorageKey = useCallback(
     (issue: SomIssueType) =>
@@ -456,13 +489,22 @@ export const ReviewPage = () => {
         const sourceIssue = issueTypes.find(
           (candidate) => candidate.id === card.issueType,
         );
+        const source = {
+          proposalId: card.proposalId,
+          issueType: card.issueType,
+          issueLabel: sourceIssue?.label || "Earlier review",
+          question: card.reviewerView.question,
+        };
+        if (
+          trustedPropagationAllowed &&
+          currentRound &&
+          trustedPropagationEnabled
+        ) {
+          await startLinkedFollowUp(followUps[0], source);
+          return;
+        }
         setFollowUpOffer({
-          source: {
-            proposalId: card.proposalId,
-            issueType: card.issueType,
-            issueLabel: sourceIssue?.label || "Earlier review",
-            question: card.reviewerView.question,
-          },
+          source,
           followUps,
           sourceQueueCompleted: result.completed,
         });
@@ -470,6 +512,14 @@ export const ReviewPage = () => {
         return;
       }
       if (activeSequence?.followUp.proposalId === card.proposalId) {
+        if (
+          trustedPropagationAllowed &&
+          currentRound &&
+          trustedPropagationEnabled
+        ) {
+          await continueContinuousReview();
+          return;
+        }
         setCompletedSequence({
           sequence: activeSequence,
           followUpQueueCompleted: result.completed,
@@ -477,15 +527,27 @@ export const ReviewPage = () => {
         setPhase("sequence-complete");
         return;
       }
-      if (result.completed) setPhase("complete");
+      if (result.completed) {
+        if (
+          trustedPropagationAllowed &&
+          currentRound &&
+          trustedPropagationEnabled
+        ) {
+          await continueContinuousReview();
+          return;
+        }
+        setPhase("complete");
+      }
     },
     [
       activeSequence,
       cards,
       currentRound,
       cursor,
+      continueContinuousReview,
       issueTypes,
       sessionId,
+      startLinkedFollowUp,
       trustedPropagationAllowed,
       trustedPropagationEnabled,
       user?.userId,
@@ -563,14 +625,23 @@ export const ReviewPage = () => {
         const sourceIssue = issueTypes.find(
           (candidate) => candidate.id === card.issueType,
         );
+        const source = {
+          proposalId: card.proposalId,
+          issueType: card.issueType,
+          issueLabel: sourceIssue?.label || "Earlier review",
+          question: card.reviewerView.question,
+        };
         setRevisionProposalId("");
+        if (
+          trustedPropagationAllowed &&
+          currentRound &&
+          trustedPropagationEnabled
+        ) {
+          await startLinkedFollowUp(followUps[0], source);
+          return;
+        }
         setFollowUpOffer({
-          source: {
-            proposalId: card.proposalId,
-            issueType: card.issueType,
-            issueLabel: sourceIssue?.label || "Earlier review",
-            question: card.reviewerView.question,
-          },
+          source,
           followUps,
           sourceQueueCompleted: cards.length === 0 || cursor >= cards.length,
         });
@@ -607,6 +678,7 @@ export const ReviewPage = () => {
       issueTypes,
       issueType,
       revisionProposalId,
+      startLinkedFollowUp,
       startSession,
       trustedPropagationAllowed,
       trustedPropagationEnabled,


### PR DESCRIPTION
## Summary
- automatically continue authorized expert reviewers through generated follow-ups and ready queues
- standardize all review verdict buttons on Agree/Disagree
- reconcile Rob's completed semantic-coverage responses, including carry-forward mappings, into a hash-verified regeneration checkpoint
- preserve ontology writes behind an explicit regeneration/application boundary

## Verification
- `npm run build`
- 31 focused Jest tests pass
- 28 `scripts/som-review/*.test.mjs` tests pass
- full Jest run: 296 pass; one unchanged legacy `YjsEditorWrapper` blur test fails and reproduces in isolation
- `npx tsc --noEmit`: reports existing project-wide type errors outside this change

## Data safety
- no ontology mutation is performed by this PR
- checkpoint application remains blocked until the two expert corrections are regenerated and the revised Sell outline is inspected
