### PR TITLE
Fix specific inheritance tracking and inherited parts display

### DIFF
--- a/src/components/NodBody/NodeCompass.tsx
+++ b/src/components/NodBody/NodeCompass.tsx
@@ -350,20 +350,25 @@ const NodeCompass: React.FC<Props> = ({
     ],
   );
 
-  // Parts are read straight from this node's `properties.parts` and will no longer follow `inheritance.parts.ref`.
-  const ids = useMemo(
-    () => ({
+  // Parts come from the node's stored `resolvedParts` snapshot
+  const ids = useMemo(() => {
+    const resolved = currentVisibleNode.resolvedParts;
+    const partIds = Array.isArray(resolved)
+      ? resolved
+          .map((p) => p?.id)
+          .filter((id): id is string => !!id)
+      : flattenIds(
+          currentVisibleNode.properties?.parts as ICollection[] | undefined,
+        );
+    return {
       left: flattenIds(currentVisibleNode.generalizations),
       right: flattenIds(currentVisibleNode.specializations),
       top: flattenIds(
         currentVisibleNode.properties?.isPartOf as ICollection[] | undefined,
       ),
-      bottom: flattenIds(
-        currentVisibleNode.properties?.parts as ICollection[] | undefined,
-      ),
-    }),
-    [currentVisibleNode],
-  );
+      bottom: partIds,
+    };
+  }, [currentVisibleNode]);
 
   const layout = useMemo(
     () =>
@@ -396,6 +401,9 @@ const NodeCompass: React.FC<Props> = ({
       currentVisibleNode.properties?.isPartOf as ICollection[] | undefined,
     );
     collect(currentVisibleNode.properties?.parts as ICollection[] | undefined);
+    for (const p of currentVisibleNode.resolvedParts ?? []) {
+      if (p?.id && p?.title) m[p.id] = p.title;
+    }
     return m;
   }, [currentVisibleNode]);
 

--- a/src/components/StructuredProperty/InheritedPartsViewer.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewer.tsx
@@ -109,7 +109,8 @@ const InheritedPartsViewer: React.FC<InheritedPartsViewerProps> = ({
     return !!resolvedParts.find((n) => n.id === partId)?.optional;
   };
 
-  // The generalization title a part is specifically inherited from.
+  // The generalization title a part is specifically inherited from: the
+  // picked gen (via) when recorded, else the gen its owner resolves through.
   const getPartSpecificSourceTitle = (partId: string): string | null => {
     const part = resolvedParts.find((n) => n.id === partId);
     if (!part?.inheritedFrom) return null;
@@ -119,14 +120,19 @@ const InheritedPartsViewer: React.FC<InheritedPartsViewerProps> = ({
       nodes,
     );
     if (providers.length < 2) return null;
-    const current = providers.find((p) => {
-      const genPart = resolvedOf(p.generalizationId).find(
-        (n) => n.id === partId,
-      );
-      return (
-        (genPart?.inheritedFrom || p.generalizationId) === part.inheritedFrom
-      );
-    });
+    const picked = part.via
+      ? providers.find((p) => p.generalizationId === part.via)
+      : undefined;
+    const current =
+      picked ??
+      providers.find((p) => {
+        const genPart = resolvedOf(p.generalizationId).find(
+          (n) => n.id === partId,
+        );
+        return (
+          (genPart?.inheritedFrom || p.generalizationId) === part.inheritedFrom
+        );
+      });
     return (
       current?.generalizationTitle ?? nodes[part.inheritedFrom]?.title ?? null
     );

--- a/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
+++ b/src/components/StructuredProperty/InheritedPartsViewerEdit.tsx
@@ -772,6 +772,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
           toOptional: liveOptional,
           optionalChange,
           inheritedFrom: partNode.inheritedFrom,
+          via: partNode.via,
         };
       }
       return {
@@ -790,6 +791,7 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
         hops: 0,
         pending: true,
         inheritedFrom: partNode.inheritedFrom,
+        via: partNode.via,
       };
     });
 
@@ -1496,67 +1498,91 @@ const InheritedPartsViewerEdit: React.FC<InheritedPartsViewerProps> = ({
                                           This part is specifically inherited
                                           from:
                                         </ListSubheader>
-                                        {[
-                                          ...(partSourcesLookup[entry.to] ??
-                                            []),
-                                        ]
-                                          .sort(
-                                            (a, b) =>
-                                              (b.owner === entry.inheritedFrom
-                                                ? 1
-                                                : 0) -
-                                              (a.owner === entry.inheritedFrom
-                                                ? 1
-                                                : 0),
-                                          )
-                                          .map((source) => {
-                                            const isCurrent =
-                                              source.owner ===
-                                              entry.inheritedFrom;
-                                            return (
-                                              <MenuItem
-                                                key={`source-${source.genId}`}
-                                                disabled={isCurrent}
-                                                onClick={() => {
-                                                  if (
-                                                    isCurrent ||
-                                                    savingPartIds.has(entry.to)
-                                                  ) {
-                                                    return;
+                                        {(() => {
+                                          // Check sits on the picked gen (via),
+                                          // else on the resolution path. Picking
+                                          // a relay records the pick; picking
+                                          // another owner repoints.
+                                          const sources =
+                                            partSourcesLookup[entry.to] ?? [];
+                                          const matching = sources
+                                            .filter(
+                                              (s) =>
+                                                s.owner === entry.inheritedFrom,
+                                            )
+                                            .map((s) => s.genId);
+                                          const overallSource =
+                                            currentVisibleNode.partsInheritance
+                                              ?.source ?? "";
+                                          const currentGenId =
+                                            entry.via &&
+                                            sources.some(
+                                              (s) => s.genId === entry.via,
+                                            )
+                                              ? entry.via
+                                              : matching.includes(overallSource)
+                                                ? overallSource
+                                                : matching[0];
+                                          return [...sources]
+                                            .sort(
+                                              (a, b) =>
+                                                (b.genId === currentGenId
+                                                  ? 1
+                                                  : 0) -
+                                                (a.genId === currentGenId
+                                                  ? 1
+                                                  : 0),
+                                            )
+                                            .map((source) => {
+                                              const isCurrent =
+                                                source.genId === currentGenId;
+                                              return (
+                                                <MenuItem
+                                                  key={`source-${source.genId}`}
+                                                  disabled={isCurrent}
+                                                  onClick={() => {
+                                                    if (
+                                                      isCurrent ||
+                                                      savingPartIds.has(
+                                                        entry.to,
+                                                      )
+                                                    ) {
+                                                      return;
+                                                    }
+                                                    switchPartSource(
+                                                      entry.to,
+                                                      source.genId,
+                                                    );
+                                                  }}
+                                                  sx={
+                                                    isCurrent
+                                                      ? currentSourceItemSx
+                                                      : optionItemSx
                                                   }
-                                                  switchPartSource(
-                                                    entry.to,
-                                                    source.genId,
-                                                  );
-                                                }}
-                                                sx={
-                                                  isCurrent
-                                                    ? currentSourceItemSx
-                                                    : optionItemSx
-                                                }
-                                              >
-                                                <CheckIcon
-                                                  sx={{
-                                                    fontSize: 18,
-                                                    color: "#f2a43a",
-                                                    visibility: isCurrent
-                                                      ? "visible"
-                                                      : "hidden",
-                                                  }}
-                                                />
-                                                <Typography
-                                                  sx={{
-                                                    fontSize: "1rem",
-                                                    fontWeight: isCurrent
-                                                      ? 700
-                                                      : 400,
-                                                  }}
                                                 >
-                                                  {source.title}
-                                                </Typography>
-                                              </MenuItem>
-                                            );
-                                          })}
+                                                  <CheckIcon
+                                                    sx={{
+                                                      fontSize: 18,
+                                                      color: "#f2a43a",
+                                                      visibility: isCurrent
+                                                        ? "visible"
+                                                        : "hidden",
+                                                    }}
+                                                  />
+                                                  <Typography
+                                                    sx={{
+                                                      fontSize: "1rem",
+                                                      fontWeight: isCurrent
+                                                        ? 700
+                                                        : 400,
+                                                    }}
+                                                  >
+                                                    {source.title}
+                                                  </Typography>
+                                                </MenuItem>
+                                              );
+                                            });
+                                        })()}
                                       </Select>
                                     </Box>
                                   </Tooltip>

--- a/src/lib/server/parts.ts
+++ b/src/lib/server/parts.ts
@@ -14,6 +14,7 @@ import {
   absorbOwnedForGens,
   absorbOwnedPart,
   applyGenChange,
+  applyViaFollowerChange,
   childSourceOf,
   isOwnedPart,
   partSourcesOf,
@@ -366,6 +367,49 @@ export async function propagateOwnedPartChange(
     batch.update(db.collection(NODES).doc(id), {
       "properties.parts": toParts(rePointed),
       partSources: partSourcesOf(rePointed),
+    });
+    pending += 1;
+    if (pending >= MAX_TRANSACTION_WRITES) {
+      await batch.commit();
+      batch = db.batch();
+      pending = 0;
+    }
+  }
+  if (pending > 0) await batch.commit();
+}
+
+/**
+ * Entries elsewhere that FOLLOW `genId` (`via`, found by the "partId@genId"
+ * key) mirror its remove/replace — for EVERY edited part, owned or not:
+ * that is the point of a pick.
+ */
+export async function propagateViaFollowers(
+  genId: string,
+  changes: { fromId: string; to?: { id: string; title: string } }[],
+): Promise<void> {
+  const docs = new Map<string, INode>();
+  for (const c of changes) {
+    const snap = await db
+      .collection(NODES)
+      .where("partSources", "array-contains", `${c.fromId}@${genId}`)
+      .get();
+    for (const d of snap.docs) {
+      const data = d.data() as INode;
+      if (!data.deleted && !docs.has(d.id)) {
+        docs.set(d.id, { ...data, id: d.id });
+      }
+    }
+  }
+
+  let batch = db.batch();
+  let pending = 0;
+  for (const [id, node] of docs) {
+    const entries = partsNodes(asPartsCollections(node.properties?.parts));
+    const { parts, changed } = applyViaFollowerChange(entries, genId, changes);
+    if (!changed) continue;
+    batch.update(db.collection(NODES).doc(id), {
+      "properties.parts": toParts(parts),
+      partSources: partSourcesOf(parts),
     });
     pending += 1;
     if (pending >= MAX_TRANSACTION_WRITES) {

--- a/src/lib/server/partsAnnotation.ts
+++ b/src/lib/server/partsAnnotation.ts
@@ -267,6 +267,8 @@ const analyzeInheritance = (
   for (const generalizationPart of generalizationParts) {
     if (!matchedParts.has(generalizationPart)) {
       for (const currentPart of currentParts) {
+        // a current part matched exactly is never picked as a specialized part ">"
+        if (usedGeneralizationParts.has(currentPart)) continue;
         const hops = findHierarchicalDistance(generalizationPart, currentPart);
         if (hops !== -1) {
           const fromOptional = getPartOptionalStatus(
@@ -317,7 +319,8 @@ const analyzeInheritance = (
 
   const currentPartsOrder = currentParts;
 
-  const hasSeenTo = new Set();
+  // Parts already matched by "=" are off-limits to ">" picks
+  const hasSeenTo = new Set(usedGeneralizationParts);
   const filteredSpecializations: TransferInheritance[] = Object.entries(
     groupedByGeneralization,
   ).reduce((acc, [from, entries]) => {

--- a/src/lib/server/partsModel.ts
+++ b/src/lib/server/partsModel.ts
@@ -55,14 +55,19 @@ export function isOwnedPart(part: ILinkNode): boolean {
 }
 
 /**
- * Query index for stored entries' inheritedFrom tags: one "partId:ownerId"
- * key per non-owned entry. Every write of `properties.parts` MUST write
- * this alongside; a missing field means empty.
+ * Query index for stored entries' provenance: one "partId:ownerId" key per
+ * non-owned entry, plus one "partId@genId" key when the entry follows a
+ * picked gen (`via`). Every write of `properties.parts` MUST write this
+ * alongside; a missing field means empty.
  */
 export function partSourcesOf(parts: PartEntry[]): string[] {
-  return parts
-    .filter((e) => e.inheritedFrom)
-    .map((e) => `${e.id}:${e.inheritedFrom}`);
+  const keys: string[] = [];
+  for (const e of parts) {
+    if (!e.inheritedFrom) continue;
+    keys.push(`${e.id}:${e.inheritedFrom}`);
+    if (e.via) keys.push(`${e.id}@${e.via}`);
+  }
+  return keys;
 }
 
 /**
@@ -98,6 +103,7 @@ function toResolved(e: PartEntry): ILinkNode {
   if (e.title !== undefined) p.title = e.title;
   if (e.optional) p.optional = true;
   if (e.inheritedFrom) p.inheritedFrom = e.inheritedFrom;
+  if (e.via) p.via = e.via;
   return p;
 }
 
@@ -446,12 +452,9 @@ export function applyReplace(
 }
 
 /**
- * Switch which generalization a part is SPECIFICALLY inherited from: the part
- * starts tracking the owner resolved through `genId`. A virtual part mints a
- * stored entry in its slot (flags fold in, its override moves onto the entry);
- * an existing entry just repoints. Membership and order don't change, so
- * attachment is untouched. No-ops (`changed: false`): part absent or owned,
- * or the gen doesn't provide it.
+ * Switch a part's specific inheritance to the owner resolved through `genId`,
+ * recording `via: genId` when the gen is a relay so edits made AT it follow.
+ * Virtual parts mint an entry, existing ones repoint; attachment and order never change.
  */
 export function applySwitchSource(
   nodeId: string,
@@ -481,15 +484,32 @@ export function applySwitchSource(
     };
   }
   const owner = childSourceOf(genPart, genId);
+  const via = owner === genId ? undefined : genId;
 
-  if (node.parts.some((e) => e.id === partId)) {
-    const parts = node.parts.map((e) =>
-      e.id === partId ? { ...e, inheritedFrom: owner } : e,
-    );
+  const existing = node.parts.find((e) => e.id === partId);
+  if (existing) {
+    if (
+      existing.inheritedFrom === owner &&
+      (existing.via ?? undefined) === via
+    ) {
+      return {
+        parts: node.parts,
+        partsInheritance: node.partsInheritance,
+        changed: false,
+      };
+    }
+    const parts = node.parts.map((e) => {
+      if (e.id !== partId) return e;
+      const copy = { ...e, inheritedFrom: owner };
+      if (via) copy.via = via;
+      else delete copy.via;
+      return copy;
+    });
     return { parts, partsInheritance: node.partsInheritance, changed: true };
   }
 
   const minted: PartEntry = { id: partId, inheritedFrom: owner };
+  if (via) minted.via = via;
   if (viewed.title !== undefined) minted.title = viewed.title;
   if (viewed.optional) minted.optional = true;
   const overrides = { ...node.partsInheritance.overrides };
@@ -583,27 +603,34 @@ export function applyGenChange(
     return p ? childSourceOf(p, g.id) : null;
   };
 
+  // A pick through a removed gen loses its path — fall back to owner-only.
+  const keepEntry = (e: PartEntry): PartEntry => {
+    const copy = { ...e };
+    if (copy.via && removedGenIds.includes(copy.via)) delete copy.via;
+    return copy;
+  };
+
   const kept: PartEntry[] = [];
   for (const e of node.parts) {
     if (isOwnedPart(e)) {
-      kept.push({ ...e });
+      kept.push(keepEntry(e));
       continue;
     }
     const tracked = removed.some(
       (g) => ownerThrough(g, e.id) === e.inheritedFrom,
     );
     if (!tracked) {
-      kept.push({ ...e });
+      kept.push(keepEntry(e));
       continue;
     }
     if (remaining.some((g) => ownerThrough(g, e.id) === e.inheritedFrom)) {
-      kept.push({ ...e });
+      kept.push(keepEntry(e));
       continue;
     }
     const provider = remaining.find((g) => g.parts.some((p) => p.id === e.id));
     if (provider) {
       kept.push({
-        ...e,
+        ...keepEntry(e),
         inheritedFrom: ownerThrough(provider, e.id) as string,
       });
     }
@@ -649,6 +676,56 @@ export function applyGenChange(
     }
   }
   return { parts, partsInheritance: { source: next.id, overrides } };
+}
+
+/**
+ * `genId` removed/replaced parts in its own view; entries that FOLLOW it
+ * (`via: genId`) mirror that: drop, or morph onto the replacement (which the
+ * gen now owns, so `via` clears). Morph collisions drop; anchors re-point.
+ */
+export function applyViaFollowerChange(
+  parts: PartEntry[],
+  genId: string,
+  changes: { fromId: string; to?: { id: string; title: string } }[],
+): { parts: PartEntry[]; changed: boolean } {
+  const presentIds = new Set(parts.map((e) => e.id));
+  const droppedIds = new Set<string>();
+  let changed = false;
+  const next: PartEntry[] = [];
+  for (const e of parts) {
+    const change = changes.find((c) => c.fromId === e.id && e.via === genId);
+    if (!change) {
+      next.push(e);
+      continue;
+    }
+    changed = true;
+    if (change.to && !presentIds.has(change.to.id)) {
+      const morphed = {
+        ...e,
+        id: change.to.id,
+        title: change.to.title,
+        inheritedFrom: genId,
+      };
+      delete morphed.via;
+      next.push(morphed);
+    } else {
+      droppedIds.add(e.id);
+    }
+  }
+  if (!changed) return { parts, changed };
+  const byId = new Map(parts.map((e) => [e.id, e]));
+  const rePointed = next.map((e) => {
+    if (e.after == null || !droppedIds.has(e.after)) return e;
+    let cursor: string | null | undefined = e.after;
+    while (cursor != null && droppedIds.has(cursor)) {
+      cursor = byId.get(cursor)?.after;
+    }
+    const copy = { ...e };
+    if (cursor === undefined) delete copy.after;
+    else copy.after = cursor;
+    return copy;
+  });
+  return { parts: rePointed, changed };
 }
 
 /**

--- a/src/pages/api/nodes/parts/remove.ts
+++ b/src/pages/api/nodes/parts/remove.ts
@@ -13,6 +13,7 @@ import {
   applyIsPartOfOwnerOnly,
   asPartsCollections,
   propagateOwnedPartChange,
+  propagateViaFollowers,
   toParts,
 } from "@components/lib/server/parts";
 import {
@@ -112,6 +113,12 @@ async function applyRemoveParts(ctx: {
       ownedRemoved.map((fromId) => ({ fromId })),
     );
   }
+
+  // Followers that PICKED this node mirror every removal, owned or not.
+  await propagateViaFollowers(
+    nodeId,
+    removed.map((p) => ({ fromId: p.id })),
+  );
 
   if (uname) {
     await writeChangeLog(

--- a/src/pages/api/nodes/parts/replace.ts
+++ b/src/pages/api/nodes/parts/replace.ts
@@ -14,6 +14,7 @@ import {
   applyIsPartOfOwnerOnly,
   asPartsCollections,
   propagateOwnedPartChange,
+  propagateViaFollowers,
   toParts,
 } from "@components/lib/server/parts";
 import {
@@ -118,6 +119,11 @@ async function applyReplaceParts(ctx: {
       { fromId, to: { id: toId, title: toNode.title ?? "" } },
     ]);
   }
+
+  // Followers that PICKED this node mirror the replace, owned or not.
+  await propagateViaFollowers(nodeId, [
+    { fromId, to: { id: toId, title: toNode.title ?? "" } },
+  ]);
 
   // The replacement is owned here now — a descendant's own copy of it
   // converts to inherited.

--- a/src/types/INode.ts
+++ b/src/types/INode.ts
@@ -49,6 +49,12 @@ export type ILinkNode = {
    * their array order is authoritative.
    */
   after?: string | null;
+  /**
+   * The generalization the user picked this inherited part to follow. Edits
+   * made AT that gen (remove/replace) reach this entry, on top of the owner's
+   * changes via `inheritedFrom`. Empty means no generalization is picked.
+   */
+  via?: string;
 };
 
 /**
@@ -100,8 +106,9 @@ export type INode = {
    */
   resolvedParts?: ILinkNode[];
   /**
-   * Query index: one "partId:ownerId" key per stored entry inherited
-   * from another node. It's used to find who tracks an owner's part. Missing means empty.
+   * Query index: a "partId:ownerId" key per stored entry inherited from another
+   * node, plus a "partId@genId" key when the entry follows a picked gen (via).
+   * Used to find who tracks an owner's part or follows a gen. Missing = empty.
    */
   partSources?: string[];
   specializations: ICollection[];


### PR DESCRIPTION
Hi @samadouhra 

This PR fixes specific inheritance tracking and resolves issues with inherited parts not being displayed or updated correctly.

Changes include:

* Updated specific inheritance to track the generalization selected by the user when the same part is available through multiple generalizations.
* Updated inherited parts to continue following the selected generalization when its part is changed, removed, or replaced.
* Fixed inherited parts not appearing correctly in the Compass Explorer.
* Fixed the specialization symbol from incorrectly claiming parts as specialized parts (>) when they are already matched as equal (=) in the inherited parts details.